### PR TITLE
Validate tag input and handle popover for 5+ groups

### DIFF
--- a/src/components/AccessControlNew.tsx
+++ b/src/components/AccessControlNew.tsx
@@ -328,7 +328,7 @@ const AccessControlNew = () => {
                             <Col span={24}>
                                 <Form.Item
                                     name="tagSourceGroups"
-                                    label={<>Source groups&nbsp;<ArrowRightOutlined /></>}
+                                    label="Source groups"
                                     rules={[{ validator: selectValidator }]}
                                     style={{display: 'flex'}}
                                 >
@@ -350,7 +350,7 @@ const AccessControlNew = () => {
                             <Col span={24}>
                                 <Form.Item
                                     name="tagDestinationGroups"
-                                    label={<><ArrowRightOutlined />&nbsp;Destination groups</>}
+                                    label="Destination groups"
                                     rules={[{ validator: selectValidator }]}
                                     style={{display: 'flex'}}
                                 >

--- a/src/components/AccessControlNew.tsx
+++ b/src/components/AccessControlNew.tsx
@@ -17,6 +17,7 @@ import {Rule, RuleToSave} from "../store/rule/types";
 import {useAuth0} from "@auth0/auth0-react";
 import { uniq } from "lodash"
 import {Header} from "antd/es/layout/layout";
+import {RuleObject} from "antd/lib/form";
 
 const { Paragraph } = Typography;
 const { Option } = Select;
@@ -213,6 +214,25 @@ const AccessControlNew = () => {
     //     })
     // }
 
+    const selectValidator = (_: RuleObject, value: string[]) => {
+        let hasSpaceNamed = []
+        if (!value.length) {
+            return Promise.reject(new Error("Please enter ate least one group"))
+        }
+
+        value.forEach(function(v: string) {
+            if (!v.trim().length) {
+                hasSpaceNamed.push(v)
+            }
+        })
+
+        if (hasSpaceNamed.length) {
+            return Promise.reject(new Error("Group names with just spaces are not allowed"))
+        }
+
+        return Promise.resolve()
+    }
+
     return (
         <>
             {rule &&
@@ -309,7 +329,7 @@ const AccessControlNew = () => {
                                 <Form.Item
                                     name="tagSourceGroups"
                                     label={<>Source groups&nbsp;<ArrowRightOutlined /></>}
-                                    rules={[{required: true, message: 'Please enter ate least one group'}]}
+                                    rules={[{ validator: selectValidator }]}
                                     style={{display: 'flex'}}
                                 >
                                     <Select mode="tags"
@@ -331,7 +351,7 @@ const AccessControlNew = () => {
                                 <Form.Item
                                     name="tagDestinationGroups"
                                     label={<><ArrowRightOutlined />&nbsp;Destination groups</>}
-                                    rules={[{required: true, message: 'Please enter ate least one group'}]}
+                                    rules={[{ validator: selectValidator }]}
                                     style={{display: 'flex'}}
                                 >
                                     <Select

--- a/src/components/AccessControlNew.tsx
+++ b/src/components/AccessControlNew.tsx
@@ -255,7 +255,7 @@ const AccessControlNew = () => {
                                                 <Form.Item
                                                     name="name"
                                                     label="Name"
-                                                    rules={[{required: true, message: 'Please add a name for this access rule'}]}
+                                                    rules={[{required: true, message: 'Please add a name for this access rule', whitespace: true}]}
                                                 >
                                                     <Input placeholder="Add rule name..." ref={inputNameRef} onPressEnter={() => toggleEditName(false)} onBlur={() => toggleEditName(false)} autoComplete="off"/>
                                                 </Form.Item>

--- a/src/components/PeerGroupsUpdate.tsx
+++ b/src/components/PeerGroupsUpdate.tsx
@@ -13,6 +13,7 @@ import type { CustomTagProps } from 'rc-select/lib/BaseSelect'
 import {useAuth0} from "@auth0/auth0-react";
 import {PeerGroupsToSave} from "../store/peer/types";
 import {Group, GroupPeer} from "../store/group/types";
+import {FlagFilled} from "@ant-design/icons";
 
 const { Paragraph } = Typography;
 const { Option } = Select;
@@ -73,11 +74,16 @@ const PeerGroupsUpdate = () => {
             event.stopPropagation();
         };
 
+        let tagClosable = true
+        if (value === "All") {
+            tagClosable = false
+        }
+
         return (
             <Tag
                 color="blue"
                 onMouseDown={onPreventMouseDown}
-                closable={closable}
+                closable={tagClosable}
                 onClose={onClose}
                 style={{ marginRight: 3 }}
             >
@@ -172,8 +178,9 @@ const PeerGroupsUpdate = () => {
                                     label="Groups"
                                     rules={[{required: true, message: 'Please enter ate least one group'}]}
                                     style={{display: 'flex'}}
+                                    validateTrigger='onSubmit'
                                 >
-                                    <Select mode="tags"  style={{ width: '100%' }} placeholder="Select groups..." tagRender={tagRender} dropdownRender={dropDownRender} onChange={handleChangeTags}>
+                                    <Select mode="tags"  style={{ width: '100%' }} placeholder="Select groups..." tagRender={tagRender} dropdownRender={dropDownRender} onChange={handleChangeTags} open={true}>
                                         {
                                             tagGroups.map(m =>
                                                 <Option key={m}>{optionRender(m)}</Option>
@@ -181,6 +188,21 @@ const PeerGroupsUpdate = () => {
                                         }
                                     </Select>
                                 </Form.Item>
+                            </Col>
+                            <Col span={24}>
+                                <Row wrap={false} gutter={12}>
+                                    <Col flex="none">
+                                        <FlagFilled/>
+                                    </Col>
+                                    <Col flex="auto">
+                                        <Paragraph>
+                                            At the moment access rules are bi-directional by default, this means both source and destination can talk to each-other in both directions. However destination peers will not be able to communicate with each other, nor will the source peers.
+                                        </Paragraph>
+                                        <Paragraph>
+                                            If you want to enable all peers of the same group to talk to each other - you can add that group both as a receiver and as a destination.
+                                        </Paragraph>
+                                    </Col>
+                                </Row>
                             </Col>
                         </Row>
                     </Form>

--- a/src/components/PeerGroupsUpdate.tsx
+++ b/src/components/PeerGroupsUpdate.tsx
@@ -161,6 +161,7 @@ const PeerGroupsUpdate = () => {
     }
 
     const selectValidator = (_: RuleObject, value: string[]) => {
+        console.log(value)
         let hasSpaceNamed = []
         let isAllPresent = false
         if (!value.length) {
@@ -209,7 +210,7 @@ const PeerGroupsUpdate = () => {
                             <Col span={24}>
                                 <Form.Item
                                     name="groups"
-                                    label="Groups"
+                                    label="Select groups to associate with this peer"
                                     rules={[{ validator: selectValidator }]}
                                     style={{display: 'flex'}}
                                 >
@@ -219,8 +220,7 @@ const PeerGroupsUpdate = () => {
                                         placeholder="Select groups..."
                                         tagRender={tagRender}
                                         dropdownRender={dropDownRender}
-                                        onChange={handleChangeTags}
-                                        defaultOpen={true}>
+                                        onChange={handleChangeTags}>
                                         {
                                             tagGroups.map(m =>
                                                 <Option key={m}>{optionRender(m)}</Option>
@@ -235,9 +235,6 @@ const PeerGroupsUpdate = () => {
                                         <FlagFilled/>
                                     </Col>
                                     <Col flex="auto">
-                                        <Paragraph>
-                                            Select or Create groups to associate with this peer.
-                                        </Paragraph>
                                         <Paragraph>
                                             Every peer is part of the group All, thus you can't remove it.
                                         </Paragraph>

--- a/src/components/PeerGroupsUpdate.tsx
+++ b/src/components/PeerGroupsUpdate.tsx
@@ -14,6 +14,7 @@ import {useAuth0} from "@auth0/auth0-react";
 import {PeerGroupsToSave} from "../store/peer/types";
 import {Group, GroupPeer} from "../store/group/types";
 import {FlagFilled} from "@ant-design/icons";
+import { RuleObject } from 'antd/lib/form';
 
 const { Paragraph } = Typography;
 const { Option } = Select;
@@ -140,7 +141,13 @@ const PeerGroupsUpdate = () => {
     }
 
     const handleChangeTags = (value: string[]) => {
-        setSelectedTagGroups(value)
+        let validatedValues: string[] = []
+        value.forEach(function(v) {
+            if (v.trim().length) {
+                validatedValues.push(v)
+            }
+        })
+        setSelectedTagGroups(validatedValues)
     };
 
     const handleFormSubmit = () => {
@@ -151,6 +158,33 @@ const PeerGroupsUpdate = () => {
             .catch((errorInfo) => {
                 console.log('errorInfo', errorInfo)
             });
+    }
+
+    const selectValidator = (_: RuleObject, value: string[]) => {
+        let hasSpaceNamed = []
+        let isAllPresent = false
+        if (!value.length) {
+            return Promise.reject(new Error("Please enter ate least one group"))
+        }
+
+        value.forEach(function(v: string) {
+            if (!v.trim().length) {
+                hasSpaceNamed.push(v)
+            }
+            if (v === 'All') {
+                isAllPresent = true
+            }
+        })
+
+        if (!isAllPresent) {
+            return Promise.reject(new Error("The All group can't be removed"))
+        }
+
+        if (hasSpaceNamed.length) {
+            return Promise.reject(new Error("Group names with just spaces are not allowed"))
+        }
+
+        return Promise.resolve()
     }
 
     return (
@@ -176,11 +210,17 @@ const PeerGroupsUpdate = () => {
                                 <Form.Item
                                     name="groups"
                                     label="Groups"
-                                    rules={[{required: true, message: 'Please enter ate least one group'}]}
+                                    rules={[{ validator: selectValidator }]}
                                     style={{display: 'flex'}}
-                                    validateTrigger='onSubmit'
                                 >
-                                    <Select mode="tags"  style={{ width: '100%' }} placeholder="Select groups..." tagRender={tagRender} dropdownRender={dropDownRender} onChange={handleChangeTags} open={true}>
+                                    <Select
+                                        mode="tags"
+                                        style={{ width: '100%' }}
+                                        placeholder="Select groups..."
+                                        tagRender={tagRender}
+                                        dropdownRender={dropDownRender}
+                                        onChange={handleChangeTags}
+                                        defaultOpen={true}>
                                         {
                                             tagGroups.map(m =>
                                                 <Option key={m}>{optionRender(m)}</Option>
@@ -196,10 +236,10 @@ const PeerGroupsUpdate = () => {
                                     </Col>
                                     <Col flex="auto">
                                         <Paragraph>
-                                            At the moment access rules are bi-directional by default, this means both source and destination can talk to each-other in both directions. However destination peers will not be able to communicate with each other, nor will the source peers.
+                                            Select or Create groups to associate with this peer.
                                         </Paragraph>
                                         <Paragraph>
-                                            If you want to enable all peers of the same group to talk to each other - you can add that group both as a receiver and as a destination.
+                                            Every peer is part of the group All, thus you can't remove it.
                                         </Paragraph>
                                     </Col>
                                 </Row>

--- a/src/views/Peers.tsx
+++ b/src/views/Peers.tsx
@@ -30,6 +30,7 @@ import ButtonCopyMessage from "../components/ButtonCopyMessage";
 import {Group, GroupPeer} from "../store/group/types";
 import PeerGroupsUpdate from "../components/PeerGroupsUpdate";
 import tableSpin from "../components/Spin";
+import {TooltipPlacement} from "antd/es/tooltip";
 
 const { Title, Paragraph } = Typography;
 const { Column } = Table;
@@ -209,8 +210,13 @@ export const Peers = () => {
             )
         })
         const mainContent = (<Space direction="vertical">{content}</Space>)
+        let popoverPlacement = "top"
+        if (content && content.length > 5) {
+            popoverPlacement = "rightTop"
+        }
+
         return (
-            <Popover key={peerToAction.key} content={mainContent} title={null}>
+            <Popover placement={popoverPlacement as TooltipPlacement} key={peerToAction.key} content={mainContent} title={null}>
                 <Button type="link" onClick={() => setUpdateGroupsVisible(peerToAction, true)}>{label}</Button>
             </Popover>
         )


### PR DESCRIPTION
Validate tag naming input
* check if only spaces has been added
* check if group All is being removed
* group All is not closeable in peers

Fixed issue when group list is too large, preventing click on the group counter