### PR TITLE
Disable service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   "scripts": {
     "copy": "copyfiles -f ./node_modules/@axa-fr/react-oidc/dist/OidcServiceWorker.js ./public",
     "copytrusted": "copyfiles -f ./public/local/OidcTrustedDomains.js ./public",
-    "start": "npm run copy && npm run copytrusted && react-scripts start",
-    "build": "npm run copy && react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,8 @@ const providerConfig = {
     refresh_time_before_tokens_expiration_in_second: 30,
     silent_redirect_uri: window.location.origin + '#silent-callback',
     scope: 'openid profile email api offline_access email_verified',
-    service_worker_relative_url:'/OidcServiceWorker.js',
+    // disabling service worker
+    // service_worker_relative_url:'/OidcServiceWorker.js',
     service_worker_only: false,
     authority_configuration: {
         authorization_endpoint: authority + "/authorize",


### PR DESCRIPTION
Service has caused some bugs where
the trust domains were ignored
and api calls were done without proper credentials