### PR TITLE
Check token before do api requests for the page

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependecies
         run: npm install
 
+      - name: List dependencies
+        run: npm list
+
       - name: Build 
         # skiping fail on warning for now
         run: CI=false npm run build

--- a/src/views/Peers.tsx
+++ b/src/views/Peers.tsx
@@ -52,7 +52,7 @@ interface PeerDataTable extends Peer {
 
 export const Peers = () => {
 
-    const {accessToken} = useOidcAccessToken()
+    const {accessToken,accessTokenPayload} = useOidcAccessToken()
     const dispatch = useDispatch()
 
     const peers = useSelector((state: RootState) => state.peer.data);
@@ -72,6 +72,7 @@ export const Peers = () => {
     const [dataTable, setDataTable] = useState([] as PeerDataTable[]);
     const [peerToAction, setPeerToAction] = useState(null as PeerDataTable | null);
     const [groupPopupVisible,setGroupPopupVisible] = useState(false as boolean|undefined)
+    const [loadOnce, setLoadOnce] = useState(false)
 
     const pageSizeOptions = [
         {label: "5", value: "5"},
@@ -108,10 +109,26 @@ export const Peers = () => {
         })
     }
 
-    useEffect(() => {
+    const doPageRequests = () => {
         dispatch(peerActions.getPeers.request({getAccessTokenSilently: accessToken, payload: null}));
         dispatch(groupActions.getGroups.request({getAccessTokenSilently: accessToken, payload: null}));
         dispatch(routeActions.getRoutes.request({getAccessTokenSilently: accessToken, payload: null}));
+    }
+
+    useEffect(() => {
+        if (!loadOnce) {
+            doPageRequests()
+            setLoadOnce(true)
+        }
+    },[accessToken])
+
+    useEffect(() => {
+        if ((accessTokenPayload.exp * 1000) > (Date.now() - 5000)) {
+            doPageRequests()
+            if (!loadOnce) {
+                setLoadOnce(true)
+            }
+        }
     }, [])
 
     useEffect(() => {


### PR DESCRIPTION
This will prevent the case where we are using an expired access token to call our API

Added a loadOnce to prevent not loading the page at least once

Also will print dependencies versions on ci/cd