### PR TITLE
Revert "bump @axa-fr/react-oidc to 6.9 to fix atob padding bug"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
-        "@axa-fr/react-oidc": "^6.9.2",
+        "@axa-fr/react-oidc": "^5.14.0",
         "@headlessui/react": "^1.5.0",
         "@heroicons/react": "^1.0.4",
         "@testing-library/jest-dom": "^5.11.4",
@@ -122,10 +122,9 @@
       }
     },
     "node_modules/@axa-fr/react-oidc": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-6.9.2.tgz",
-      "integrity": "sha512-DaAerrnl5uCN89mWIGuIEmXN2APuD1Q+060AsdT0H021BeQkvCkBq0EwjsRUMWrgKzcwWipqN/1e0jpd0QWPQw==",
-      "hasInstallScript": true,
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-5.14.2.tgz",
+      "integrity": "sha512-N+ssJlVtVHnsvlusMxY3zLPKCB+lGzeHIxWXUb0WY3uA7Z+jxx7A2m9W1kHbhYzHuihgA3rWIcdKsvtdkeKXwg==",
       "dependencies": {
         "@openid/appauth": "1.3.1"
       },
@@ -16821,9 +16820,9 @@
       }
     },
     "@axa-fr/react-oidc": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-6.9.2.tgz",
-      "integrity": "sha512-DaAerrnl5uCN89mWIGuIEmXN2APuD1Q+060AsdT0H021BeQkvCkBq0EwjsRUMWrgKzcwWipqN/1e0jpd0QWPQw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-5.14.2.tgz",
+      "integrity": "sha512-N+ssJlVtVHnsvlusMxY3zLPKCB+lGzeHIxWXUb0WY3uA7Z+jxx7A2m9W1kHbhYzHuihgA3rWIcdKsvtdkeKXwg==",
       "requires": {
         "@openid/appauth": "1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
-    "@axa-fr/react-oidc": "^6.9.2",
+    "@axa-fr/react-oidc": "^5.14.0",
     "@headlessui/react": "^1.5.0",
     "@heroicons/react": "^1.0.4",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,16 +16,12 @@ const config = getConfig();
 // Unfortunately Auth0 https://<DOMAIN>/.well-known/openid-configuration doesn't contain end_session_endpoint that
 // is required for doing logout. Therefore, we need to hardcode the config for auth
 const auth0AuthorityConfig: AuthorityConfiguration = {
-  issuer:
-    config.authority.slice(-1) === "/"
-      ? config.authority
-      : config.authority + "/",
-  authorization_endpoint: new URL("authorize", config.authority).href,
-  token_endpoint: new URL("oauth/token", config.authority).href,
-  revocation_endpoint: new URL("oauth/revoke", config.authority).href,
-  end_session_endpoint: new URL("v2/logout", config.authority).href,
-  userinfo_endpoint: new URL("userinfo", config.authority).href,
-} as AuthorityConfiguration;
+    authorization_endpoint: new URL("authorize", config.authority).href,
+    token_endpoint:  new URL("oauth/token", config.authority).href,
+    revocation_endpoint: new URL("oauth/revoke", config.authority).href,
+    end_session_endpoint: new URL("v2/logout", config.authority).href,
+    userinfo_endpoint: new URL("userinfo", config.authority).href,
+} as AuthorityConfiguration
 
 const providerConfig = {
     authority: config.authority,


### PR DESCRIPTION
Reverts netbirdio/dashboard#97

@BeryJu unfortunately we will have to revert the PR as the new version's silent login has some issues that passed my tests, but they are more visible when working with shorter expiration times for your access tokens.