### PR TITLE
fix: apt-key deprecation warning/errors

### DIFF
--- a/src/components/addpeer/UbuntuTab.tsx
+++ b/src/components/addpeer/UbuntuTab.tsx
@@ -26,7 +26,7 @@ export const UbuntuTab = () => {
             title: 'Add repository:',
             commands: [
                 `sudo apt install ca-certificates curl gnupg -y`,
-                `curl -L https://pkgs.wiretrustee.com/debian/public.key | sudo apt-key add -`,
+                `curl -L https://pkgs.wiretrustee.com/debian/public.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/wiretrustee.gpg`,
                 `echo 'deb https://pkgs.wiretrustee.com/debian stable main' | sudo tee /etc/apt/sources.list.d/wiretrustee.list`
             ].join('\n'),
             copied: false,


### PR DESCRIPTION
The use of apt-key has been deprecated for security reasons, and best practice is now to add keyrings to the directory `/etc/apt/trusted.gpg.d/`. 
When adding the gpg key using the current method, the following error is being displayed:
`Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).`
Similar warning appears when running `apt update`:
`Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.`
It should also be noted that apt-key(8) will last be available in Debian 11 and Ubuntu 22.04.

This PR edits one of the commands in the installation guide for Ubuntu-based distros, to use the new suggested method.