### PR TITLE
Add distribution groups to Network routes

### DIFF
--- a/src/components/PeerUpdate.tsx
+++ b/src/components/PeerUpdate.tsx
@@ -353,7 +353,7 @@ const PeerUpdate = () => {
                                                                 max={59}/>
                                                         </Form.Item>
                                                     <Form.Item
-                                                        label="Possible domain name after saving"
+                                                        label="New peer domain name preview"
                                                         tooltip="If the domain name already exists, we add an increment number suffix to it"
                                                         style={{margin: '1px'}}
                                                     >

--- a/src/components/RouteUpdate.tsx
+++ b/src/components/RouteUpdate.tsx
@@ -243,13 +243,23 @@ const RouteUpdate = () => {
         return Promise.resolve()
     }
 
+    const selectPreValidator = (obj: RuleObject, value: string[]) => {
+       if (setupNewRouteHA && formRoute.peer == '') {
+           let [, newGroups ] = getExistingAndToCreateGroupsLists(value)
+           if (newGroups.length > 0) {
+               return Promise.reject(new Error("You can't add new Groups from the group update view, please remove:\"" + newGroups +"\""))
+           }
+       }
+       return selectValidator(obj, value)
+    }
+
     return (
         <>
             {route &&
                 <Drawer
                     headerStyle={{display: "none"}}
                     forceRender={true}
-                    visible={setupNewRouteVisible}
+                    open={setupNewRouteVisible}
                     bodyStyle={{paddingBottom: 80}}
                     onClose={onCancel}
                     autoFocus={true}
@@ -393,7 +403,7 @@ const RouteUpdate = () => {
                                     name="groups"
                                     label="Distribution groups"
                                     tooltip="Distribution groups define to which group of peers this route will be distributed to"
-                                    rules={[{validator: selectValidator}]}
+                                    rules={[{validator: selectPreValidator}]}
                                 >
                                     <Select mode="tags"
                                             style={{width: '100%'}}

--- a/src/components/RouteUpdate.tsx
+++ b/src/components/RouteUpdate.tsx
@@ -271,7 +271,7 @@ const RouteUpdate = () => {
                         </Space>
                     }
                 >
-                    <Form layout="vertical" form={form} onValuesChange={onChange}>
+                    <Form layout="vertical" form={form} requiredMark={false} onValuesChange={onChange}>
                         <Row gutter={16}>
                             <Col span={24}>
                                 <Header style={{margin: "-32px -24px 20px -24px", padding: "24px 24px 0 24px"}}>
@@ -402,7 +402,7 @@ const RouteUpdate = () => {
                                 <Form.Item
                                     name="groups"
                                     label="Distribution groups"
-                                    tooltip="Distribution groups define to which group of peers this route will be distributed to"
+                                    tooltip="NetBird will advertise this route to peers that belong to the following groups"
                                     rules={[{validator: selectPreValidator}]}
                                 >
                                     <Select mode="tags"

--- a/src/store/route/actions.ts
+++ b/src/store/route/actions.ts
@@ -1,5 +1,5 @@
 import { ActionType, createAction, createAsyncAction } from 'typesafe-actions';
-import {Route} from './types';
+import {Route, RouteToSave} from './types';
 import {ApiError, CreateResponse, DeleteResponse, RequestPayload} from '../../services/api-client/types';
 
 const actions = {
@@ -13,7 +13,7 @@ const actions = {
       'SAVE_ROUTE_REQUEST',
       'SAVE_ROUTE_SUCCESS',
       'SAVE_ROUTE_FAILURE',
-  )<RequestPayload<Route>, CreateResponse<Route | null>, CreateResponse<Route | null>>(),
+  )<RequestPayload<RouteToSave>, CreateResponse<Route | null>, CreateResponse<Route | null>>(),
   setSavedRoute: createAction('SET_CREATE_ROUTE')<CreateResponse<Route | null>>(),
   resetSavedRoute: createAction('RESET_CREATE_ROUTE')<null>(),
   

--- a/src/store/route/types.ts
+++ b/src/store/route/types.ts
@@ -1,3 +1,4 @@
+
 export interface Route {
     id?: string
     description: string
@@ -8,4 +9,10 @@ export interface Route {
     network_type?: string
     metric?: number
     masquerade:	boolean
+    groups: string[]
+}
+
+export interface RouteToSave extends Route
+{
+    groupsToCreate: string[]
 }

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -34,6 +34,7 @@ export interface GroupedDataTable {
     description: string
     routesCount: number
     groupedRoutes: RouteDataTable[]
+    routesGroups: string[]
 }
 
 export const transformDataTable = (d:Route[],peerIPToName:PeerIPToName):RouteDataTable[] => {
@@ -52,10 +53,12 @@ export const transformGroupedDataTable = (routes:Route[],peerIPToName:PeerIPToNa
     }))
 
     let groupedRoutes:GroupedDataTable[] = []
+
     keySet.forEach((p) => {
         let hasEnabled = false
         let lastRoute:Route
         let listedRoutes:Route[] = []
+        let groupList:string[] = []
         routes.forEach((r) => {
             if ( p === r.network_id + r.network ) {
                 lastRoute = r
@@ -63,8 +66,10 @@ export const transformGroupedDataTable = (routes:Route[],peerIPToName:PeerIPToNa
                     hasEnabled = true
                 }
                 listedRoutes.push(r)
+                groupList = groupList.concat(r.groups)
             }
         })
+        groupList = groupList.filter((value,index,arrary) => arrary.indexOf(value) === index)
         let groupDataTableRoutes = transformDataTable(listedRoutes,peerIPToName)
         groupedRoutes.push({
             key: p.toString(),
@@ -75,6 +80,7 @@ export const transformGroupedDataTable = (routes:Route[],peerIPToName:PeerIPToNa
             enabled: hasEnabled,
             routesCount: groupDataTableRoutes.length,
             groupedRoutes: groupDataTableRoutes,
+            routesGroups: groupList,
         })
     })
     return groupedRoutes

--- a/src/views/DNS.tsx
+++ b/src/views/DNS.tsx
@@ -301,7 +301,7 @@ export const DNS = () => {
             let errorMsg = "Failed to update nameserver group"
             switch (savedNSGroup.error.statusCode) {
                 case 403:
-                    errorMsg = "Failed to update user. You might not have enough permissions."
+                    errorMsg = "Failed to update nameserver group. You might not have enough permissions."
                     break
                 default:
                     errorMsg = savedNSGroup.error.data.message ? savedNSGroup.error.data.message : errorMsg

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -9,7 +9,7 @@ import {
     Input,
     Menu,
     message,
-    Modal,
+    Modal, Popover,
     Radio,
     RadioChangeEvent,
     Row,
@@ -24,7 +24,7 @@ import {
 import {Container} from "../components/Container";
 import {useDispatch, useSelector} from "react-redux";
 import {RootState} from "typesafe-actions";
-import {Route} from "../store/route/types";
+import {Route, RouteToSave} from "../store/route/types";
 import {actions as routeActions} from "../store/route";
 import {actions as peerActions} from "../store/peer";
 import {filter, sortBy} from "lodash";
@@ -42,6 +42,9 @@ import {
     transformGroupedDataTable
 } from '../utils/routes'
 import {useGetAccessTokenSilently} from "../utils/token";
+import {Group} from "../store/group/types";
+import {TooltipPlacement} from "antd/es/tooltip";
+import {actions as groupActions} from "../store/group";
 
 const {Title, Paragraph, Text} = Typography;
 const {Column} = Table;
@@ -51,6 +54,7 @@ export const Routes = () => {
     const {getAccessTokenSilently} = useGetAccessTokenSilently()
     const dispatch = useDispatch()
 
+    const groups = useSelector((state: RootState) => state.group.data)
     const routes = useSelector((state: RootState) => state.route.data);
     const failed = useSelector((state: RootState) => state.route.failed);
     const loading = useSelector((state: RootState) => state.route.loading);
@@ -58,6 +62,7 @@ export const Routes = () => {
     const savedRoute = useSelector((state: RootState) => state.route.savedRoute);
     const peers = useSelector((state: RootState) => state.peer.data)
     const loadingPeer = useSelector((state: RootState) => state.peer.loading);
+    const setupNewRouteVisible = useSelector((state: RootState) => state.route.setupNewRouteVisible)
     const [showTutorial, setShowTutorial] = useState(true)
     const [textToSearch, setTextToSearch] = useState('');
     const [optionAllEnable, setOptionAllEnable] = useState('enabled');
@@ -67,6 +72,7 @@ export const Routes = () => {
     const [routeToAction, setRouteToAction] = useState(null as RouteDataTable | null);
     const [groupedDataTable, setGroupedDataTable] = useState([] as GroupedDataTable[]);
     const [expandRowsOnClick, setExpandRowsOnClick] = useState(true)
+    const [groupPopupVisible, setGroupPopupVisible] = useState(false as boolean | undefined)
 
     const [peerNameToIP, peerIPToName] = initPeerMaps(peers);
 
@@ -83,10 +89,6 @@ export const Routes = () => {
             key: "view",
             label: (<Button type="text" block onClick={() => onClickViewRoute()}>View</Button>)
         },
-        // {
-        //     key: "delete",
-        //     label: (<Button type="text" block onClick={() => showConfirmDeactivate()}>Deactivate</Button>)
-        // },
         {
             key: "delete",
             label: (<Button type="text" block onClick={() => showConfirmDelete()}>Delete</Button>)
@@ -104,6 +106,7 @@ export const Routes = () => {
 
     useEffect(() => {
         dispatch(peerActions.getPeers.request({getAccessTokenSilently: getAccessTokenSilently, payload: null}));
+        dispatch(groupActions.getGroups.request({getAccessTokenSilently: getAccessTokenSilently, payload: null}));
     }, [])
 
     const filterGroupedDataTable = (routes: GroupedDataTable[]): GroupedDataTable[] => {
@@ -264,7 +267,8 @@ export const Routes = () => {
             peer: route.peer ? peerToPeerIP(route.peer, peerNameToIP[route.peer]) : '',
             metric: route.metric ? route.metric : 9999,
             masquerade: route.masquerade,
-            enabled: route.enabled
+            enabled: route.enabled,
+            groups: route.groups
         } as Route))
         dispatch(routeActions.setSetupNewRouteVisible(true));
     }
@@ -293,15 +297,75 @@ export const Routes = () => {
         });
     }
 
+    const onPopoverVisibleChange = () => {
+        if (setupNewRouteVisible) {
+            setGroupPopupVisible(false)
+        } else {
+            setGroupPopupVisible(undefined)
+        }
+    }
+
     function handleSwitchMasquerade(routeGroup: GroupedDataTable, checked: boolean) {
         routeGroup.groupedRoutes.forEach((record) => {
             const route = {
                 ...record,
                 peer: peerNameToIP[record.peer],
                 masquerade: checked,
-            } as Route
+                groupsToCreate: []
+            } as RouteToSave
             dispatch(routeActions.saveRoute.request({getAccessTokenSilently: getAccessTokenSilently, payload: route}));
         })
+    }
+
+    const renderPopoverGroups = (label: string, rowGroups: string[] | null, userToAction: RouteDataTable) => {
+
+        let groupsMap = new Map<string, Group>();
+        groups.forEach(g => {
+            groupsMap.set(g.id!, g)
+        })
+
+        let displayGroups: Group[] = []
+        if (rowGroups) {
+            displayGroups = rowGroups.filter(g => groupsMap.get(g)).map(g => groupsMap.get(g)!)
+        }
+
+        let btn = <Button type="link" onClick={() => setRouteAndView(userToAction)}>{displayGroups.length}</Button>
+
+        if (!displayGroups || displayGroups!.length < 1) {
+            return btn
+        }
+
+        const content = displayGroups?.map((g, i) => {
+            const _g = g as Group
+            const peersCount = ` - ${_g.peers_count || 0} ${(!_g.peers_count || parseInt(_g.peers_count) !== 1) ? 'peers' : 'peer'} `
+            return (
+                <div key={i}>
+                    <Tag
+                        color="blue"
+                        style={{marginRight: 3}}
+                    >
+                        <strong>{_g.name}</strong>
+                    </Tag>
+                    <span style={{fontSize: ".85em"}}>{peersCount}</span>
+                </div>
+            )
+        })
+        const mainContent = (<Space direction="vertical">{content}</Space>)
+        let popoverPlacement = "top"
+        if (content && content.length > 5) {
+            popoverPlacement = "rightTop"
+        }
+
+        return (
+            <Popover placement={popoverPlacement as TooltipPlacement}
+                     key={userToAction.id}
+                     onOpenChange={onPopoverVisibleChange}
+                     open={groupPopupVisible}
+                     content={mainContent}
+                     title={null}>
+                {btn}
+            </Popover>
+        )
     }
 
     const expandedRowRender = (record: GroupedDataTable) => {
@@ -327,6 +391,11 @@ export const Routes = () => {
                     onFilter={(value: string | number | boolean, record) => (record as any).metric.includes(value)}
                     sorter={(a, b) => ((a as any).metric - ((b as any).metric))}
             />
+            <Column title="Groups" dataIndex="groupsCount" align="center"
+                    render={(text, record: RouteDataTable) => {
+                        return renderPopoverGroups(text, record.groups, record)
+                    }}
+            />
             <Column title="Status" dataIndex="enabled" align="center"
                     render={(text: Boolean) => {
                         return text ? <Tag color="green">enabled</Tag> : <Tag color="red">disabled</Tag>
@@ -336,7 +405,7 @@ export const Routes = () => {
                     render={(text, record) => {
                         if (deletedRoute.loading || savedRoute.loading) return <></>
                         return <Dropdown.Button type="text" overlay={actionsMenu} trigger={["click"]}
-                                                onVisibleChange={visible => {
+                                                onOpenChange={visible => {
                                                     if (visible) setRouteToAction(record as RouteDataTable)
                                                 }}></Dropdown.Button>
                     }}

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -45,6 +45,7 @@ import {useGetAccessTokenSilently} from "../utils/token";
 import {Group} from "../store/group/types";
 import {TooltipPlacement} from "antd/es/tooltip";
 import {actions as groupActions} from "../store/group";
+import {useGetGroupTagHelpers} from "../utils/groups";
 
 const {Title, Paragraph, Text} = Typography;
 const {Column} = Table;
@@ -53,6 +54,9 @@ const {confirm} = Modal;
 export const Routes = () => {
     const {getAccessTokenSilently} = useGetAccessTokenSilently()
     const dispatch = useDispatch()
+    const {
+        getGroupNamesFromIDs,
+    } = useGetGroupTagHelpers()
 
     const groups = useSelector((state: RootState) => state.group.data)
     const routes = useSelector((state: RootState) => state.route.data);
@@ -112,7 +116,9 @@ export const Routes = () => {
     const filterGroupedDataTable = (routes: GroupedDataTable[]): GroupedDataTable[] => {
         const t = textToSearch.toLowerCase().trim()
         let f: GroupedDataTable[] = filter(routes, (f) =>
-            (f.network_id.toLowerCase().includes(t) || f.network.toLowerCase().includes(t) || f.description.toLowerCase().includes(t) || t === "")
+            (f.network_id.toLowerCase().includes(t) || f.network.toLowerCase().includes(t) ||
+                f.description.toLowerCase().includes(t) || t === "" ||
+                getGroupNamesFromIDs(f.routesGroups).find(u => u.toLowerCase().trim().includes(t)) )
         ) as GroupedDataTable[]
         if (optionAllEnable !== "all") {
             f = filter(f, (f) => f.enabled)

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -532,8 +532,8 @@ export const Routes = () => {
                                                 if (count > 1) {
                                                     tag = <Tag color="green">on</Tag>
                                                 }
-                                                return <div>{tag}<Divider type="vertical"/><Button type="link"
-                                                                                                   onClick={() => setRouteAndView(record)}>Configure</Button>
+                                                return <div>{tag}<Divider type="vertical"/>
+                                                    <Button type="link" onClick={() => setRouteAndView(record)}>Configure</Button>
                                                 </div>
                                             }}
                                     />

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -160,10 +160,19 @@ export const Routes = () => {
             dispatch(routeActions.setSavedRoute({...savedRoute, success: false}))
             dispatch(routeActions.resetSavedRoute(null))
         } else if (savedRoute.error) {
+            let errorMsg = "Failed to update network route"
+            switch (savedRoute.error.statusCode) {
+                case 403:
+                    errorMsg = "Failed to update network route. You might not have enough permissions."
+                    break
+                default:
+                    errorMsg = savedRoute.error.data.message ? savedRoute.error.data.message : errorMsg
+                    break
+            }
             message.error({
-                content: savedRoute.error.data ? savedRoute.error.data : savedRoute.error.message,
+                content: errorMsg,
                 key: saveKey,
-                duration: 2,
+                duration: 5,
                 style: styleNotification
             });
             dispatch(routeActions.setSavedRoute({...savedRoute, error: null}))
@@ -402,7 +411,7 @@ export const Routes = () => {
                         return renderPopoverGroups(text, record.groups, record)
                     }}
             />
-            <Column title="Status" dataIndex="enabled" align="center"
+            <Column title="Routing peer status" dataIndex="enabled" align="center"
                     render={(text: Boolean) => {
                         return text ? <Tag color="green">enabled</Tag> : <Tag color="red">disabled</Tag>
                     }}
@@ -513,7 +522,7 @@ export const Routes = () => {
                                             sorter={(a, b) => ((a as any).network.localeCompare((b as any).network))}
                                         // defaultSortOrder='ascend'
                                     />
-                                    <Column title="Status" dataIndex="enabled" align="center"
+                                    <Column title="Route status" dataIndex="enabled" align="center"
                                             render={(text: Boolean) => {
                                                 return text ? <Tag color="green">enabled</Tag> :
                                                     <Tag color="red">disabled</Tag>

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -242,7 +242,6 @@ export const Routes = () => {
 
 
     const onClickAddNewRoute = () => {
-        dispatch(routeActions.setSetupNewRouteHA(true));
         dispatch(routeActions.setSetupNewRouteVisible(true));
         dispatch(routeActions.setRoute({
             network: '',


### PR DESCRIPTION
Users can add distribution groups to network routes

Groups can be added to individual network routes or to all routes in the group

Adding a new group in the modal is restricted to individual network route operations