### PR TITLE
Fix MacOS custom netbird up command  

### DIFF
--- a/src/components/addpeer/MacTab.tsx
+++ b/src/components/addpeer/MacTab.tsx
@@ -3,6 +3,7 @@ import React, {useState} from 'react';
 import { Button } from "antd";
 import TabSteps from "./TabSteps";
 import { StepCommand } from "./types"
+import { formatNetBirdUP } from "./common"
 
 export const LinuxTab = () => {
 
@@ -30,9 +31,7 @@ export const LinuxTab = () => {
         {
             key: 3,
             title: 'Run NetBird and log in the browser:',
-            commands: [
-                `sudo netbird up`
-            ].join('\n'),
+            commands: formatNetBirdUP(),
             copied: false,
             showCopyButton: true
         } as StepCommand,

--- a/src/components/addpeer/UbuntuTab.tsx
+++ b/src/components/addpeer/UbuntuTab.tsx
@@ -5,20 +5,11 @@ import TabSteps from "./TabSteps";
 import { StepCommand } from "./types"
 import { getConfig } from "../../config";
 import Paragraph from 'antd/lib/skeleton/Paragraph';
-const { grpcApiOrigin } = getConfig();
+import { formatNetBirdUP } from "./common"
+
 
 
 export const UbuntuTab = () => {
-
-    const formatNetBirdUP = () => {
-        let cmd = "sudo netbird up"
-        if (grpcApiOrigin) {
-            cmd = "sudo netbird up --management-url " + grpcApiOrigin
-        }
-        return [
-            cmd
-        ].join('\n')
-    }
 
     const [steps, setSteps] = useState([
         {

--- a/src/components/addpeer/common.ts
+++ b/src/components/addpeer/common.ts
@@ -1,0 +1,13 @@
+import {getConfig} from "../../config";
+const { grpcApiOrigin } = getConfig();
+
+
+export const formatNetBirdUP = () => {
+    let cmd = "sudo netbird up"
+    if (grpcApiOrigin) {
+        cmd = "sudo netbird up --management-url " + grpcApiOrigin
+    }
+    return [
+        cmd
+    ].join('\n')
+}


### PR DESCRIPTION
Currently, the `netbird up` command doesn't show the case, when running the netbird server components in the self-hosted mode in case of MacOS. This PR adds the support for it to show the `netbird up --management-url [self-hosted server]` for MacOS tab, similar to the ubuntu tab.   