### PR TITLE
Account settings view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {User} from "./store/user/types";
 import {SecureLoading} from "./components/Loading";
 import DNS from "./views/DNS";
 import Activity from "./views/Activity";
+import Settings from "./views/Settings";
 
 
 
@@ -107,6 +108,7 @@ function App() {
                             <Route path="/users" component={withOidcSecure(Users)}/>
                             <Route path="/dns" component={withOidcSecure(DNS)}/>
                             <Route path="/activity" component={withOidcSecure(Activity)}/>
+                            <Route path="/settings" component={withOidcSecure(Settings)}/>
                         </Switch>
                     </Content>
                     <FooterComponent/>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -41,13 +41,14 @@ const Navbar = () => {
         {label: (<Link to="/routes">Network Routes</Link>), key: '/routes'},
         { label: (<Link  to="/dns">DNS</Link>), key: '/dns' },
         {label: (<Link to="/users">Users</Link>), key: '/users'},
-        {label: (<Link to="/activity">Activity</Link>), key: '/activity'}
+        {label: (<Link to="/activity">Activity</Link>), key: '/activity'},
+        {label: (<Link to="/settings">Settings</Link>), key: '/settings'}
     ] as ItemType[]
 
     const userEmailKey = 'user-email'
     const userLogoutKey = 'user-logout'
     const userDividerKey = 'user-divider'
-    const adminOnlyTabs = ["/setup-keys", "/acls", "/routes", "/dns", "/activity"]
+    const adminOnlyTabs = ["/setup-keys", "/acls", "/routes", "/dns", "/activity", "/settings"]
     const [menuItems, setMenuItems] = useState(items)
     const logoutWithRedirect = () =>
         logout("/", {client_id: config.clientId});

--- a/src/components/SetupKeyNew.tsx
+++ b/src/components/SetupKeyNew.tsx
@@ -23,7 +23,7 @@ import {RootState} from "typesafe-actions";
 import {CloseOutlined, EditOutlined, QuestionCircleFilled} from "@ant-design/icons";
 import {FormSetupKey, SetupKey, SetupKeyToSave} from "../store/setup-key/types";
 import {Header} from "antd/es/layout/layout";
-import {formatDate, timeAgo, checkExpiresIn} from "../utils/common";
+import {checkExpiresIn, formatDate, timeAgo} from "../utils/common";
 import {RuleObject} from "antd/lib/form";
 import {CustomTagProps} from "rc-select/lib/BaseSelect";
 import {Group} from "../store/group/types";
@@ -440,7 +440,13 @@ const SetupKeyNew = () => {
                                 <Col span={24}>
                                     <Form.Item name="expiresInFormatted" label="Expires In"
                                                rules={[{validator: checkExpiresIn}]}>
-                                        <ExpiresInInput/>
+                                        <ExpiresInInput options={
+                                            Array.of(
+                                                {key: "day", title: "Days"},
+                                                {key: "week", title: "Weeks"},
+                                                {key: "month", title: "Months"},
+                                                {key: "year", title: "Years"})
+                                        }/>
                                     </Form.Item>
                                 </Col>}
                             <Col span={12}>
@@ -448,7 +454,8 @@ const SetupKeyNew = () => {
                                            label="Usage Limit"
                                            tooltip="Limit the number of times this key can be used. Use 0 for unlimited use."
                                 >
-                                    <InputNumber min={0} defaultValue={0} disabled={setupKey.id || formSetupKey.type !== "reusable"}
+                                    <InputNumber min={0} defaultValue={0}
+                                                 disabled={setupKey.id || formSetupKey.type !== "reusable"}
                                                  style={{width: "100%"}}
                                     />
                                 </Form.Item>

--- a/src/components/SetupKeyNew.tsx
+++ b/src/components/SetupKeyNew.tsx
@@ -28,7 +28,7 @@ import {RuleObject} from "antd/lib/form";
 import {CustomTagProps} from "rc-select/lib/BaseSelect";
 import {Group} from "../store/group/types";
 import {useGetAccessTokenSilently} from "../utils/token";
-import ExpiresInInput, {ExpiresInValue} from "../views/ExpiresInInput";
+import ExpiresInInput, {expiresInToSeconds, ExpiresInValue} from "../views/ExpiresInInput";
 
 const {Option} = Select;
 
@@ -116,31 +116,6 @@ const SetupKeyNew = () => {
             expires_in: expiresIn,
             usage_limit: formSetupKey.usage_limit
         } as SetupKeyToSave
-    }
-    const expiresInToSeconds = (expiresIn: ExpiresInValue): number => {
-        if (!expiresIn.number || !expiresIn.interval) {
-            return 0
-        }
-        let multiplier = 0
-        switch (expiresIn.interval.toLowerCase()) {
-            case "day":
-                multiplier = 24 * 3600
-                break
-            case "week":
-                multiplier = 7 * 24 * 3600
-                break
-            case "month":
-                multiplier = 30 * 24 * 3600
-                break
-            case "year":
-                multiplier = 365 * 24 * 3600
-                break
-            default:
-                multiplier = 0
-        }
-
-        return expiresIn.number * multiplier
-
     }
 
     const handleFormSubmit = () => {

--- a/src/components/SetupKeyNew.tsx
+++ b/src/components/SetupKeyNew.tsx
@@ -418,7 +418,6 @@ const SetupKeyNew = () => {
                                         <ExpiresInInput options={
                                             Array.of(
                                                 {key: "day", title: "Days"},
-                                                {key: "week", title: "Weeks"},
                                                 {key: "month", title: "Months"},
                                                 {key: "year", title: "Years"})
                                         }/>

--- a/src/services/api-client/api-request.ts
+++ b/src/services/api-client/api-request.ts
@@ -3,12 +3,6 @@ import axios from 'axios';
 import {ApiError, ApiRequestParams, ApiResponse} from './types';
 import {headersFactory, RequestHeader} from './header-factory';
 
-/*axios.interceptors.response.use(undefined, err => {
-  let res = err.response;
-  if (res.status === 401) {
-  }
-})*/
-
 async function apiRequest<T>(params: ApiRequestParams): Promise<ApiResponse<T>> {
   const data = params.data ? (params.data as any).payload : undefined;
   const url = `${params.urlBase}${params.url}`;

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -1,0 +1,14 @@
+import {ActionType, createAsyncAction} from 'typesafe-actions';
+import {Account} from './types';
+import {ApiError, RequestPayload} from '../../services/api-client/types';
+
+const actions = {
+  getAccounts: createAsyncAction(
+      'GET_ACCOUNTS_REQUEST',
+      'GET_ACCOUNTS_SUCCESS',
+      'GET_ACCOUNTS_FAILURE',
+  )<RequestPayload<null>, Account[], ApiError>(),
+};
+
+export type ActionTypes = ActionType<typeof actions>;
+export default actions;

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -1,14 +1,23 @@
-import {ActionType, createAsyncAction} from 'typesafe-actions';
+import {ActionType, createAction, createAsyncAction} from 'typesafe-actions';
 import {Account} from './types';
-import {ApiError, RequestPayload} from '../../services/api-client/types';
+import {ApiError, ChangeResponse, RequestPayload} from '../../services/api-client/types';
 
 const actions = {
-  getAccounts: createAsyncAction(
-      'GET_ACCOUNTS_REQUEST',
-      'GET_ACCOUNTS_SUCCESS',
-      'GET_ACCOUNTS_FAILURE',
-  )<RequestPayload<null>, Account[], ApiError>(),
+    getAccounts: createAsyncAction(
+        'GET_ACCOUNTS_REQUEST',
+        'GET_ACCOUNTS_SUCCESS',
+        'GET_ACCOUNTS_FAILURE',
+    )<RequestPayload<null>, Account[], ApiError>(),
+
+    updateAccount: createAsyncAction(
+        'UPDATE_ACCOUNT',
+        'UPDATE_ACCOUNT_SUCCESS',
+        'UPDATE_ACCOUNT_FAILURE',
+    )<RequestPayload<Account>, ChangeResponse<Account | null>, ChangeResponse<Account | null>>(),
+    setUpdateAccount: createAction('SET_UPDATED_ACCOUNT')<ChangeResponse<Account | null>>(),
+    resetUpdateAccount: createAction('RESET_UPDATED_ACCOUNT')<null>(),
 };
+
 
 export type ActionTypes = ActionType<typeof actions>;
 export default actions;

--- a/src/store/account/index.ts
+++ b/src/store/account/index.ts
@@ -1,0 +1,7 @@
+import actions, { ActionTypes as _actionTypes } from './actions';
+import reducer from './reducer';
+import sagas from './sagas';
+
+export type ActionTypes = _actionTypes;
+
+export { actions, reducer, sagas };

--- a/src/store/account/reducer.ts
+++ b/src/store/account/reducer.ts
@@ -2,18 +2,26 @@ import { createReducer } from 'typesafe-actions';
 import { combineReducers } from 'redux';
 import { Account } from './types';
 import actions, { ActionTypes } from './actions';
-import {ApiError, CreateResponse} from "../../services/api-client/types";
+import {ApiError, ChangeResponse} from "../../services/api-client/types";
 
 type StateType = Readonly<{
   data: Account[] | null;
   loading: boolean;
   failed: ApiError | null;
+  savedAccount: ChangeResponse<Account | null>;
 }>;
 
 const initialState: StateType = {
   data: [],
   loading: false,
   failed: null,
+  savedAccount: <ChangeResponse<Account | null>>{
+    loading: false,
+    success: false,
+    failure: false,
+    error: null,
+    data : null
+  },
 };
 
 const data = createReducer<Account[], ActionTypes>(initialState.data as Account[])
@@ -30,9 +38,17 @@ const failed = createReducer<ApiError | null, ActionTypes>(initialState.failed)
     .handleAction(actions.getAccounts.success, () => null)
     .handleAction(actions.getAccounts.failure, (store, action) => action.payload);
 
+const updatedAccount = createReducer<ChangeResponse<Account | null>, ActionTypes>(initialState.savedAccount)
+    .handleAction(actions.updateAccount.request, () => initialState.savedAccount)
+    .handleAction(actions.updateAccount.success, (store, action) => action.payload)
+    .handleAction(actions.updateAccount.failure, (store, action) => action.payload)
+    .handleAction(actions.setUpdateAccount, (store, action) => action.payload)
+    .handleAction(actions.resetUpdateAccount, () => initialState.savedAccount)
+
 
 export default combineReducers({
   data,
   loading,
   failed,
+  updatedAccount
 });

--- a/src/store/account/reducer.ts
+++ b/src/store/account/reducer.ts
@@ -1,0 +1,38 @@
+import { createReducer } from 'typesafe-actions';
+import { combineReducers } from 'redux';
+import { Account } from './types';
+import actions, { ActionTypes } from './actions';
+import {ApiError, CreateResponse} from "../../services/api-client/types";
+
+type StateType = Readonly<{
+  data: Account[] | null;
+  loading: boolean;
+  failed: ApiError | null;
+}>;
+
+const initialState: StateType = {
+  data: [],
+  loading: false,
+  failed: null,
+};
+
+const data = createReducer<Account[], ActionTypes>(initialState.data as Account[])
+  .handleAction(actions.getAccounts.success,(_, action) => action.payload)
+  .handleAction(actions.getAccounts.failure, () => []);
+
+const loading = createReducer<boolean, ActionTypes>(initialState.loading)
+    .handleAction(actions.getAccounts.request, () => true)
+    .handleAction(actions.getAccounts.success, () => false)
+    .handleAction(actions.getAccounts.failure, () => false);
+
+const failed = createReducer<ApiError | null, ActionTypes>(initialState.failed)
+    .handleAction(actions.getAccounts.request, () => null)
+    .handleAction(actions.getAccounts.success, () => null)
+    .handleAction(actions.getAccounts.failure, (store, action) => action.payload);
+
+
+export default combineReducers({
+  data,
+  loading,
+  failed,
+});

--- a/src/store/account/sagas.ts
+++ b/src/store/account/sagas.ts
@@ -1,0 +1,23 @@
+import {all, call, put, takeLatest} from 'redux-saga/effects';
+import {ApiError, ApiResponse} from '../../services/api-client/types';
+import {Account} from './types'
+import service from './service';
+import actions from './actions';
+
+export function* getAccounts(action: ReturnType<typeof actions.getAccounts.request>): Generator {
+    try {
+        const effect = yield call(service.getAccounts, action.payload);
+        const response = effect as ApiResponse<Account[]>;
+
+        yield put(actions.getAccounts.success(response.body));
+    } catch (err) {
+        yield put(actions.getAccounts.failure(err as ApiError));
+    }
+}
+
+export default function* sagas(): Generator {
+    yield all([
+        takeLatest(actions.getAccounts.request, getAccounts),
+    ]);
+}
+

--- a/src/store/account/sagas.ts
+++ b/src/store/account/sagas.ts
@@ -1,9 +1,8 @@
-import {all, call, put, select, takeLatest} from 'redux-saga/effects';
+import {all, call, put, takeLatest} from 'redux-saga/effects';
 import {ApiError, ApiResponse, ChangeResponse} from '../../services/api-client/types';
 import {Account} from './types'
 import service from './service';
 import actions from './actions';
-import {Peer} from "../peer/types";
 
 export function* getAccounts(action: ReturnType<typeof actions.getAccounts.request>): Generator {
     try {
@@ -26,12 +25,11 @@ export function* updateAccount(action: ReturnType<typeof actions.updateAccount.r
             data: null
         }))
 
-        const peer = action.payload.payload
-        const peerId = peer.id
+        const account = action.payload.payload
 
         const payloadToSave = {
             getAccessTokenSilently: action.payload.getAccessTokenSilently,
-            payload: peer
+            payload: account
         }
 
         const effect = yield call(service.updateAccount, payloadToSave)

--- a/src/store/account/service.ts
+++ b/src/store/account/service.ts
@@ -8,5 +8,12 @@ export default {
       `/api/accounts`,
         payload
     );
+  },
+  async updateAccount(payload:RequestPayload<Account>): Promise<ApiResponse<Account>> {
+    const id = payload.payload.id
+    return apiClient.put<Account>(
+        `/api/accounts/${id}`,
+        payload
+    );
   }
 };

--- a/src/store/account/service.ts
+++ b/src/store/account/service.ts
@@ -1,0 +1,12 @@
+import {ApiResponse, RequestPayload} from '../../services/api-client/types';
+import { apiClient } from '../../services/api-client';
+import {Account} from './types';
+
+export default {
+  async getAccounts(payload:RequestPayload<null>): Promise<ApiResponse<Account[]>> {
+    return apiClient.get<Account[]>(
+      `/api/accounts`,
+        payload
+    );
+  }
+};

--- a/src/store/account/types.ts
+++ b/src/store/account/types.ts
@@ -1,0 +1,11 @@
+import {ExpiresInValue} from "../../views/ExpiresInInput";
+
+export interface Account {
+    id: string;
+    settings: { peer_login_expiration_enabled: boolean, peer_login_expiration: number}
+}
+
+export interface FormAccount extends Account {
+    peer_login_expiration_enabled: boolean
+    peer_login_expiration_formatted : ExpiresInValue
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,7 @@ import { sagas as routeSagas } from './route';
 import { sagas as nameserverGroupSagas } from './nameservers';
 import { sagas as eventSagas } from './event';
 import { sagas as dnsSettingsSagas } from './dns-settings';
+import { sagas as accountSagas } from './account';
 
 import rootReducer from './root-reducer';
 import { apiClient } from '../services/api-client';
@@ -31,5 +32,6 @@ sagaMiddleware.run(routeSagas);
 sagaMiddleware.run(nameserverGroupSagas);
 sagaMiddleware.run(eventSagas);
 sagaMiddleware.run(dnsSettingsSagas);
+sagaMiddleware.run(accountSagas);
 
 export { apiClient, rootReducer, store };

--- a/src/store/root-action.ts
+++ b/src/store/root-action.ts
@@ -7,6 +7,7 @@ import {actions as RouteActions} from './route';
 import {actions as NameServerGroupActions} from './nameservers';
 import {actions as EventActions} from './event';
 import {actions as DNSSettingsActions} from './dns-settings';
+import {actions as AccountActions} from './account';
 
 export default {
   peer: PeerActions,
@@ -17,5 +18,6 @@ export default {
   route: RouteActions,
   nameserverGroup: NameServerGroupActions,
   event: EventActions,
-  dnsSettings: DNSSettingsActions
+  dnsSettings: DNSSettingsActions,
+  account: AccountActions
 };

--- a/src/store/root-reducer.ts
+++ b/src/store/root-reducer.ts
@@ -9,6 +9,7 @@ import { reducer as route } from './route';
 import { reducer as nameserverGroup } from './nameservers';
 import { reducer as event } from './event';
 import { reducer as dnsSettings } from './dns-settings';
+import { reducer as account } from './account';
 
 export default combineReducers({
   peer,
@@ -19,5 +20,6 @@ export default combineReducers({
   route,
   nameserverGroup,
   event,
-  dnsSettings
+  dnsSettings,
+  account
 });

--- a/src/views/DNSSettings.tsx
+++ b/src/views/DNSSettings.tsx
@@ -104,9 +104,6 @@ export const DNSSettingsForm = () => {
                     payload: dnsSettingsToSave
                 }))
             })
-            .then(() => {
-                console.log("issued the request")
-            })
             .catch((errorInfo) => {
                 let msg = "please check the fields and try again"
                 if (errorInfo.errorFields) {

--- a/src/views/ExpiresInInput.tsx
+++ b/src/views/ExpiresInInput.tsx
@@ -19,6 +19,58 @@ interface ExpiresInInputProps {
     options: SelectOption[];
 }
 
+
+export const secondsToExpiresIn = (expiresIn: number, availableOptions: string[]): ExpiresInValue => {
+
+    if (expiresIn == 0) {
+        return {interval: "day", number: 0}
+    }
+    console.log((expiresIn % 86400 === 0))
+    console.log(availableOptions)
+    let result = {interval: "hour", number: expiresIn / 3600}
+    availableOptions.forEach(opt => {
+        if (opt === "year" && (expiresIn % 31104000 === 0)) {
+            result = {interval: "year", number: expiresIn / 31104000}
+        } else if (opt === "month" && (expiresIn % 2592000 === 0)) {
+            result =  {interval: "month", number: expiresIn / 2592000}
+        } else if (opt === "day" && (expiresIn % 86400 === 0)) {
+            result =  {interval: "day", number: expiresIn / 86400}
+        } else if (opt === "hour" && (expiresIn % 3600 === 0)) {
+            result =  {interval: "hour", number: expiresIn / 3600}
+        }
+    })
+    return result
+}
+
+export const expiresInToSeconds = (expiresIn: ExpiresInValue): number => {
+    if (!expiresIn.number || !expiresIn.interval) {
+        return 0
+    }
+    let multiplier = 0
+    switch (expiresIn.interval.toLowerCase()) {
+        case "hour":
+            multiplier = 3600
+            break
+        case "day":
+            multiplier = 24 * 3600
+            break
+        case "week":
+            multiplier = 7 * 24 * 3600
+            break
+        case "month":
+            multiplier = 30 * 24 * 3600
+            break
+        case "year":
+            multiplier = 365 * 24 * 3600
+            break
+        default:
+            multiplier = 0
+    }
+
+    return expiresIn.number * multiplier
+
+}
+
 const ExpiresInInput: React.FC<ExpiresInInputProps> = ({
                                                            value = {},
                                                            onChange,

--- a/src/views/ExpiresInInput.tsx
+++ b/src/views/ExpiresInInput.tsx
@@ -1,8 +1,6 @@
 import {Input, Select, Space} from 'antd';
 import React, {useState} from 'react';
 
-const {Option} = Select;
-
 export interface ExpiresInValue {
     number?: number;
     interval?: string;
@@ -17,6 +15,7 @@ interface ExpiresInInputProps {
     value?: ExpiresInValue;
     onChange?: (value: ExpiresInValue) => void;
     options: SelectOption[];
+    disabled?: boolean;
 }
 
 export const secondsToExpiresIn = (expiresIn: number, availableOptions: string[]): ExpiresInValue => {
@@ -72,7 +71,8 @@ export const expiresInToSeconds = (expiresIn: ExpiresInValue): number => {
 const ExpiresInInput: React.FC<ExpiresInInputProps> = ({
                                                            value = {},
                                                            onChange,
-                                                           options
+                                                           options,
+                                                           disabled= false,
                                                        }) => {
     const [number, setNumber] = useState(60);
     const [interval, setInterval] = useState("day");
@@ -98,9 +98,11 @@ const ExpiresInInput: React.FC<ExpiresInInputProps> = ({
                 type="number"
                 value={value.number || number}
                 onChange={onNumberChange}
+                disabled={disabled}
             />
             <Select style={{width: "100%"}}
                     value={value?.interval || interval}
+                    disabled={disabled}
                     onChange={onIntervalChange}>
                 {options.map(m =>
                     <Select.Option key={m.key}>{m.title}</Select.Option>)}

--- a/src/views/ExpiresInInput.tsx
+++ b/src/views/ExpiresInInput.tsx
@@ -8,12 +8,22 @@ export interface ExpiresInValue {
     interval?: string;
 }
 
+export interface SelectOption {
+    key: string,
+    title: string
+}
+
 interface ExpiresInInputProps {
     value?: ExpiresInValue;
     onChange?: (value: ExpiresInValue) => void;
+    options: SelectOption[];
 }
 
-const ExpiresInInput: React.FC<ExpiresInInputProps> = ({value = {}, onChange}) => {
+const ExpiresInInput: React.FC<ExpiresInInputProps> = ({
+                                                           value = {},
+                                                           onChange,
+                                                           options
+                                                       }) => {
     const [number, setNumber] = useState(60);
     const [interval, setInterval] = useState("day");
 
@@ -39,15 +49,13 @@ const ExpiresInInput: React.FC<ExpiresInInputProps> = ({value = {}, onChange}) =
                 value={value.number || number}
                 onChange={onNumberChange}
             />
-             <Select style={{width: "100%"}}
-                     value={value?.interval || interval}
-                     onChange={onIntervalChange}>
-                <Option value="day">Days</Option>
-                <Option value="week">Weeks</Option>
-                <Option value="month">Months</Option>
-                <Option value="year">Years</Option>
+            <Select style={{width: "100%"}}
+                    value={value?.interval || interval}
+                    onChange={onIntervalChange}>
+                {options.map(m =>
+                    <Select.Option key={m.key}>{m.title}</Select.Option>)}
             </Select>
-    </Space>
+        </Space>
     );
 };
 

--- a/src/views/ExpiresInInput.tsx
+++ b/src/views/ExpiresInInput.tsx
@@ -19,14 +19,12 @@ interface ExpiresInInputProps {
     options: SelectOption[];
 }
 
-
 export const secondsToExpiresIn = (expiresIn: number, availableOptions: string[]): ExpiresInValue => {
 
     if (expiresIn == 0) {
         return {interval: "day", number: 0}
     }
-    console.log((expiresIn % 86400 === 0))
-    console.log(availableOptions)
+
     let result = {interval: "hour", number: expiresIn / 3600}
     availableOptions.forEach(opt => {
         if (opt === "year" && (expiresIn % 31104000 === 0)) {

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -56,19 +56,19 @@ export const Settings = () => {
         form.setFieldsValue(fAccount)
     }, [accounts])
 
-    const createKey = 'saving';
+    const updatingSettings = 'updating_settings';
     useEffect(() => {
         if (updatedAccount.loading) {
-            message.loading({content: 'Saving...', key: createKey, duration: 0, style: styleNotification});
+            message.loading({content: 'Saving...', key: updatingSettings, duration: 0, style: styleNotification});
         } else if (updatedAccount.success) {
             message.success({
                 content: 'Account settings has been successfully saved.',
-                key: createKey,
+                key: updatingSettings,
                 duration: 2,
                 style: styleNotification
             });
-            // dispatch(accountActions.setUpdateAccount({...updatedAccount, success: false}));
-            //dispatch(accountActions.setUpdateAccount({}))
+            dispatch(accountActions.setUpdateAccount({...updatedAccount, success: false}));
+            dispatch(accountActions.resetUpdateAccount(null))
         } else if (updatedAccount.error) {
             let errorMsg = "Failed to update account settings"
             switch (updatedAccount.error.statusCode) {
@@ -81,7 +81,7 @@ export const Settings = () => {
             }
             message.error({
                 content: errorMsg,
-                key: createKey,
+                key: updatingSettings,
                 duration: 5,
                 style: styleNotification
             });
@@ -157,7 +157,6 @@ export const Settings = () => {
                                                     buttonStyle="solid"
                                                     onChange={function (e) {
                                                         setFormPeerExpirationEnabled(e.target.value)
-                                                        console.log(e.target.value)
                                                     }}
                                                 />
                                             </Form.Item>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -145,7 +145,7 @@ export const Settings = () => {
                                             <Form.Item
                                                 label="Peer login expiration"
                                                 name="peer_login_expiration_enabled"
-                                                tooltip=" "
+                                                tooltip="Enabled peer expirations allows to periodically request authentication of peers that were added with the SSO login."
                                                 //rules={[{validator: selectValidatorEmptyStrings}]}
                                             >
                                                 <Radio.Group
@@ -162,7 +162,7 @@ export const Settings = () => {
                                             </Form.Item>
                                             <Form.Item name="peer_login_expiration_formatted"
                                                        label="Peer login expires in"
-                                                       tooltip=" "
+                                                       tooltip="Time after which every peer added with SSO login will require re-authentication."
                                                        rules={[{validator: checkExpiresIn}]}>
                                                 <ExpiresInInput
                                                     disabled={!formPeerExpirationEnabled}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -4,8 +4,6 @@ import {RootState} from "typesafe-actions";
 import {Button, Card, Col, Form, message, Radio, Row, Space, Typography,} from "antd";
 import {useGetAccessTokenSilently} from "../utils/token";
 import {useGetGroupTagHelpers} from "../utils/groups";
-import {actions as dnsSettingsActions} from '../store/dns-settings';
-import {DNSSettings, DNSSettingsToSave} from "../store/dns-settings/types";
 import {Container} from "../components/Container";
 import UserUpdate from "../components/UserUpdate";
 import ExpiresInInput, {expiresInToSeconds, secondsToExpiresIn} from "./ExpiresInInput";
@@ -14,6 +12,8 @@ import {actions as accountActions} from "../store/account";
 import {Account, FormAccount} from "../store/account/types";
 
 const {Title, Paragraph} = Typography;
+
+const styleNotification = {marginTop: 85}
 
 export const Settings = () => {
     const {getAccessTokenSilently} = useGetAccessTokenSilently()
@@ -26,6 +26,7 @@ export const Settings = () => {
     const accounts = useSelector((state: RootState) => state.account.data);
     const failed = useSelector((state: RootState) => state.account.failed);
     const loading = useSelector((state: RootState) => state.account.loading);
+    const updatedAccount = useSelector((state: RootState) => state.account.updatedAccount);
     const users = useSelector((state: RootState) => state.user.data);
     const [formAccount, setFormAccount] = useState({} as FormAccount);
 
@@ -54,26 +55,26 @@ export const Settings = () => {
     }, [accounts])
 
     const createKey = 'saving';
-    /*useEffect(() => {
-        if (savedDNSSettings.loading) {
+    useEffect(() => {
+        if (updatedAccount.loading) {
             message.loading({content: 'Saving...', key: createKey, duration: 0, style: styleNotification});
-        } else if (savedDNSSettings.success) {
+        } else if (updatedAccount.success) {
             message.success({
-                content: 'DNS settings has been successfully saved.',
+                content: 'Account settings has been successfully saved.',
                 key: createKey,
                 duration: 2,
                 style: styleNotification
             });
-            dispatch(dnsSettingsActions.setSavedDNSSettings({...savedDNSSettings, success: false}));
-            dispatch(dnsSettingsActions.resetSavedDNSSettings(null))
-        } else if (savedDNSSettings.error) {
-            let errorMsg = "Failed to update DNS settings"
-            switch (savedDNSSettings.error.statusCode) {
+           // dispatch(accountActions.setUpdateAccount({...updatedAccount, success: false}));
+            //dispatch(accountActions.setUpdateAccount({}))
+        } else if (updatedAccount.error) {
+            let errorMsg = "Failed to update account settings"
+            switch (updatedAccount.error.statusCode) {
                 case 403:
-                    errorMsg = "Failed to update DNS settings. You might not have enough permissions."
+                    errorMsg = "Failed to update account settings. You might not have enough permissions."
                     break
                 default:
-                    errorMsg = savedDNSSettings.error.data.message ? savedDNSSettings.error.data.message : errorMsg
+                    errorMsg = updatedAccount.error.data.message ? updatedAccount.error.data.message : errorMsg
                     break
             }
             message.error({
@@ -82,23 +83,17 @@ export const Settings = () => {
                 duration: 5,
                 style: styleNotification
             });
-            dispatch(dnsSettingsActions.setSavedDNSSettings({...savedDNSSettings, error: null}));
-            dispatch(nsGroupActions.resetSavedNameServerGroup(null))
         }
-    }, [savedDNSSettings])*/
+    }, [updatedAccount])
 
     const handleFormSubmit = () => {
         form.validateFields()
             .then((values) => {
                 let accountToSave = createAccountToSave(values)
-                console.log(accountToSave)
                 dispatch(accountActions.updateAccount.request({
                     getAccessTokenSilently: getAccessTokenSilently,
                     payload: accountToSave
                 }))
-            })
-            .then(() => {
-                console.log("issued the request")
             })
             .catch((errorInfo) => {
                 let msg = "please check the fields and try again"

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -10,6 +10,7 @@ import ExpiresInInput, {expiresInToSeconds, secondsToExpiresIn} from "./ExpiresI
 import {checkExpiresIn} from "../utils/common";
 import {actions as accountActions} from "../store/account";
 import {Account, FormAccount} from "../store/account/types";
+import {values} from "lodash";
 
 const {Title, Paragraph} = Typography;
 
@@ -20,7 +21,6 @@ export const Settings = () => {
     const dispatch = useDispatch()
 
     const {
-        selectValidatorEmptyStrings
     } = useGetGroupTagHelpers()
 
     const accounts = useSelector((state: RootState) => state.account.data);
@@ -29,6 +29,7 @@ export const Settings = () => {
     const updatedAccount = useSelector((state: RootState) => state.account.updatedAccount);
     const users = useSelector((state: RootState) => state.user.data);
     const [formAccount, setFormAccount] = useState({} as FormAccount);
+    const [formPeerExpirationEnabled, setFormPeerExpirationEnabled] = useState(true);
 
 
     const [form] = Form.useForm()
@@ -51,6 +52,7 @@ export const Settings = () => {
             peer_login_expiration_enabled: account.settings.peer_login_expiration_enabled
         } as FormAccount
         setFormAccount(fAccount)
+        setFormPeerExpirationEnabled(fAccount.peer_login_expiration_enabled)
         form.setFieldsValue(fAccount)
     }, [accounts])
 
@@ -65,7 +67,7 @@ export const Settings = () => {
                 duration: 2,
                 style: styleNotification
             });
-           // dispatch(accountActions.setUpdateAccount({...updatedAccount, success: false}));
+            // dispatch(accountActions.setUpdateAccount({...updatedAccount, success: false}));
             //dispatch(accountActions.setUpdateAccount({}))
         } else if (updatedAccount.error) {
             let errorMsg = "Failed to update account settings"
@@ -153,16 +155,23 @@ export const Settings = () => {
                                                     }]}
                                                     optionType="button"
                                                     buttonStyle="solid"
+                                                    onChange={function (e) {
+                                                        setFormPeerExpirationEnabled(e.target.value)
+                                                        console.log(e.target.value)
+                                                    }}
                                                 />
                                             </Form.Item>
-                                            <Form.Item name="peer_login_expiration_formatted" label="Peer login expires in"
+                                            <Form.Item name="peer_login_expiration_formatted"
+                                                       label="Peer login expires in"
                                                        tooltip=" "
                                                        rules={[{validator: checkExpiresIn}]}>
-                                                <ExpiresInInput options={
-                                                    Array.of(
-                                                        {key: "hour", title: "Hours"},
-                                                        {key: "day", title: "Days"})
-                                                }/>
+                                                <ExpiresInInput
+                                                    disabled={!formPeerExpirationEnabled}
+                                                    options={Array.of({key: "hour", title: "Hours"}, {
+                                                        key: "day",
+                                                        title: "Days"
+                                                    })
+                                                    }/>
                                             </Form.Item>
                                         </Card>
                                         <Form.Item style={{textAlign: 'center'}}>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -145,7 +145,7 @@ export const Settings = () => {
                                             <Form.Item
                                                 label="Peer login expiration"
                                                 name="peer_login_expiration_enabled"
-                                                tooltip="Enabled peer expirations allows to periodically request authentication of peers that were added with the SSO login."
+                                                tooltip="Peer login expiration allows to periodically request re-authentication of peers that were added with the SSO login. You can disable the expiration per peer in the peers tab."
                                                 //rules={[{validator: selectValidatorEmptyStrings}]}
                                             >
                                                 <Radio.Group

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,0 +1,185 @@
+import React, {useEffect} from 'react';
+import {useDispatch, useSelector} from "react-redux";
+import {RootState} from "typesafe-actions";
+import {Button, Card, Col, Form, message, Radio, Row, Space, Typography,} from "antd";
+import {useGetAccessTokenSilently} from "../utils/token";
+import {useGetGroupTagHelpers} from "../utils/groups";
+import {actions as dnsSettingsActions} from '../store/dns-settings';
+import {DNSSettings, DNSSettingsToSave} from "../store/dns-settings/types";
+import {actions as nsGroupActions} from "../store/nameservers";
+import {Container} from "../components/Container";
+import UserUpdate from "../components/UserUpdate";
+import ExpiresInInput from "./ExpiresInInput";
+import {checkExpiresIn} from "../utils/common";
+
+const {Title, Paragraph} = Typography;
+const styleNotification = {marginTop: 85}
+
+export const Settings = () => {
+    const {getAccessTokenSilently} = useGetAccessTokenSilently()
+    const dispatch = useDispatch()
+
+    const {
+        getExistingAndToCreateGroupsLists,
+        getGroupNamesFromIDs,
+        selectValidatorEmptyStrings
+    } = useGetGroupTagHelpers()
+
+    const dnsSettings = useSelector((state: RootState) => state.dnsSettings.dnsSettings)
+    const dnsSettingsData = useSelector((state: RootState) => state.dnsSettings.data)
+    const savedDNSSettings = useSelector((state: RootState) => state.dnsSettings.savedDNSSettings)
+    const loading = useSelector((state: RootState) => state.dnsSettings.loading);
+
+
+    const [form] = Form.useForm()
+
+    useEffect(() => {
+        dispatch(dnsSettingsActions.getDNSSettings.request({
+            getAccessTokenSilently: getAccessTokenSilently,
+            payload: null
+        }));
+    }, []);
+
+    useEffect(() => {
+        if (!dnsSettingsData) return
+        dispatch(dnsSettingsActions.setDNSSettings({
+            disabled_management_groups: getGroupNamesFromIDs(dnsSettingsData.disabled_management_groups),
+        }))
+    }, [dnsSettingsData])
+
+    useEffect(() => {
+        form.setFieldsValue(dnsSettings)
+    }, [dnsSettings])
+
+    const createKey = 'saving';
+    useEffect(() => {
+        if (savedDNSSettings.loading) {
+            message.loading({content: 'Saving...', key: createKey, duration: 0, style: styleNotification});
+        } else if (savedDNSSettings.success) {
+            message.success({
+                content: 'DNS settings has been successfully saved.',
+                key: createKey,
+                duration: 2,
+                style: styleNotification
+            });
+            dispatch(dnsSettingsActions.setSavedDNSSettings({...savedDNSSettings, success: false}));
+            dispatch(dnsSettingsActions.resetSavedDNSSettings(null))
+        } else if (savedDNSSettings.error) {
+            let errorMsg = "Failed to update DNS settings"
+            switch (savedDNSSettings.error.statusCode) {
+                case 403:
+                    errorMsg = "Failed to update DNS settings. You might not have enough permissions."
+                    break
+                default:
+                    errorMsg = savedDNSSettings.error.data.message ? savedDNSSettings.error.data.message : errorMsg
+                    break
+            }
+            message.error({
+                content: errorMsg,
+                key: createKey,
+                duration: 5,
+                style: styleNotification
+            });
+            dispatch(dnsSettingsActions.setSavedDNSSettings({...savedDNSSettings, error: null}));
+            dispatch(nsGroupActions.resetSavedNameServerGroup(null))
+        }
+    }, [savedDNSSettings])
+
+    const handleFormSubmit = () => {
+        form.validateFields()
+            .then((values) => {
+                let dnsSettingsToSave = createDNSSettingsToSave(values)
+                dispatch(dnsSettingsActions.saveDNSSettings.request({
+                    getAccessTokenSilently: getAccessTokenSilently,
+                    payload: dnsSettingsToSave
+                }))
+            })
+            .then(() => {
+                console.log("issued the request")
+            })
+            .catch((errorInfo) => {
+                let msg = "please check the fields and try again"
+                if (errorInfo.errorFields) {
+                    msg = errorInfo.errorFields[0].errors[0]
+                }
+                message.error({
+                    content: msg,
+                    duration: 1,
+                });
+            });
+    }
+
+    const createDNSSettingsToSave = (values: DNSSettings): DNSSettingsToSave => {
+        let [existingGroups, newGroups] = getExistingAndToCreateGroupsLists(values.disabled_management_groups)
+        return {
+            disabled_management_groups: existingGroups,
+            groupsToCreate: newGroups
+        } as DNSSettingsToSave
+    }
+
+    return (
+        <>
+            <Container style={{paddingTop: "40px"}}>
+                <Row>
+                    <Col span={24}>
+                        <Title level={4}>Settings</Title>
+                        <Paragraph>Manage your account's settings</Paragraph>
+                        <Space direction="vertical" size="large" style={{display: 'flex'}}>
+
+                            <Card bodyStyle={{padding: 0}}>
+                                <Form
+                                    name="basic"
+                                    autoComplete="off"
+                                    form={form}
+                                    onFinish={handleFormSubmit}
+                                >
+                                    <Space direction={"vertical"}
+                                           style={{display: 'flex'}}>
+                                        <Card
+                                            title="Authentication"
+                                            loading={loading}
+                                            defaultValue={"Enabled"}
+                                        >
+                                            <Form.Item
+                                                label="Peer login expiration"
+                                                name="login_expiration_enabled"
+                                                tooltip=" "
+                                                rules={[{validator: selectValidatorEmptyStrings}]}
+                                            >
+                                                <Radio.Group
+                                                    options={[{label: 'Enabled', value: true}, {
+                                                        label: 'Disabled',
+                                                        value: false
+                                                    }]}
+                                                    optionType="button"
+                                                    buttonStyle="solid"
+                                                />
+                                            </Form.Item>
+                                            <Form.Item name="expiresInFormatted" label="Peer login expires in"
+                                                       tooltip=" "
+                                                       rules={[{validator: checkExpiresIn}]}>
+                                                <ExpiresInInput options={
+                                                    Array.of(
+                                                        {key: "hour", title: "Hours"},
+                                                        {key: "day", title: "Days"})
+                                                }/>
+                                            </Form.Item>
+                                        </Card>
+                                        <Form.Item style={{textAlign: 'center'}}>
+                                            <Button type="primary" htmlType="submit">
+                                                Save
+                                            </Button>
+                                        </Form.Item>
+                                    </Space>
+                                </Form>
+                            </Card>
+                        </Space>
+                    </Col>
+                </Row>
+            </Container>
+            <UserUpdate/>
+        </>
+    )
+}
+
+export default Settings;

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -62,7 +62,7 @@ export const Settings = () => {
             message.loading({content: 'Saving...', key: updatingSettings, duration: 0, style: styleNotification});
         } else if (updatedAccount.success) {
             message.success({
-                content: 'Account settings has been successfully saved.',
+                content: 'Account settings have been successfully saved.',
                 key: updatingSettings,
                 duration: 2,
                 style: styleNotification


### PR DESCRIPTION
New Settings tab added to the dashboard.
It is possible to enable or disable peer login expiration globally for an account.
As well as defining the expiration time period.

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/700848/219969365-0886794e-72d1-41cc-886c-d7464b188d2f.gif)
