### PR TITLE
Make table headers font-weight normal

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -140,3 +140,7 @@ body {
 .ant-steps-item-tail {
   border: none;
 }
+
+.ant-table-thead .ant-table-cell {
+  font-weight: normal !important;
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/700848/227954122-064426b5-a6d5-45ec-81bd-1aa0e4833e43.png)

After:
![image](https://user-images.githubusercontent.com/700848/227953957-3f5140cb-66f1-49fd-881a-978ec0799651.png)
