### PR TITLE
Fix Routes view when updating routes

### DIFF
--- a/src/components/RouteUpdate.tsx
+++ b/src/components/RouteUpdate.tsx
@@ -123,7 +123,7 @@ const RouteUpdate = () => {
     peers.forEach((p) => {
         let os: string
         os = p.os
-        if (!os.toLowerCase().startsWith("darwin") && !os.toLowerCase().startsWith("windows")) {
+        if (!os.toLowerCase().startsWith("darwin") && !os.toLowerCase().startsWith("windows") && route && !routes.filter(r => r.network_id === route.network_id).find(r => r.peer === p.id)) {
             options?.push({
                 label: peerToPeerIP(p.name, p.ip),
                 value: peerToPeerIP(p.name, p.ip),
@@ -135,10 +135,14 @@ const RouteUpdate = () => {
     const createRouteToSave = (inputRoute: FormRoute): RouteToSave => {
         let peerIDList = inputRoute.peer.split(routePeerSeparator)
         let peerID: string
-        if (peerIDList[1]) {
-            peerID = peerIPToID[peerIDList[1]]
+        if (peerIDList.length === 1) {
+            peerID = inputRoute.peer
         } else {
-            peerID = peerIPToID[peerNameToIP[inputRoute.peer]]
+            if (peerIDList[1]) {
+                peerID = peerIPToID[peerIDList[1]]
+            } else {
+                peerID = peerIPToID[peerNameToIP[inputRoute.peer]]
+            }
         }
 
         let [ existingGroups, groupsToCreate ] = getExistingAndToCreateGroupsLists(inputRoute.groups)

--- a/src/components/RouteUpdate.tsx
+++ b/src/components/RouteUpdate.tsx
@@ -123,7 +123,8 @@ const RouteUpdate = () => {
     peers.forEach((p) => {
         let os: string
         os = p.os
-        if (!os.toLowerCase().startsWith("darwin") && !os.toLowerCase().startsWith("windows") && route && !routes.filter(r => r.network_id === route.network_id).find(r => r.peer === p.id)) {
+        if (!os.toLowerCase().startsWith("darwin") && !os.toLowerCase().startsWith("windows") && !os.toLowerCase().startsWith("android")
+            && route && !routes.filter(r => r.network_id === route.network_id).find(r => r.peer === p.id)) {
             options?.push({
                 label: peerToPeerIP(p.name, p.ip),
                 value: peerToPeerIP(p.name, p.ip),

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -284,7 +284,6 @@ export const Routes = () => {
             content = masqueradeEnabledMSG
         }
 
-        console.log("Asking")
         confirm({
             icon: <ExclamationCircleOutlined/>,
             title: tittle,

--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -284,6 +284,7 @@ export const Routes = () => {
             content = masqueradeEnabledMSG
         }
 
+        console.log("Asking")
         confirm({
             icon: <ExclamationCircleOutlined/>,
             title: tittle,
@@ -310,7 +311,7 @@ export const Routes = () => {
         routeGroup.groupedRoutes.forEach((record) => {
             const route = {
                 ...record,
-                peer: peerNameToIP[record.peer],
+                peer: record.peer,
                 masquerade: checked,
                 groupsToCreate: []
             } as RouteToSave


### PR DESCRIPTION
Fixed issues when updating routes that the existing routing peers get messed up.
Additionally fixed routing peer dropdown to filter already assigned routing peers.