### PR TITLE
Fix displaying groups on route peer update

### DIFF
--- a/src/views/Routes.tsx
+++ b/src/views/Routes.tsx
@@ -243,17 +243,18 @@ export const Routes = () => {
 
     const onClickViewRoute = () => {
         dispatch(routeActions.setSetupNewRouteHA(false));
-        dispatch(routeActions.setSetupNewRouteVisible(true));
         dispatch(routeActions.setRoute({
             id: routeToAction?.id || null,
             network: routeToAction?.network,
             network_id: routeToAction?.network_id,
             description: routeToAction?.description,
-            peer: peerToPeerIP(routeToAction!.peer, peerNameToIP[routeToAction!.peer]),
+            peer: peerToPeerIP(routeToAction!.peer_name, routeToAction!.peer_ip),
             metric: routeToAction?.metric,
             masquerade: routeToAction?.masquerade,
-            enabled: routeToAction?.enabled
+            enabled: routeToAction?.enabled,
+            groups: routeToAction?.groups
         } as Route))
+        dispatch(routeActions.setSetupNewRouteVisible(true));
     }
 
     const setRouteAndView = (route: RouteDataTable) => {


### PR DESCRIPTION
When clicking view in the dropdown menu of route peer update the name was showing wrong data and the groups where empty. FIxed that.