### PR TITLE
Fix to many requestes on user edit

### DIFF
--- a/src/components/UserEdit.tsx
+++ b/src/components/UserEdit.tsx
@@ -102,18 +102,6 @@ const UserEdit = () => {
                 dispatch(userActions.setEditUserPopupVisible(false));
                 dispatch(userActions.setUser(null as unknown as User))
                 dispatch(personalAccessTokenActions.resetPersonalAccessTokens(null))
-                dispatch(groupActions.getGroups.request({
-                    getAccessTokenSilently: getTokenSilently,
-                    payload: null
-                }));
-                dispatch(userActions.getServiceUsers.request({
-                    getAccessTokenSilently: getTokenSilently,
-                    payload: null
-                }))
-                dispatch(userActions.getUsers.request({
-                    getAccessTokenSilently: getTokenSilently,
-                    payload: null
-                }))
             })
             .catch((errorInfo) => {
                 console.log('errorInfo', errorInfo)

--- a/src/store/user/sagas.ts
+++ b/src/store/user/sagas.ts
@@ -99,15 +99,6 @@ export function* saveUser(action: ReturnType<typeof actions.saveUser.request>): 
             error: null,
             data: response.body
         } as CreateResponse<User | null>));
-
-        yield put(groupActions.getGroups.request({
-            getAccessTokenSilently: action.payload.getAccessTokenSilently,
-            payload: null
-        }));
-        yield put(actions.getUsers.request({
-            getAccessTokenSilently: action.payload.getAccessTokenSilently,
-            payload: null
-        }));
     } catch (err) {
         yield put(actions.saveUser.failure({
             loading: false,


### PR DESCRIPTION
we had up to 11 requests on user edit due to reload. Reduced to the minimum possible