### PR TITLE
Fix user view reload on breadcrumbs

### DIFF
--- a/src/components/UserEdit.tsx
+++ b/src/components/UserEdit.tsx
@@ -279,24 +279,6 @@ const UserEdit = () => {
         }
     }, [form, user, currentGroups])
 
-    const menuItems = [
-        {
-            key: '1',
-            label: (
-                <Text onClick={() => onBreadcrumbUsersClick("Users")}>
-                    Users
-                </Text>
-            ),
-        },
-        {
-            key: '2',
-            label: (
-                <Text onClick={() => onBreadcrumbUsersClick("Service Users")}>
-                    Service Users
-                </Text>
-            ),
-        },
-    ];
 
     const isUserAdmin = (userId: string): boolean => {
         return users.find(u => u.id === userId)?.role === "admin"
@@ -308,10 +290,10 @@ const UserEdit = () => {
                 <Breadcrumb style={{marginBottom: "30px"}}
                             items={[
                                 {
-                                    title: <a href = "" onClick={() => onBreadcrumbUsersClick("Users")}>All Users</a>,
+                                    title: <a onClick={() => onBreadcrumbUsersClick("Users")}>All Users</a>,
                                 },
                                 {
-                                    title: <a href= "" onClick={() => onBreadcrumbUsersClick(tab)}>{tab}</a>,
+                                    title: <a onClick={() => onBreadcrumbUsersClick(tab)}>{tab}</a>,
                                     // menu: { items: menuItems },
                                 },
                                 {


### PR DESCRIPTION
When we click on any of the breadcrumbs the whole user page reloads which is anoying for the user because he has to wait for oauth to authenticate again.Fixed it to not reload page!