### PR TITLE
Add pkg installer to MacOS Popup

### DIFF
--- a/src/components/popups/addpeer/addpeer/AddPeerPopup.tsx
+++ b/src/components/popups/addpeer/addpeer/AddPeerPopup.tsx
@@ -49,7 +49,7 @@ export const AddPeerPopup: React.FC<Props> = ({
         },
         {
             key: "3",
-            label: <span><AppleFilled/>macOS</span>,
+            label: <span><AppleFilled/>MacOS</span>,
             children: <MacTab/>,
         },
         {

--- a/src/components/popups/addpeer/addpeer/MacTab.tsx
+++ b/src/components/popups/addpeer/addpeer/MacTab.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 
-import {Button, Row, Tooltip, Typography} from "antd";
+import {Button, Divider, Row, Tooltip, Typography} from "antd";
 import TabSteps from "./TabSteps";
 import {StepCommand} from "./types"
 import {formatNetBirdUP} from "./common"
@@ -100,8 +100,9 @@ export const LinuxTab = () => {
             <div style={{marginTop: 5}}>
                 <TabSteps stepsItems={quickSteps}/>
             </div>
-            <Collapse bordered={false} defaultActiveKey={['1']}>
-                <Panel header={
+            <Divider></Divider>
+            <Collapse bordered={false} style={{backgroundColor: "unset"}}>
+                <Panel className="CustomPopupCollapse"  header={
                     <b>Or install via command line</b>
                 } key="1">
                     <Text style={{fontWeight: "bold"}}>
@@ -120,39 +121,7 @@ export const LinuxTab = () => {
                     </div>
                 </Panel>
             </Collapse>
-            {/*<Text style={{fontWeight: "bold"}}>*/}
-            {/*    Install using installer pkg*/}
-            {/*</Text>*/}
-            {/*<Row style={{paddingTop: "5px", paddingBottom: "20px"}}>*/}
-            {/*    <Button style={{marginRight: "10px"}} type="primary" href="https://pkgs.netbird.io/macos/amd64">Download for Intel</Button>*/}
-            {/*    <Button style={{marginRight: "10px"}} type="default" href="https://pkgs.netbird.io/macos/arm64">Download for M1 & M2</Button>*/}
-            {/*</Row>*/}
-            {/*<Text style={{fontWeight: "bold"}}>*/}
-            {/*    Install with one command*/}
-            {/*</Text>*/}
-            {/*<div style={{fontSize: ".85em", marginTop: 5, marginBottom: 25}}>*/}
-            {/*    <SyntaxHighlighter language="bash">*/}
-            {/*        curl -fsSL https://pkgs.netbird.io/install.sh | sh*/}
-            {/*    </SyntaxHighlighter>*/}
-            {/*</div>*/}
-            {/*<Text style={{fontWeight: "bold"}}>*/}
-            {/*    Or install manually with HomeBrew*/}
-            {/*</Text>*/}
-            {/*<div style={{marginTop: 5}}>*/}
-            {/*    <TabSteps stepsItems={steps}/>*/}
-            {/*</div>*/}
         </div>
-    /*<div style={{marginTop: 5}}>
-                <TabSteps stepsItems={quickSteps}/>
-            </div>*/
-        /*<div style={{marginTop: 10}}>
-            <Text style={{fontWeight: "bold"}}>
-                Install on macOS with Homebrew
-            </Text>
-            <div style={{marginTop: 5}}>
-                <TabSteps stepsItems={steps}/>
-            </div>
-        </div>*/
     )
 }
 

--- a/src/components/popups/addpeer/addpeer/MacTab.tsx
+++ b/src/components/popups/addpeer/addpeer/MacTab.tsx
@@ -100,7 +100,7 @@ export const LinuxTab = () => {
             <div style={{marginTop: 5}}>
                 <TabSteps stepsItems={quickSteps}/>
             </div>
-            <Divider></Divider>
+            <Divider style={{marginTop: "5px"}} />
             <Collapse bordered={false} style={{backgroundColor: "unset"}}>
                 <Panel className="CustomPopupCollapse"  header={
                     <b>Or install via command line</b>

--- a/src/components/popups/addpeer/addpeer/MacTab.tsx
+++ b/src/components/popups/addpeer/addpeer/MacTab.tsx
@@ -1,11 +1,12 @@
 import React, {useState} from 'react';
 
-import {Button, Typography} from "antd";
+import {Button, Row, Tooltip, Typography} from "antd";
 import TabSteps from "./TabSteps";
 import {StepCommand} from "./types"
 import {formatNetBirdUP} from "./common"
 import {Collapse} from "antd";
 import SyntaxHighlighter from "react-syntax-highlighter";
+import {QuestionCircleOutlined} from "@ant-design/icons";
 const { Panel } = Collapse;
 
 const {Text} = Typography;
@@ -15,10 +16,23 @@ export const LinuxTab = () => {
     const [quickSteps, setQuickSteps] = useState([
         {
             key: 1,
-            title: 'Download and run installer:',
+            title: (
+                <Row>
+                    <Text>Download and run MacOS installer: </Text>
+                    <Tooltip title={
+                        <text>If you don't know what chip your Mac has, you can find out by clicking on the Apple logo in the top left corner of your screen and selecting 'About This Mac'. For more information click <a href="https://support.apple.com/en-us/HT211814" target="_blank">here</a></text>
+                    }
+                             className={"ant-form-item-tooltip"}>
+                        <QuestionCircleOutlined style={{color: "rgba(0, 0, 0, 0.45)", cursor: "help", marginLeft: "3px"}}/>
+                    </Tooltip>
+                </Row>
+
+            ),
             commands: (
-                <Button style={{marginTop: "5px"}} type="primary" href="https://pkgs.netbird.io/windows/x64"
-                        target="_blank">Download NetBird</Button>
+                <Row style={{paddingTop: "5px"}}>
+                    <Button style={{marginRight: "10px"}} type="primary" href="https://pkgs.netbird.io/macos/amd64">Download for Intel</Button>
+                    <Button style={{marginRight: "10px"}} type="default" href="https://pkgs.netbird.io/macos/arm64">Download for M1 & M2</Button>
+                </Row>
             ),
             copied: false
         } as StepCommand,
@@ -78,23 +92,55 @@ export const LinuxTab = () => {
             showCopyButton: true
         } as StepCommand
     ])
-
     return (
         <div style={{marginTop: 10}}>
             <Text style={{fontWeight: "bold"}}>
-                Install with one command
-            </Text>
-            <div style={{fontSize: ".85em", marginTop: 5, marginBottom: 25}}>
-                <SyntaxHighlighter language="bash">
-                    curl -fsSL https://pkgs.netbird.io/install.sh | sh
-                </SyntaxHighlighter>
-            </div>
-            <Text style={{fontWeight: "bold"}}>
-                Or install manually with HomeBrew
+                Install on MacOS
             </Text>
             <div style={{marginTop: 5}}>
-                <TabSteps stepsItems={steps}/>
+                <TabSteps stepsItems={quickSteps}/>
             </div>
+            <Collapse bordered={false} defaultActiveKey={['1']}>
+                <Panel header={
+                    <b>Or install via command line</b>
+                } key="1">
+                    <Text style={{fontWeight: "bold"}}>
+                        Install with one command
+                    </Text>
+                    <div style={{fontSize: ".85em", marginTop: 5, marginBottom: 25}}>
+                        <SyntaxHighlighter language="bash">
+                            curl -fsSL https://pkgs.netbird.io/install.sh | sh
+                        </SyntaxHighlighter>
+                    </div>
+                    <Text style={{fontWeight: "bold"}}>
+                        Or install manually with HomeBrew
+                    </Text>
+                    <div style={{marginTop: 5}}>
+                        <TabSteps stepsItems={steps}/>
+                    </div>
+                </Panel>
+            </Collapse>
+            {/*<Text style={{fontWeight: "bold"}}>*/}
+            {/*    Install using installer pkg*/}
+            {/*</Text>*/}
+            {/*<Row style={{paddingTop: "5px", paddingBottom: "20px"}}>*/}
+            {/*    <Button style={{marginRight: "10px"}} type="primary" href="https://pkgs.netbird.io/macos/amd64">Download for Intel</Button>*/}
+            {/*    <Button style={{marginRight: "10px"}} type="default" href="https://pkgs.netbird.io/macos/arm64">Download for M1 & M2</Button>*/}
+            {/*</Row>*/}
+            {/*<Text style={{fontWeight: "bold"}}>*/}
+            {/*    Install with one command*/}
+            {/*</Text>*/}
+            {/*<div style={{fontSize: ".85em", marginTop: 5, marginBottom: 25}}>*/}
+            {/*    <SyntaxHighlighter language="bash">*/}
+            {/*        curl -fsSL https://pkgs.netbird.io/install.sh | sh*/}
+            {/*    </SyntaxHighlighter>*/}
+            {/*</div>*/}
+            {/*<Text style={{fontWeight: "bold"}}>*/}
+            {/*    Or install manually with HomeBrew*/}
+            {/*</Text>*/}
+            {/*<div style={{marginTop: 5}}>*/}
+            {/*    <TabSteps stepsItems={steps}/>*/}
+            {/*</div>*/}
         </div>
     /*<div style={{marginTop: 5}}>
                 <TabSteps stepsItems={quickSteps}/>

--- a/src/components/popups/addpeer/addpeer/MacTab.tsx
+++ b/src/components/popups/addpeer/addpeer/MacTab.tsx
@@ -7,7 +7,8 @@ import {formatNetBirdUP} from "./common"
 import {Collapse} from "antd";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import {QuestionCircleOutlined} from "@ant-design/icons";
-const { Panel } = Collapse;
+
+const {Panel} = Collapse;
 
 const {Text} = Typography;
 
@@ -20,18 +21,23 @@ export const LinuxTab = () => {
                 <Row>
                     <Text>Download and run MacOS installer: </Text>
                     <Tooltip title={
-                        <text>If you don't know what chip your Mac has, you can find out by clicking on the Apple logo in the top left corner of your screen and selecting 'About This Mac'. For more information click <a href="https://support.apple.com/en-us/HT211814" target="_blank">here</a></text>
+                        <text>If you don't know what chip your Mac has, you can find out by clicking on the Apple logo
+                            in the top left corner of your screen and selecting 'About This Mac'. For more information
+                            click <a href="https://support.apple.com/en-us/HT211814" target="_blank">here</a></text>
                     }
                              className={"ant-form-item-tooltip"}>
-                        <QuestionCircleOutlined style={{color: "rgba(0, 0, 0, 0.45)", cursor: "help", marginLeft: "3px"}}/>
+                        <QuestionCircleOutlined
+                            style={{color: "rgba(0, 0, 0, 0.45)", cursor: "help", marginLeft: "3px"}}/>
                     </Tooltip>
                 </Row>
 
             ),
             commands: (
                 <Row style={{paddingTop: "5px"}}>
-                    <Button style={{marginRight: "10px"}} type="primary" href="https://pkgs.netbird.io/macos/amd64">Download for Intel</Button>
-                    <Button style={{marginRight: "10px"}} type="default" href="https://pkgs.netbird.io/macos/arm64">Download for M1 & M2</Button>
+                    <Button style={{marginRight: "10px"}} type="primary" href="https://pkgs.netbird.io/macos/amd64">Download
+                        for Intel</Button>
+                    <Button style={{marginRight: "10px"}} type="default" href="https://pkgs.netbird.io/macos/arm64">Download
+                        for M1 & M2</Button>
                 </Row>
             ),
             copied: false
@@ -97,27 +103,29 @@ export const LinuxTab = () => {
             <Text style={{fontWeight: "bold"}}>
                 Install on MacOS
             </Text>
-            <div style={{marginTop: 5}}>
+            <div style={{marginTop: 5, marginBottom: 5}}>
                 <TabSteps stepsItems={quickSteps}/>
             </div>
-            <Divider style={{marginTop: "5px"}} />
+            <div style={{marginTop: 0}}/>
+            {/*<Divider style={{marginTop: "5px"}} />*/}
             <Collapse bordered={false} style={{backgroundColor: "unset"}}>
-                <Panel className="CustomPopupCollapse"  header={
-                    <b>Or install via command line</b>
-                } key="1">
-                    <Text style={{fontWeight: "bold"}}>
-                        Install with one command
-                    </Text>
-                    <div style={{fontSize: ".85em", marginTop: 5, marginBottom: 25}}>
-                        <SyntaxHighlighter language="bash">
-                            curl -fsSL https://pkgs.netbird.io/install.sh | sh
-                        </SyntaxHighlighter>
-                    </div>
-                    <Text style={{fontWeight: "bold"}}>
-                        Or install manually with HomeBrew
-                    </Text>
-                    <div style={{marginTop: 5}}>
-                        <TabSteps stepsItems={steps}/>
+                <Panel className="CustomPopupCollapse" header={<Text strong={true}>Or install via command line</Text>}
+                       key="1">
+                    <div style={{marginLeft: "25px"}}>
+                        <Text style={{fontWeight: "bold"}}>
+                            Install with one command
+                        </Text>
+                        <div style={{fontSize: ".85em", marginTop: 5, marginBottom: 25}}>
+                            <SyntaxHighlighter language="bash">
+                                curl -fsSL https://pkgs.netbird.io/install.sh | sh
+                            </SyntaxHighlighter>
+                        </div>
+                        <Text style={{fontWeight: "bold"}}>
+                            Or install manually with HomeBrew
+                        </Text>
+                        <div style={{marginTop: 5}}>
+                            <TabSteps stepsItems={steps}/>
+                        </div>
                     </div>
                 </Panel>
             </Collapse>

--- a/src/index.css
+++ b/src/index.css
@@ -152,3 +152,8 @@ td.non-highlighted-table-column {
 .ant-table-thead .ant-table-cell {
   font-weight: normal !important;
 }
+
+.CustomPopupCollapse .ant-collapse-content-box, .CustomPopupCollapse .ant-collapse-header {
+  padding-left: 0 !important;
+  padding-top: 0 !important;
+}


### PR DESCRIPTION
Updating the popup for adding a peer on MacOS to recommend pkg installer primarily and move commandline istall as secondary.

Before: 
<img width="837" alt="Screenshot 2023-05-30 at 16 35 01" src="https://github.com/netbirdio/dashboard/assets/32096965/9b4a3830-c6d8-4112-9410-727bb6d3e097">

After:
<img width="1002" alt="Screenshot 2023-05-30 at 15 30 58" src="https://github.com/netbirdio/dashboard/assets/32096965/eacc622b-5584-4409-b17d-9e82384e698f">
