### PR TITLE
Fix false error message on group enter

### DIFF
--- a/src/components/popups/AddPATPopup.tsx
+++ b/src/components/popups/AddPATPopup.tsx
@@ -98,22 +98,6 @@ const AddPATPopup = () => {
         }
     }, [savedPersonalAccessToken])
 
-    useEffect(() => {
-        const keyDownHandler = (event: any) => {
-            console.log('User pressed: ', event.key);
-
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                handleFormSubmit();
-            }
-        };
-
-        document.addEventListener('keydown', keyDownHandler);
-
-        return () => {
-            document.removeEventListener('keydown', keyDownHandler);
-        };
-    }, []);
 
     return (
         <>


### PR DESCRIPTION
We were showing a false error message "PAT creation failed" if you enter a group and confirm by pressing enter.