### PR TITLE
Fix isAdmin check to not depend on oidc

### DIFF
--- a/src/components/UserEdit.tsx
+++ b/src/components/UserEdit.tsx
@@ -258,11 +258,6 @@ const UserEdit = () => {
         }
     }, [form, user, currentGroups])
 
-
-    const isUserAdmin = (userId: string): boolean => {
-        return users.find(u => u.id === userId)?.role === "admin"
-    }
-
     return (
       <>
         <div style={{ paddingTop: "13px" }}>
@@ -371,7 +366,7 @@ const UserEdit = () => {
                           placeholder="Associate groups with the user"
                           tagRender={blueTagRender}
                           dropdownRender={dropDownRender}
-                          disabled={oidcUser && !isUserAdmin(oidcUser.sub)}
+                          disabled={!isAdmin}
                         >
                           {tagGroups.map((m) => (
                             <Option key={m}>{optionRender(m)}</Option>

--- a/src/views/Peers.tsx
+++ b/src/views/Peers.tsx
@@ -74,6 +74,7 @@ export const Peers = () => {
   const users = useSelector((state: RootState) => state.user.data);
   const [addPeerModalOpen, setAddPeerModalOpen] = useState(false);
   const { oidcUser } = useOidcUser();
+  const [isAdmin, setIsAdmin] = useState(false);
 
   const [textToSearch, setTextToSearch] = useState("");
   const [optionOnOff, setOptionOnOff] = useState("all");
@@ -130,9 +131,14 @@ export const Peers = () => {
     });
   };
 
-  const isUserAdmin = (userId: string): boolean => {
-    return users.find((u) => u.id === userId)?.role === "admin";
-  };
+  useEffect(() => {
+    if(users) {
+      let currentUser = users.find((user) => user.is_current)
+      if(currentUser) {
+        setIsAdmin(currentUser.role === "admin");
+      }
+    }
+  }, [users])
 
   const refresh = () => {
     dispatch(
@@ -153,7 +159,7 @@ export const Peers = () => {
         payload: null,
       })
     );
-    if (oidcUser && isUserAdmin(oidcUser.sub))
+    if (isAdmin)
       dispatch(
         routeActions.getRoutes.request({
           getAccessTokenSilently: getTokenSilently,


### PR DESCRIPTION
A user reported an issue with the UI that the autogroups filed on the user view was disabled even tho he is admin. The autogroups box used old isAdmin check depending on oidc (which should still work fine on fully configured IdP, but this way we will be more resillient). Replace this and on peers view to not depend on oidc.