### PR TITLE
Extend gitignore to ignore multiple config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,6 @@ yarn-error.log*
 src/auth_config.json
 .idea
 .eslintcache
-src/.local-config.json
+src/.local-config*.json
 /public/OidcServiceWorker.js
 /public/OidcTrustedDomains.js


### PR DESCRIPTION
For multiple IdPs I have a config each to simply switch for testing that should not be uploaded by accident.