### PR TITLE
Fix default value for expiration for setup keys

### DIFF
--- a/src/components/SetupKeyNew.tsx
+++ b/src/components/SetupKeyNew.tsx
@@ -104,6 +104,7 @@ const SetupKeyNew = () => {
     const groupsToCreate = formSetupKey.autoGroupNames.filter(
       (s) => !allGroupsNames.includes(s)
     );
+
     const expiresIn = formSetupKey.expires_in * 24 * 3600 // the api expects seconds we have days
     return {
       id: formSetupKey.id,

--- a/src/components/SetupKeyNew.tsx
+++ b/src/components/SetupKeyNew.tsx
@@ -104,7 +104,6 @@ const SetupKeyNew = () => {
     const groupsToCreate = formSetupKey.autoGroupNames.filter(
       (s) => !allGroupsNames.includes(s)
     );
-
     const expiresIn = formSetupKey.expires_in * 24 * 3600 // the api expects seconds we have days
     return {
       id: formSetupKey.id,
@@ -371,7 +370,6 @@ const SetupKeyNew = () => {
             form={form}
             onValuesChange={onChange}
             initialValues={{
-              expires_in: 7,
               usage_limit: 1,
             }}
           >

--- a/src/views/SetupKeys.tsx
+++ b/src/views/SetupKeys.tsx
@@ -252,6 +252,7 @@ export const SetupKeys = () => {
         name: "",
         type: "one-off",
         auto_groups: autoGroups,
+        expires_in: 7,
       } as SetupKey)
     );
   };


### PR DESCRIPTION
The setup keys popup was not setting the default expiration properly.