### PR TITLE
Allow unset audience

### DIFF
--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -22,6 +22,10 @@ if [[ -z "${AUTH_AUDIENCE}" ]]; then
     fi
 fi
 
+if [[ "${AUTH_AUDIENCE}" == "none" ]]; then
+    unset AUTH_AUDIENCE
+fi
+
 if [[ -z "${AUTH_SUPPORTED_SCOPES}" ]]; then
     if [[ -z "${AUTH0_DOMAIN}" ]]; then
         echo "AUTH_SUPPORTED_SCOPES environment variable must be set"


### PR DESCRIPTION
by setting the AUTH_AUDIENCE=none we will unset the audience value, not passing that to the requests

This is required for the jumpcloud support