### PR TITLE
Add public installation page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,16 +70,7 @@ function App() {
 
     return (
         <>
-        <ConfigProvider
-            theme={{
-                token: {
-                    borderRadius: 4,
-                    colorPrimary: "#1890ff",
-                    fontFamily: "Arial"
-                },
-                components: {Badge: {fontSizeSM: 20}},
-            }}
-        >
+
             <Provider store={store}>
                 {!show && <SecureLoading padding="3em" width={50} height={50}/>}
                 {show &&
@@ -124,8 +115,6 @@ function App() {
                     </Layout>
                 }
             </Provider>
-
-        </ConfigProvider>
         </>
     )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,8 @@ import {BrowserRouter} from "react-router-dom";
 import Loading from "./components/Loading";
 import LoginError from "./components/LoginError";
 import {AuthorityConfiguration} from "@axa-fr/react-oidc/dist/vanilla/oidc";
+import InstallPage from "./views/Install";
+import {ConfigProvider} from "antd";
 
 const config = getConfig();
 
@@ -61,8 +63,14 @@ const root = ReactDOM.createRoot(
 
 const loadingComponent = () => <Loading padding="3em" width={50} height={50}/>
 
-root.render(
-    <OidcProvider
+const showApp = () => {
+    if (window.location.pathname === "/install") {
+        // We bypass authentication for pages that do not require auth.
+        // E.g., when we just want to show installation steps for public.
+        return <InstallPage/>
+    }
+
+    return <OidcProvider
         configuration={providerConfig}
         callbackSuccessComponent={loadingComponent}
         authenticatingErrorComponent={LoginError}
@@ -77,6 +85,21 @@ root.render(
             <App/>
         </BrowserRouter>
     </OidcProvider>
+}
+
+root.render(
+    <ConfigProvider
+        theme={{
+            token: {
+                borderRadius: 4,
+                colorPrimary: "#1890ff",
+                fontFamily: "Arial"
+            },
+            components: {Badge: {fontSizeSM: 20}},
+        }}
+    >
+        {showApp()}
+    </ConfigProvider>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/views/Install.tsx
+++ b/src/views/Install.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import {Container} from "../components/Container";
+import { Modal,
+} from "antd";
+import AddPeerPopup from "../components/popups/addpeer/addpeer/AddPeerPopup";
+
+
+export const InstallPage = () => {
+    return (
+        <>
+            <Container style={{paddingTop: "40px"}}>
+              <Modal
+                  closable={false}
+                  open={true}
+                  footer={[]}
+                  width={780}
+              >
+                <AddPeerPopup
+                    greeting={"Hi there!"}
+                    headline={ "It's time to add your first device."}
+                />
+              </Modal>
+            </Container>
+        </>
+    );
+};
+
+export default InstallPage;


### PR DESCRIPTION
This page allows to display installation steps without 
authentication. Can be referenced from the landing
page. for example.