### PR TITLE
Add windows/macos/android instructions for self-hosted

### DIFF
--- a/src/components/popups/addpeer/addpeer/AndroidTab.tsx
+++ b/src/components/popups/addpeer/addpeer/AndroidTab.tsx
@@ -4,6 +4,9 @@ import {Button, Image, Typography} from "antd";
 import TabSteps from "./TabSteps";
 import { StepCommand } from "./types"
 import googleplay from '../../../../assets/google-play-badge.png';
+import {getConfig} from "../../../../config";
+const { grpcApiOrigin } = getConfig();
+
 const {Text} = Typography;
 
 export const AndroidTab = () => {
@@ -19,15 +22,23 @@ export const AndroidTab = () => {
             ),
             copied: false
         } as StepCommand,
-        {
+        ... grpcApiOrigin ? [{
             key: 2,
-            title: 'Run the application and click on the "Connect" button in the middle of the screen',
+            title: 'Click on "Change Server" and enter the following "Server"',
+            commands: grpcApiOrigin,
+            commandsForCopy: grpcApiOrigin,
+            copied: false,
+            showCopyButton: false
+        }] : [],
+        {
+            key: 2 + (grpcApiOrigin ? 1 : 0),
+            title: 'Click on the "Connect" button in the middle of the screen',
             commands: '',
             copied: false,
             showCopyButton: false
         },
         {
-            key: 3,
+            key: 3 + (grpcApiOrigin ? 1 : 0),
             title: 'Sign up using your email address',
             commands: '',
             copied: false,

--- a/src/components/popups/addpeer/addpeer/MacTab.tsx
+++ b/src/components/popups/addpeer/addpeer/MacTab.tsx
@@ -9,6 +9,8 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { CheckOutlined, CopyOutlined } from "@ant-design/icons";
 import { copyToClipboard } from "../../../../utils/common";
+import {getConfig} from "../../../../config";
+const { grpcApiOrigin } = getConfig();
 
 const { Panel } = Collapse;
 
@@ -68,15 +70,23 @@ export const LinuxTab = () => {
       ),
       copied: false,
     } as StepCommand,
-    {
+    ... grpcApiOrigin ? [{
       key: 2,
+      title: 'Click on "Settings" from the NetBird icon in your system tray and enter the following "Management URL"',
+      commands: grpcApiOrigin,
+      commandsForCopy: grpcApiOrigin,
+      copied: false,
+      showCopyButton: false,
+    }] : [],
+    {
+      key: 2 + (grpcApiOrigin ? 1 : 0),
       title: 'Click on "Connect" from the NetBird icon in your system tray',
       commands: "",
       copied: false,
       showCopyButton: false,
     },
     {
-      key: 3,
+      key: 3 + (grpcApiOrigin) ? 1 : 0,
       title: "Sign up using your email address",
       commands: "",
       copied: false,

--- a/src/components/popups/addpeer/addpeer/WindowsTab.tsx
+++ b/src/components/popups/addpeer/addpeer/WindowsTab.tsx
@@ -3,6 +3,9 @@ import React, {useState} from 'react';
 import {Button, Typography} from "antd";
 import TabSteps from "./TabSteps";
 import { StepCommand } from "./types"
+import {getConfig} from "../../../../config";
+const { grpcApiOrigin } = getConfig();
+
 const {Text} = Typography;
 
 export const WindowsTab = () => {
@@ -16,15 +19,23 @@ export const WindowsTab = () => {
             ),
             copied: false
         } as StepCommand,
-        {
+        ... grpcApiOrigin ? [{
             key: 2,
+            title: 'Click on "Settings" from the NetBird icon in your system tray and enter the following "Management URL"',
+            commands: grpcApiOrigin,
+            commandsForCopy: grpcApiOrigin,
+            copied: false,
+            showCopyButton: false
+        }] : [],
+        {
+            key: 2 + (grpcApiOrigin ? 1 : 0),
             title: 'Click on "Connect" from the NetBird icon in your system tray',
             commands: '',
             copied: false,
             showCopyButton: false
         },
         {
-            key: 3,
+            key: 3 + (grpcApiOrigin ? 1 : 0),
             title: 'Sign up using your email address',
             commands: '',
             copied: false,


### PR DESCRIPTION
Implemented #93

Edit: Added android too

<img width="765" alt="image" src="https://github.com/netbirdio/dashboard/assets/14923000/958f24c3-de1c-4a46-9068-36f13a7982e1">

<img width="761" alt="image" src="https://github.com/netbirdio/dashboard/assets/14923000/8a3c6a4a-365f-4430-8494-5568cb40d567">

<img width="758" alt="image" src="https://github.com/netbirdio/dashboard/assets/14923000/ec4078ce-37b4-4675-a3f9-023f93c4e65b">

