### PR TITLE
Fix last login for regular entries in users overview

### DIFF
--- a/src/views/RegularUsers.tsx
+++ b/src/views/RegularUsers.tsx
@@ -521,7 +521,7 @@ export const RegularUsers = () => {
                                 {btn}
                                 <Tag color="blue">me</Tag>
                               </div>
-                              <Text type={"secondary"} style={{paddingLeft: "15px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>
+                              {((record as User).last_login && <Text type={"secondary"} style={{paddingLeft: "15px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>)}
                             </>
                         );
                       }
@@ -533,7 +533,7 @@ export const RegularUsers = () => {
                                 {btn}
                                 <Tag color="gold">invited</Tag>
                               </div>
-                              <Text type={"secondary"} style={{paddingLeft: "15px", paddingTop: "0px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>
+                              {((record as User).last_login && <Text type={"secondary"} style={{paddingLeft: "15px", paddingTop: "0px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>)}
                             </>
                         );
                       }
@@ -545,7 +545,7 @@ export const RegularUsers = () => {
                                 {btn}
                                 <Tag color="red">blocked</Tag>
                               </div>
-                              <Text type={"secondary"} style={{paddingLeft: "15px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>
+                              {((record as User).last_login && <Text type={"secondary"} style={{paddingLeft: "15px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>)}
                             </>
                         );
                       }
@@ -555,7 +555,7 @@ export const RegularUsers = () => {
                             <div>
                               {btn}
                             </div>
-                            <Text type={"secondary"} style={{paddingLeft: "15px", paddingTop: "0px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>
+                            {((record as User).last_login && <Text type={"secondary"} style={{paddingLeft: "15px", paddingTop: "0px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>)}
                           </>
                       );
                     }}

--- a/src/views/RegularUsers.tsx
+++ b/src/views/RegularUsers.tsx
@@ -396,7 +396,7 @@ export const RegularUsers = () => {
         icon: <ExclamationCircleOutlined />,
         title: (
           <span className="font-500">
-            Are you sure you want to block {user.name} ?
+            Are you sure you want to block {user.name? user.name : user.id}?
           </span>
         ),
         width: 600,
@@ -450,11 +450,12 @@ export const RegularUsers = () => {
   const handleDeleteUser = (user: UserDataTable) => {
     confirmModal.confirm({
       icon: <ExclamationCircleOutlined />,
-      title: <span className="font-500">Delete user {user.name}</span>,
+      title: <span className="font-500">Are you sure you want to delete {user.name? user.name : user.id}?</span>,
       width: 500,
       content: (
         <Space direction="vertical" size="small">
-          <Paragraph>Are you sure you want to delete this user?</Paragraph>
+          <Paragraph>
+            Deleting this user will remove their devices and remove dashboard access.</Paragraph>
         </Space>
       ),
       onOk() {

--- a/src/views/RegularUsers.tsx
+++ b/src/views/RegularUsers.tsx
@@ -550,7 +550,14 @@ export const RegularUsers = () => {
                         );
                       }
 
-                      return btn;
+                      return (
+                          <>
+                            <div>
+                              {btn}
+                            </div>
+                            <Text type={"secondary"} style={{paddingLeft: "15px", paddingTop: "0px"}}>Last login: {String(timeAgo((record as User).last_login))}</Text>
+                          </>
+                      );
                     }}
                   />
                   <Column


### PR DESCRIPTION
In the users overview we added the last login information. This is only shown for entries that have a tag (me, blocked, invited). This PR also adds it for regular entries without tag