### PR TITLE
Hide network routes card for non-linux peers

### DIFF
--- a/src/components/PeerUpdate.tsx
+++ b/src/components/PeerUpdate.tsx
@@ -179,6 +179,13 @@ const PeerUpdate = (props: any) => {
 
   useEffect(() => {}, [users]);
 
+  const routeAddAllowed = (os: string): boolean => {
+    return os !== ""
+        && !os.toLowerCase().startsWith("darwin")
+        && !os.toLowerCase().startsWith("windows")
+        && !os.toLowerCase().startsWith("android")
+  }
+
   const toggleEditName = (status: boolean, value?: string) => {
     setEditName(status);
 
@@ -965,6 +972,7 @@ const PeerUpdate = (props: any) => {
           {/* --- */}
           {!isGroupUpdateView && (
             <>
+              {routeAddAllowed(peer.os) &&
               <Card
                 bordered={true}
                 // loading={loading}ƒ
@@ -1090,7 +1098,7 @@ const PeerUpdate = (props: any) => {
                     </Space>
                   )}
                 </div>
-              </Card>
+              </Card>}
 
               <Card bordered={true} style={{ marginBottom: "50px" }}>
                 <Col span={24}>


### PR DESCRIPTION
Linux machine view (with Network Routes section)

![image](https://github.com/netbirdio/dashboard/assets/700848/85164d8a-7dd7-4240-868d-5540abe7eeb8)

Non-Linux machine view (without Network Routes section)

![Screenshot from 2023-09-18 19-10-51](https://github.com/netbirdio/dashboard/assets/700848/02ad1f89-bff6-4cdc-8986-0306760636f3)


