### PR TITLE
Fix/blank page on empty policy groups

### DIFF
--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -305,14 +305,14 @@ export const Settings = () => {
     const createSingleArrayForPolicy: any = [];
     policies.map((aControl: any) => {
       const cSingleAccessArray = aControl.allGroups ? aControl.allGroups : [];
-      if (aControl.rules[0].destinations.length > 0) {
+      if (aControl.rules[0].destinations) {
         aControl.rules[0].destinations.forEach((destination: any) => {
           if (cSingleAccessArray.indexOf(destination.id) === -1) {
             cSingleAccessArray.push(destination.id);
           }
         });
       }
-      if (aControl.rules[0].sources.length > 0) {
+      if (aControl.rules[0].sources) {
         aControl.rules[0].sources.forEach((source: any) => {
           if (cSingleAccessArray.indexOf(source.id) === -1) {
             cSingleAccessArray.push(source.id);

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -305,17 +305,20 @@ export const Settings = () => {
     const createSingleArrayForPolicy: any = [];
     policies.map((aControl: any) => {
       const cSingleAccessArray = aControl.allGroups ? aControl.allGroups : [];
-      aControl.rules[0].destinations.forEach((destination: any) => {
-        if (cSingleAccessArray.indexOf(destination.id) === -1) {
-          cSingleAccessArray.push(destination.id);
-        }
-      });
-
-      aControl.rules[0].sources.forEach((source: any) => {
-        if (cSingleAccessArray.indexOf(source.id) === -1) {
-          cSingleAccessArray.push(source.id);
-        }
-      });
+      if (aControl.rules[0].destinations.length > 0) {
+        aControl.rules[0].destinations.forEach((destination: any) => {
+          if (cSingleAccessArray.indexOf(destination.id) === -1) {
+            cSingleAccessArray.push(destination.id);
+          }
+        });
+      }
+      if (aControl.rules[0].sources.length > 0) {
+        aControl.rules[0].sources.forEach((source: any) => {
+          if (cSingleAccessArray.indexOf(source.id) === -1) {
+            cSingleAccessArray.push(source.id);
+          }
+        });
+      }
 
       aControl["cSingleAccessArray"] = cSingleAccessArray;
       createSingleArrayForPolicy.push(aControl);


### PR DESCRIPTION
Add a check for null sources and destination fields from the policy rules in the settings page.

We should prevent this at the API level: 
https://github.com/netbirdio/netbird/issues/1276