### PR TITLE
Add delete account support

### DIFF
--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -1,6 +1,6 @@
 import {ActionType, createAction, createAsyncAction} from 'typesafe-actions';
 import {Account} from './types';
-import {ApiError, ChangeResponse, RequestPayload} from '../../services/api-client/types';
+import {ApiError, ChangeResponse, DeleteResponse, RequestPayload} from '../../services/api-client/types';
 
 const actions = {
     getAccounts: createAsyncAction(
@@ -16,6 +16,13 @@ const actions = {
     )<RequestPayload<Account>, ChangeResponse<Account | null>, ChangeResponse<Account | null>>(),
     setUpdateAccount: createAction('SET_UPDATED_ACCOUNT')<ChangeResponse<Account | null>>(),
     resetUpdateAccount: createAction('RESET_UPDATED_ACCOUNT')<null>(),
+    deleteAccount: createAsyncAction(
+        'DELETE_ACCOUNT_REQUEST',
+        'DELETE_ACCOUNT_SUCCESS',
+        'DELETE_ACCOUNT_FAILURE'
+    )<RequestPayload<string>, DeleteResponse<string | null>, DeleteResponse<string | null>>(),
+    resetDeletedAccount: createAction('RESET_DELETED_ACCOUNT')<null>(),
+    setDeleteAccount: createAction('SET_DELETE_ACCOUNT')<DeleteResponse<string | null>>(),
 };
 
 

--- a/src/store/account/reducer.ts
+++ b/src/store/account/reducer.ts
@@ -2,13 +2,14 @@ import { createReducer } from 'typesafe-actions';
 import { combineReducers } from 'redux';
 import { Account } from './types';
 import actions, { ActionTypes } from './actions';
-import {ApiError, ChangeResponse} from "../../services/api-client/types";
+import {ApiError, ChangeResponse, DeleteResponse} from "../../services/api-client/types";
 
 type StateType = Readonly<{
   data: Account[] | null;
   loading: boolean;
   failed: ApiError | null;
   savedAccount: ChangeResponse<Account | null>;
+  deletedAccount: DeleteResponse<string | null>;
 }>;
 
 const initialState: StateType = {
@@ -16,6 +17,13 @@ const initialState: StateType = {
   loading: false,
   failed: null,
   savedAccount: <ChangeResponse<Account | null>>{
+    loading: false,
+    success: false,
+    failure: false,
+    error: null,
+    data : null
+  },
+  deletedAccount: <DeleteResponse<string | null>>{
     loading: false,
     success: false,
     failure: false,
@@ -45,10 +53,18 @@ const updatedAccount = createReducer<ChangeResponse<Account | null>, ActionTypes
     .handleAction(actions.setUpdateAccount, (store, action) => action.payload)
     .handleAction(actions.resetUpdateAccount, () => initialState.savedAccount)
 
+const deleteAccount = createReducer<DeleteResponse<string | null>, ActionTypes>(initialState.deletedAccount)
+    .handleAction(actions.deleteAccount.request, () => initialState.deletedAccount)
+    .handleAction(actions.deleteAccount.success, (store, action) => action.payload)
+    .handleAction(actions.deleteAccount.failure, (store, action) => action.payload)
+    .handleAction(actions.setDeleteAccount, (store, action) => action.payload)
+    .handleAction(actions.resetDeletedAccount, () => initialState.deletedAccount)
+
 
 export default combineReducers({
   data,
   loading,
   failed,
-  updatedAccount
+  updatedAccount,
+  deleteAccount
 });

--- a/src/store/account/sagas.ts
+++ b/src/store/account/sagas.ts
@@ -1,8 +1,9 @@
-import {all, call, put, takeLatest} from 'redux-saga/effects';
-import {ApiError, ApiResponse, ChangeResponse} from '../../services/api-client/types';
+import {all, call, put, select, takeLatest} from 'redux-saga/effects';
+import {ApiError, ApiResponse, ChangeResponse, DeleteResponse} from '../../services/api-client/types';
 import {Account} from './types'
 import service from './service';
 import actions from './actions';
+import {deletePeer} from "../peer/sagas";
 
 export function* getAccounts(action: ReturnType<typeof actions.getAccounts.request>): Generator {
     try {
@@ -55,10 +56,55 @@ export function* updateAccount(action: ReturnType<typeof actions.updateAccount.r
     }
 }
 
+export function* deleteAccount(
+    action: ReturnType<typeof actions.deleteAccount.request>
+): Generator {
+    try {
+        yield call(actions.setDeleteAccount, {
+            loading: true,
+            success: false,
+            failure: false,
+            error: null,
+            data: null,
+        } as DeleteResponse<string | null>);
+
+        const effect = yield call(service.deleteAccount, action.payload);
+        const response = effect as ApiResponse<any>;
+
+        yield put(
+            actions.deleteAccount.success({
+                loading: false,
+                success: true,
+                failure: false,
+                error: null,
+                data: response.body,
+            } as DeleteResponse<string | null>)
+        );
+
+        const accounts = (yield select((state) => state.peer.data)) as Account[];
+        yield put(
+            actions.getAccounts.success(
+                accounts.filter((p: Account) => p.id !== action.payload.payload)
+            )
+        );
+    } catch (err) {
+        yield put(
+            actions.deleteAccount.failure({
+                loading: false,
+                success: false,
+                failure: false,
+                error: err as ApiError,
+                data: null,
+            } as DeleteResponse<string | null>)
+        );
+    }
+}
+
 export default function* sagas(): Generator {
     yield all([
         takeLatest(actions.getAccounts.request, getAccounts),
         takeLatest(actions.updateAccount.request, updateAccount),
+        takeLatest(actions.deleteAccount.request, deleteAccount),
     ]);
 }
 

--- a/src/store/account/service.ts
+++ b/src/store/account/service.ts
@@ -15,5 +15,11 @@ export default {
         `/api/accounts/${id}`,
         payload
     );
-  }
+  },
+  async deleteAccount(payload:RequestPayload<string>): Promise<ApiResponse<any>> {
+    return apiClient.delete<any>(
+        `/api/accounts/` + payload.payload,
+        payload
+    );
+  },
 };

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -864,6 +864,59 @@ export const Settings = () => {
           <div >
             <Row>
               <Col span={12}>
+                {(isNetBirdHosted() || isLocalDev()) && <Form.Item name="peer_approval_enabled" label="">
+                  <div
+                      style={{
+                        display: "flex",
+                        gap: "15px",
+                      }}
+                  >
+                    <Switch
+                        onChange={(checked) => {
+                          setFormPeerApprovalEnabled(checked);
+                        }}
+                        size="small"
+                        checked={formPeerApprovalEnabled}
+                    />
+                    <div>
+                      <label
+                          style={{
+                            color: "rgba(0, 0, 0, 0.88)",
+                            fontSize: "14px",
+                            fontWeight: "500",
+                          }}
+                      >
+                        Peer approval{" "}
+                        <Tooltip
+                            title="Peer approval requires that every newly added peer
+                          will require approval by an administrator before it can connect to other peers.
+                          You can approve peers in the peers tab."
+                        >
+                          <Text
+                              style={{
+                                marginLeft: "5px",
+                                fontSize: "14px",
+                                color: "#bdbdbe",
+                              }}
+                              type={"secondary"}
+                          >
+                            <QuestionCircleFilled />
+                          </Text>
+                        </Tooltip>
+                      </label>
+                      <Paragraph
+                          type={"secondary"}
+                          style={{
+                            marginTop: "-2",
+                            fontWeight: "400",
+                            marginBottom: "0",
+                          }}
+                      >
+                        Require peers to be approved by an administrator
+                      </Paragraph>
+                    </div>
+                  </div>
+                </Form.Item>}
                 <Form.Item name="peer_login_expiration_enabled" label="">
                   <div
                       style={{

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -81,6 +81,9 @@ export const Settings = () => {
   const [dangerClicked, setDangerClicked] = useState(false);
   const [accountDeleting, setAccountDeleting] = useState(false);
 
+  const [isOwner, setIsOwner] = useState(false);
+
+
   const [filterGroup, setFilterGroup] = useState([]);
   const [textToSearch, setTextToSearch] = useState(
     getFilterState("groupsManagementPage", "search")
@@ -141,6 +144,16 @@ export const Settings = () => {
   const { confirm } = Modal;
 
   const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (users) {
+      let currentUser = users.find((user) => user?.is_current);
+      if (currentUser) {
+        setIsOwner(currentUser.role === "owner");
+      }
+    }
+  }, [users]);
+
   useEffect(() => {
     dispatch(
       accountActions.getAccounts.request({
@@ -665,7 +678,8 @@ export const Settings = () => {
     key: React.Key,
     icon?: React.ReactNode,
     children?: MenuItem[],
-    type?: "group"
+    type?: "group",
+    disabled?: boolean
   ): MenuItem {
     return {
       key,
@@ -673,6 +687,7 @@ export const Settings = () => {
       children,
       label,
       type,
+      disabled,
     } as MenuItem;
   }
 
@@ -681,7 +696,7 @@ export const Settings = () => {
       "System settings",
       "sub2",
       <SettingOutlined />,
-      [getItem("Authentication", "auth"), getItem("Groups", "groups"), getItem("Danger zone", "danger")],
+      [getItem("Authentication", "auth"), getItem("Groups", "groups"), getItem("Danger zone", "danger", undefined, undefined, undefined, !isOwner)],
       "group"
     ),
   ];


### PR DESCRIPTION
Add support for deleting an account via dashboard in a settings `Danger zone` menu. The setting menu is available only to owner users.

After an account is deleted, a popup with a redirect message is displayed, and the user is logged out and redirected to the login page.

Flow screenshots:

Danger zone:
![image](https://github.com/netbirdio/dashboard/assets/7747744/b200d5db-691c-4407-8b16-59757db71530)

Deleting confirmation:
![image](https://github.com/netbirdio/dashboard/assets/7747744/d8557595-9f57-4777-a4cc-9a721192d081)

After deleting the notification:
![image](https://github.com/netbirdio/dashboard/assets/7747744/e4104cd0-0b56-4b77-80d8-9cabcd051fe2)