### PR TITLE
Use Approve for approve peer modal

### DIFF
--- a/src/views/Peers.tsx
+++ b/src/views/Peers.tsx
@@ -437,6 +437,7 @@ export const Peers = () => {
       title: <span className="font-500">Approve peer {name}</span>,
       width: 600,
       content: content,
+      okText: "Approve",
       onOk() {
         record.approval_required = false
         dispatch(


### PR DESCRIPTION
User Approve for the approve peer modal. e.g.:

<img width="599" alt="image" src="https://github.com/netbirdio/dashboard/assets/7747744/9c0d5370-a26b-4026-88c0-491307ffab97">
