### PR TITLE
Fix duplicate groups issue when group does not exist

### DIFF
--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -132,7 +132,7 @@ function PeerOverview() {
             <Breadcrumbs.Item label={peer.ip} active />
           </Breadcrumbs>
 
-          <div className={"flex justify-between max-w-6xl"}>
+          <div className={"flex justify-between max-w-6xl items-start"}>
             <div>
               <div className={"flex items-center gap-3"}>
                 <h1 className={"flex items-center gap-3"}>

--- a/src/modules/access-control/AccessControlModal.tsx
+++ b/src/modules/access-control/AccessControlModal.tsx
@@ -162,7 +162,9 @@ export function AccessControlModalContent({
     const createOrUpdateGroups = uniqBy([...g1, ...g2], "name").map(
       (g) => g.promise,
     );
-    const groups = await Promise.all(createOrUpdateGroups);
+    const groups = await Promise.all(
+      createOrUpdateGroups.map((call) => call()),
+    );
 
     let sources = sourceGroups
       .map((g) => {

--- a/src/modules/access-control/table/AccessControlTable.tsx
+++ b/src/modules/access-control/table/AccessControlTable.tsx
@@ -26,7 +26,6 @@ import AccessControlNameCell from "@/modules/access-control/table/AccessControlN
 import AccessControlPortsCell from "@/modules/access-control/table/AccessControlPortsCell";
 import AccessControlProtocolCell from "@/modules/access-control/table/AccessControlProtocolCell";
 import AccessControlSourcesCell from "@/modules/access-control/table/AccessControlSourcesCell";
-import RouteModal from "@/modules/routes/RouteModal";
 
 type Props = {
   policies?: Policy[];
@@ -211,12 +210,12 @@ export default function AccessControlTable({ policies, isLoading }: Props) {
               "It looks like you don't have any rules yet. Rules can allow connections by specific protocol and ports."
             }
             button={
-              <RouteModal>
+              <AccessControlModal>
                 <Button variant={"primary"} className={""}>
                   <PlusCircle size={16} />
                   Add Rule
                 </Button>
-              </RouteModal>
+              </AccessControlModal>
             }
             learnMore={
               <>

--- a/src/modules/routes/RouteModal.tsx
+++ b/src/modules/routes/RouteModal.tsx
@@ -113,7 +113,9 @@ export function RouteModalContent({ onSuccess, peer }: ModalProps) {
     const createOrUpdateGroups = uniqBy([...g1, ...g2], "name").map(
       (g) => g.promise,
     );
-    const createdGroups = await Promise.all(createOrUpdateGroups);
+    const createdGroups = await Promise.all(
+      createOrUpdateGroups.map((call) => call()),
+    );
     const peerGroups = routingPeerGroups
       .map((g) => {
         const find = createdGroups.find((group) => group.name === g.name);

--- a/src/modules/routes/RouteUpdateModal.tsx
+++ b/src/modules/routes/RouteUpdateModal.tsx
@@ -150,7 +150,9 @@ function RouteUpdateModalContent({ onSuccess, route, cell }: ModalProps) {
     const createOrUpdateGroups = uniqBy([...g1, ...g2], "name").map(
       (g) => g.promise,
     );
-    const createdGroups = await Promise.all(createOrUpdateGroups);
+    const createdGroups = await Promise.all(
+      createOrUpdateGroups.map((call) => call()),
+    );
     const peerGroups = routingPeerGroups
       .map((g) => {
         const find = createdGroups.find((group) => group.name === g.name);


### PR DESCRIPTION
- Fix an issue where creating new groups in the access control modal would create a duplicate if the group does not exist and was used in the "source" and "destination" field
- Add additional check to prevent adding "null" to peer_groups 