### PR TITLE
Fix peer groups occasionally not refreshing 

### DIFF
--- a/src/app/(dashboard)/peers/page.tsx
+++ b/src/app/(dashboard)/peers/page.tsx
@@ -22,6 +22,7 @@ export default function Peers() {
 
   useEffect(() => {
     refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const peersWithUser = peers?.map((peer) => {

--- a/src/app/(dashboard)/peers/page.tsx
+++ b/src/app/(dashboard)/peers/page.tsx
@@ -6,8 +6,9 @@ import Paragraph from "@components/Paragraph";
 import SkeletonTable from "@components/skeletons/SkeletonTable";
 import useFetchApi from "@utils/api";
 import { ExternalLinkIcon } from "lucide-react";
-import React, { lazy, Suspense } from "react";
+import React, { lazy, Suspense, useEffect } from "react";
 import PeerIcon from "@/assets/icons/PeerIcon";
+import { useGroups } from "@/contexts/GroupsProvider";
 import { useUsers } from "@/contexts/UsersProvider";
 import { Peer } from "@/interfaces/Peer";
 import PageContainer from "@/layouts/PageContainer";
@@ -17,6 +18,11 @@ const PeersTable = lazy(() => import("@/modules/peers/PeersTable"));
 export default function Peers() {
   const { data: peers, isLoading } = useFetchApi<Peer[]>("/peers");
   const { users } = useUsers();
+  const { refresh } = useGroups();
+
+  useEffect(() => {
+    refresh();
+  }, []);
 
   const peersWithUser = peers?.map((peer) => {
     if (!users) return peer;

--- a/src/contexts/GroupsProvider.tsx
+++ b/src/contexts/GroupsProvider.tsx
@@ -21,7 +21,7 @@ export default function GroupsProvider({ children }: Props) {
   const [dropdownOptions, setDropdownOptions] = useState<Group[]>([]);
 
   const refresh = () => {
-    mutate().then();
+    if (groups && !isLoading) mutate().then();
   };
 
   return (


### PR DESCRIPTION
Sometimes, updating a group for a user with `group propagation` enabled doesn’t trigger a refresh in the peer view. 
This PR includes a fix to trigger a refresh of the groups once the peer's table is visited again. 