### PR TITLE
Show peers for regular users but hide / disable actions (delete, enable ssh etc.)

### DIFF
--- a/src/app/(dashboard)/peers/page.tsx
+++ b/src/app/(dashboard)/peers/page.tsx
@@ -21,7 +21,7 @@ export default function Peers() {
 
   return (
     <PageContainer>
-      {isUser ? <PeersDefaultView /> : <PeersView />}
+      <PeersView />
     </PageContainer>
   );
 }

--- a/src/contexts/CountryProvider.tsx
+++ b/src/contexts/CountryProvider.tsx
@@ -19,7 +19,17 @@ const CountryContext = React.createContext(
 export default function CountryProvider({ children }: Props) {
   const { isUser } = useLoggedInUser();
 
-  return <CountryProviderContent>{children}</CountryProviderContent>;
+  const getRegionByPeer = (peer: Peer) => "Unknown";
+
+  return isUser ? (
+    <CountryContext.Provider
+      value={{ countries: [], isLoading: false, getRegionByPeer }}
+    >
+      {children}
+    </CountryContext.Provider>
+  ) : (
+    <CountryProviderContent>{children}</CountryProviderContent>
+  );
 }
 
 function CountryProviderContent({ children }: Props) {

--- a/src/contexts/CountryProvider.tsx
+++ b/src/contexts/CountryProvider.tsx
@@ -19,11 +19,7 @@ const CountryContext = React.createContext(
 export default function CountryProvider({ children }: Props) {
   const { isUser } = useLoggedInUser();
 
-  return isUser ? (
-    children
-  ) : (
-    <CountryProviderContent>{children}</CountryProviderContent>
-  );
+  return <CountryProviderContent>{children}</CountryProviderContent>;
 }
 
 function CountryProviderContent({ children }: Props) {

--- a/src/contexts/GroupsProvider.tsx
+++ b/src/contexts/GroupsProvider.tsx
@@ -22,11 +22,7 @@ export default function GroupsProvider({ children }: Props) {
   const path = usePathname();
   const { isUser } = useLoggedInUser();
 
-  return isUser && path == "/peers" ? (
-    children
-  ) : (
-    <GroupsProviderContent>{children}</GroupsProviderContent>
-  );
+  return <GroupsProviderContent>{children}</GroupsProviderContent>;
 }
 
 export function GroupsProviderContent({ children }: Props) {

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -154,7 +154,7 @@ function DashboardPageContent({ children }: { children: React.ReactNode }) {
                 height: `calc(100vh - ${headerHeight + bannerHeight}px)`,
               }}
             >
-              {!isUser && <Navigation hideOnMobile />}
+              <Navigation hideOnMobile />
               {children}
             </div>
           </motion.div>

--- a/src/modules/common-table-rows/GroupsRow.tsx
+++ b/src/modules/common-table-rows/GroupsRow.tsx
@@ -14,6 +14,7 @@ import { FolderGit2 } from "lucide-react";
 import * as React from "react";
 import { useMemo } from "react";
 import { useGroups } from "@/contexts/GroupsProvider";
+import { useLoggedInUser } from "@/contexts/UsersProvider";
 import { Group } from "@/interfaces/Group";
 import { Peer } from "@/interfaces/Peer";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
@@ -38,6 +39,7 @@ export default function GroupsRow({
   peer,
 }: Props) {
   const { groups: allGroups } = useGroups();
+  const { isUser } = useLoggedInUser();
 
   // Get the group by the id
   const foundGroups = useMemo(() => {
@@ -54,7 +56,7 @@ export default function GroupsRow({
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          setModal && setModal(true);
+          setModal && !isUser && setModal(true);
         }}
       >
         <MultipleGroups groups={foundGroups} label={label} />

--- a/src/modules/peers/PeersTable.tsx
+++ b/src/modules/peers/PeersTable.tsx
@@ -17,6 +17,7 @@ import React from "react";
 import { useSWRConfig } from "swr";
 import PeerIcon from "@/assets/icons/PeerIcon";
 import PeerProvider from "@/contexts/PeerProvider";
+import { useLoggedInUser } from "@/contexts/UsersProvider";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { Group } from "@/interfaces/Group";
 import { Peer } from "@/interfaces/Peer";
@@ -133,6 +134,7 @@ const PeersTableColumns: ColumnDef<Peer>[] = [
     ),
   },
   {
+    id: "actions",
     accessorKey: "id",
     header: "",
     cell: ({ row }) => (
@@ -176,6 +178,8 @@ export default function PeersTable({ peers, isLoading }: Props) {
       "name",
     ) as Group[]) || ([] as Group[]);
 
+  const { isUser } = useLoggedInUser();
+
   return (
     <DataTable
       onRowClick={(row) => router.push("/peer?id=" + row.original.id)}
@@ -193,6 +197,7 @@ export default function PeersTable({ peers, isLoading }: Props) {
         ip: false,
         user_name: false,
         user_email: false,
+        actions: !isUser,
       }}
       isLoading={isLoading}
       getStartedCard={


### PR DESCRIPTION
This PR reverts the recent changes in the peer's view. 
Regular users can now view their peers.

Some actions that regular users can not perform are hidden (delete peer, enable ssh, etc.)
![CleanShot 2024-03-21 at 09 47 56](https://github.com/netbirdio/dashboard/assets/21257535/0441f08a-73a4-4da4-9ecc-c4f8f4fa41c7)

Fields that require admin permissions are now disabled for regular users.
![CleanShot 2024-03-21 at 09 48 45](https://github.com/netbirdio/dashboard/assets/21257535/852aa663-a4ca-4efa-9890-5cd1665ecabd)

