### PR TITLE
Fix user deletion notification

### DIFF
--- a/src/modules/users/table-cells/UserActionCell.tsx
+++ b/src/modules/users/table-cells/UserActionCell.tsx
@@ -20,7 +20,7 @@ export default function UserActionCell({ user, serviceUser = false }: Props) {
   const deleteRule = async () => {
     const name = user.name || "User";
     notify({
-      title: name + "deleted",
+      title: `'${name}' deleted`,
       description: "User was successfully deleted.",
       promise: userRequest.del("", `/${user.id}`).then(() => {
         mutate(`/users?service_user=${serviceUser}`);


### PR DESCRIPTION
The user deletion notification didn't have a space/match the style of the other deletion stages before (title would be e.g. Userdeleted).

This updates the notification to match the style of the rest of the deletion stages (encasing the name in ') as well as adding the missing space between the name and deleted.