### PR TITLE
Fix DNS modal to allow one char domains

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -42,7 +42,7 @@ export const sleep = (ms: number) => {
 export const validator = {
   isValidDomain: (domain: string) => {
     const unicodeDomain =
-        /^(?!.*\s)(\.?[a-zA-Z0-9\u00A1-\uFFFF](?!.*\s$)(?!.*\.$)(?:(?!-)[a-zA-Z0-9\u00A1-\uFFFF-]{0,63}(?<!-)\.){0,126}(?!-)[a-zA-Z0-9\u00A1-\uFFFF-]{1,63}(?<!-))$/u;
+        /^(?!.*\.\.)(?!.*\.$)(?!.*\s)(?:(?!-)(?!.*--)[a-zA-Z0-9\u00A1-\uFFFF-]{1,63}(?<!-)\.)+(?!-)(?!.*--)[a-zA-Z0-9\u00A1-\uFFFF-]{2,63}$/u;
     try {
       const minMaxChars = [1, 255];
       const isValidDomainLength =

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -42,7 +42,7 @@ export const sleep = (ms: number) => {
 export const validator = {
   isValidDomain: (domain: string) => {
     const unicodeDomain =
-      /^(?!.*\s)(\.?[a-zA-Z0-9\u00A1-\uFFFF](?!.*\s$)(?!.*\.$)(?:(?!-)[a-zA-Z0-9\u00A1-\uFFFF-]{1,63}(?<!-)\.){0,126}(?!-)[a-zA-Z0-9\u00A1-\uFFFF-]{1,63}(?<!-))$/u;
+        /^(?!.*\s)(\.?[a-zA-Z0-9\u00A1-\uFFFF](?!.*\s$)(?!.*\.$)(?:(?!-)[a-zA-Z0-9\u00A1-\uFFFF-]{0,63}(?<!-)\.){0,126}(?!-)[a-zA-Z0-9\u00A1-\uFFFF-]{1,63}(?<!-))$/u;
     try {
       const minMaxChars = [1, 255];
       const isValidDomainLength =


### PR DESCRIPTION
This PR fixes the isValidDomain regex to allow single char domain names like `a.bc.com`
Tested the regex with the following set:
```
console.log(isValidDomain("p.abc.com")); // true
console.log(isValidDomain("example.com")); // true
console.log(isValidDomain("invalid domain")); // false
console.log(isValidDomain("a..b")); // false
console.log(isValidDomain(".3.v")); // false
console.log(isValidDomain("a-b.com")); // true
console.log(isValidDomain("a.b")); // true
console.log(isValidDomain("ab.bc.de")); // true
console.log(isValidDomain("a-b.dc.de")); // true
console.log(isValidDomain("a--b.com")); // false
console.log(isValidDomain("-abc.com")); // false
console.log(isValidDomain("abc-.com")); // false
console.log(isValidDomain("abc..com")); // false
```