### PR TITLE
Use a non-root user to limit root access in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,26 @@ RUN apk add --no-cache bash curl less ca-certificates git tzdata zip gettext \
     nginx curl supervisor certbot-nginx && \
     rm -rf /var/cache/apk/* && mkdir -p /run/nginx
 
+ENV USER=netbird
+ENV GROUPNAME=$USER
+ENV UID=1000
+ENV GID=1000
+
+RUN addgroup \
+    --gid "$GID" \
+    "$GROUPNAME" \
+&&  adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "$(pwd)" \
+    --ingroup "$GROUPNAME" \
+    --no-create-home \
+    --uid "$UID" \
+    $USER \
+
 STOPSIGNAL SIGINT
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
+EXPOSE 8443
 ENTRYPOINT ["/usr/bin/supervisord","-c","/etc/supervisord.conf"]
 
 WORKDIR /usr/share/nginx/html
@@ -22,3 +39,20 @@ RUN chmod +x /usr/local/init_react_envs.sh
 COPY docker/supervisord.conf /etc/supervisord.conf
 # copy build files
 COPY out/ /usr/share/nginx/html/
+
+# Set permissions for Nginx
+RUN chown -R netbird:netbird /var/lib/nginx \
+&&  chown -R netbird:netbird /var/log/nginx \
+&&  chown -R netbird:netbird /usr/share/nginx \
+&&  chown -R netbird:netbird /run/nginx \
+&&  chown -R netbird:netbird /etc/nginx
+
+# Set permissions for directories used by letsencrypt certbot
+# Set permissions for crontab which will be modified by init_cert.sh
+RUN mkdir -p /etc/letsencrypt /var/lib/letsencrypt /var/log/letsencrypt \
+&&  chown -R netbird:netbird /etc/crontabs/ \
+&&  chown -R netbird:netbird /var/lib/letsencrypt \
+&&  chown -R netbird:netbird /var/log/letsencrypt \
+&&  chown -R netbird:netbird /etc/letsencrypt
+
+USER netbird

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,11 +7,11 @@ NetBird Dashboard is NetBirds Management server UI. It allows users to signin, v
 ## How to use this image
 HTTP run:
 ```shell
-docker run -d --rm -p 80:80 wiretrustee/dashboard:main
+docker run -d --rm -p 80:8080 netbirdio/dashboard:main
 ```
 Using SSL certificate from Let's Encrypt®:
 ```shell
-docker run -d --rm -p 80:80 -p 443:443 \
+docker run -d --rm -p 80:8080 -p 443:8443 \
   -e LETSENCRYPT_DOMAIN=app.mydomain.com \
   -e LETSENCRYPT_EMAIL=hello@mydomain.com \
   netbirdio/dashboard:main

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,6 +1,6 @@
 server {
-	listen 80 default_server;
-	listen [::]:80 default_server;
+	listen 8080 default_server;
+	listen [::]:8080 default_server;
 
     root /usr/share/nginx/html;
 

--- a/docker/init_cert.sh
+++ b/docker/init_cert.sh
@@ -2,7 +2,7 @@
 set -ex
 LETSENCRYPT_DOMAIN=${LETSENCRYPT_DOMAIN:-"none"}
 LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-"example@local"}
-NGINX_SSL_PORT=${NGINX_SSL_PORT:-443}
+NGINX_SSL_PORT=${NGINX_SSL_PORT:-8443}
 
 # If no domain is provided, skip certbot execution and configuration
 if [ "${LETSENCRYPT_DOMAIN}-x" == "none-x" ]; then

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,7 +1,7 @@
 # /etc/nginx/nginx.conf
 daemon off;
 
-user nginx;
+#user nginx;
 
 # Set number of worker processes automatically based on number of CPU cores.
 worker_processes auto;

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,6 +1,7 @@
 [unix_http_server]
-file=/var/run/supervisor.sock
+file=/tmp/supervisor.sock
 chmod=0700
+chown=netbird:netbird
 username = dummy
 password = dummy
 
@@ -8,15 +9,15 @@ password = dummy
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock
+serverurl=unix:///tmp/supervisor.sock
 username = dummy
 password = dummy
 
 [supervisord]
 nodaemon=true
-user=root
+user=netbird
 
-pidfile=/run/supervisord.pid
+pidfile=/tmp/supervisord.pid
 
 logfile=/proc/self/fd/1
 logfile_maxbytes=0
@@ -24,7 +25,7 @@ loglevel=warn
 
 [program:cron]
 command=crond -f -d 8
-user=root
+user=netbird
 priority=101
 numprocs=1
 autostart=0
@@ -37,7 +38,7 @@ stderr_logfile_maxbytes=0
 
 [program:nginx]
 command=/usr/sbin/nginx
-user=root
+user=netbird
 priority=100
 numprocs=1
 autostart=1
@@ -50,7 +51,7 @@ stderr_logfile_maxbytes=0
 
 [program:init_cert]
 command=/usr/local/init_cert.sh
-user=root
+user=netbird
 
 numprocs=1
 autostart=1
@@ -64,7 +65,7 @@ stderr_logfile_maxbytes=0
 
 [program:init_react_envs]
 command=/usr/local/init_react_envs.sh
-user=root
+user=netbird
 
 numprocs=1
 autostart=1


### PR DESCRIPTION
I'd like to be able to deploy the netbird dashboard to a highly restricted environment. One of the requirements is to run docker as non-root. See also the best practices mentioned [here](https://www.docker.com/blog/understanding-the-docker-user-instruction/). 
While it is possible to simply start the netbird dashboard container with another user it is not able to run since it is configured to:
- bind to ports lower than 1000 which are privileged ports.
- Writes files to /etc/, e.g. /etc/crontabs/root
- Letsencrypt bot writes to several places as well

I have tested to run the image in my environment and I am fairly confident that it should run somewhere else, too. I did not test running it with letsencrypt. This should be definitely tested before considering this to be merged. 

This feature was asked for in #406. Consider this a first shot in this direction. 
