### PR TITLE
Add admin-url to the add-peer dialogue

### DIFF
--- a/src/utils/netbird.ts
+++ b/src/utils/netbird.ts
@@ -5,8 +5,16 @@ export const GRPC_API_ORIGIN = config.grpcApiOrigin;
 
 export const getNetBirdUpCommand = () => {
   let cmd = "netbird up";
-  if (!GRPC_API_ORIGIN) return cmd;
-  cmd += " --management-url " + GRPC_API_ORIGIN;
+  if (GRPC_API_ORIGIN) {
+    cmd += " --management-url " + GRPC_API_ORIGIN
+  }
+  if (!isNetBirdHosted) {
+    admin_url = window.location.protocol + "://" + window.location.hostname
+    if (window.location.port != "") {
+      admin_url += ":" + window.location.port
+    }
+    cmd += " --admin-url " + admin_url
+  };
   return cmd;
 };
 

--- a/src/utils/netbird.ts
+++ b/src/utils/netbird.ts
@@ -8,7 +8,7 @@ export const getNetBirdUpCommand = () => {
   if (GRPC_API_ORIGIN) {
     cmd += " --management-url " + GRPC_API_ORIGIN
   }
-  if (!isNetBirdHosted) {
+  if (!isNetBirdHosted()) {
     let admin_url = window.location.protocol + "://" + window.location.hostname
     if (window.location.port != "") {
       admin_url += ":" + window.location.port

--- a/src/utils/netbird.ts
+++ b/src/utils/netbird.ts
@@ -9,7 +9,7 @@ export const getNetBirdUpCommand = () => {
     cmd += " --management-url " + GRPC_API_ORIGIN
   }
   if (!isNetBirdHosted) {
-    admin_url = window.location.protocol + "://" + window.location.hostname
+    let admin_url = window.location.protocol + "://" + window.location.hostname
     if (window.location.port != "") {
       admin_url += ":" + window.location.port
     }


### PR DESCRIPTION
This change adds a flag to the `netbird up` command when the site is not hosted by netbird.io or wiretrustee.com