### PR TITLE
fix: follow oauth2 spec for redirect uri

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,8 +23,8 @@ interface Config {
  */
 const loadConfig = (): Config => {
   let configJson: any;
-  let redirectURI = "/#callback";
-  let silentRedirectURI = "/#silent-callback";
+  let redirectURI = "/peers";
+  let silentRedirectURI = "/add-peer";
   let tokenSource = "accessToken";
 
   if (process.env.APP_ENV === "test") {


### PR DESCRIPTION
The OAuth2 spec explicitely forbids using fragments in redirect uri. Any IDP that follows the spec can currently not be used without changing the uris in netbird.
I think the default should be following the spec.

Closes #91 
[rfc-editor.org/rfc/rfc6749#section-3.1.2](https://www.rfc-editor.org/rfc/rfc6749#section-3.1.2)

"""
The redirection endpoint URI MUST be an absolute URI as defined by
[[RFC3986] Section 4.3](https://www.rfc-editor.org/rfc/rfc3986#section-4.3). The endpoint URI MAY include an
"application/x-www-form-urlencoded" formatted (per [Appendix B](https://www.rfc-editor.org/rfc/rfc6749#appendix-B)) query
component ([[RFC3986] Section 3.4](https://www.rfc-editor.org/rfc/rfc3986#section-3.4)), which MUST be retained when adding
additional query parameters. The endpoint URI MUST NOT include a
fragment component.
"""