### PR TITLE
Fix posture checks table filters

### DIFF
--- a/src/modules/posture-checks/table/PostureCheckBrowseTable.tsx
+++ b/src/modules/posture-checks/table/PostureCheckBrowseTable.tsx
@@ -3,14 +3,12 @@ import { Checkbox } from "@components/Checkbox";
 import { DataTable } from "@components/table/DataTable";
 import DataTableHeader from "@components/table/DataTableHeader";
 import DataTableRefreshButton from "@components/table/DataTableRefreshButton";
-import { useLocalStorage } from "@hooks/useLocalStorage";
 import {
   ColumnDef,
   RowSelectionState,
   SortingState,
 } from "@tanstack/react-table";
 import useFetchApi from "@utils/api";
-import { usePathname } from "next/navigation";
 import React, { useState } from "react";
 import { useSWRConfig } from "swr";
 import { PostureCheck } from "@/interfaces/PostureCheck";
@@ -25,18 +23,14 @@ export default function PostureCheckBrowseTable({ onAdd }: Readonly<Props>) {
   const { data: postureChecks, isLoading } =
     useFetchApi<PostureCheck[]>("/posture-checks");
   const { mutate } = useSWRConfig();
-  const path = usePathname();
 
   // Default sorting state of the table
-  const [sorting, setSorting] = useLocalStorage<SortingState>(
-    "netbird-table-sort" + path,
-    [
-      {
-        id: "name",
-        desc: true,
-      },
-    ],
-  );
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: "name",
+      desc: true,
+    },
+  ]);
 
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
 
@@ -47,6 +41,7 @@ export default function PostureCheckBrowseTable({ onAdd }: Readonly<Props>) {
         rowSelection={selectedRows}
         setRowSelection={setSelectedRows}
         isLoading={isLoading}
+        keepStateInLocalStorage={false}
         text={"Posture Check"}
         sorting={sorting}
         wrapperClassName={""}


### PR DESCRIPTION
Fix the issue where browsing posture checks would use filters / search from the access control policies table.
See issue: https://github.com/netbirdio/netbird/issues/3377