### PR TITLE
fix: add multi-group support for JWT allow groups with tag system

### DIFF
--- a/src/modules/settings/GroupsTab.tsx
+++ b/src/modules/settings/GroupsTab.tsx
@@ -27,6 +27,7 @@ import {
 import React, { lazy, Suspense, useState } from "react";
 import { useSWRConfig } from "swr";
 import SettingsIcon from "@/assets/icons/SettingsIcon";
+import Badge from "@/components/Badge";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { useHasChanges } from "@/hooks/useHasChanges";


### PR DESCRIPTION
Fixes the JWT allow groups input to support multiple groups as an array, matching the API capability.

<img width="645" height="587" alt="Capture d’écran 2025-10-30 à 20 41 32" src="https://github.com/user-attachments/assets/ad501039-f2e0-446c-ba51-962ea89a5f50" />

https://github.com/netbirdio/dashboard/issues/499

Fix the issue : #499 