### PR TITLE
docs: fix broken Auth0 quickstart link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Auth0 so far is the only 3rd party dependency that can't be really self-hosted.
      -e AUTH0_DOMAIN=<SET YOUR AUTH DOMAIN> \
      -e AUTH0_CLIENT_ID=<SET YOUR CLIENT ID> \
      -e AUTH0_AUDIENCE=<SET YOUR AUDIENCE> \
-     -e NETBIRD_MGMT_API_ENDPOINT=<SET YOUR MANAGEMETN API URL> \
+     -e NETBIRD_MGMT_API_ENDPOINT=<SET YOUR MANAGEMENT API URL> \
      netbirdio/dashboard:main
    ```
 
@@ -71,7 +71,7 @@ Auth0 so far is the only 3rd party dependency that can't be really self-hosted.
      -e AUTH0_DOMAIN=<SET YOUR AUTH DOMAIN> \
      -e AUTH0_CLIENT_ID=<SET YOUR CLEITN ID> \
      -e AUTH0_AUDIENCE=<SET YOUR AUDIENCE> \
-     -e NETBIRD_MGMT_API_ENDPOINT=<SET YOUR MANAGEMETN API URL> \
+     -e NETBIRD_MGMT_API_ENDPOINT=<SET YOUR MANAGEMENT API URL> \
      netbirdio/dashboard:main
    ```
 


### PR DESCRIPTION
The Auth0 React SDK quickstart link currently returns 404.
Updated it to the new Auth0 documentation URL:
https://auth0.com/docs/quickstart/spa/react

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved README spacing and section layout for clearer presentation
  * Fixed typographical errors (e.g., "JTW" → "JWT") and updated Auth0 guide reference to the general SPA guide
  * Clarified wording and possessive usage in the management API description
  * Cleaned up Docker/run instruction text and code block formatting for readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->