### PR TITLE
Remove architecture info tooltip for MacOS

### DIFF
--- a/src/modules/setup-netbird-modal/MacOSTab.tsx
+++ b/src/modules/setup-netbird-modal/MacOSTab.tsx
@@ -6,17 +6,14 @@ import {
 } from "@components/Accordion";
 import Button from "@components/Button";
 import Code from "@components/Code";
-import InlineLink from "@components/InlineLink";
 import Separator from "@components/Separator";
 import Steps from "@components/Steps";
 import TabsContentPadding, { TabsContent } from "@components/Tabs";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@components/Tooltip";
 import { getNetBirdUpCommand, GRPC_API_ORIGIN } from "@utils/netbird";
 import {
   BeerIcon,
   DownloadIcon,
   ExternalLinkIcon,
-  HelpCircle,
   PackageOpenIcon,
   TerminalSquareIcon,
 } from "lucide-react";


### PR DESCRIPTION
Previously, this tooltip helped users determine which binary to download. Since #501, there is only one universal binary download link, so keeping the tooltip explaining how to determine the CPU architecture is unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed the inline help tooltip from the macOS installer download step; the step content and controls remain unchanged. Users will no longer see the small help icon, descriptive text, or the inline "Learn more" link in that step, simplifying the UI and reducing on-screen guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->