### PR TITLE
Indicate that local user auth is disabled

### DIFF
--- a/src/modules/users/table-cells/UserStatusCell.tsx
+++ b/src/modules/users/table-cells/UserStatusCell.tsx
@@ -15,7 +15,7 @@ export default function UserStatusCell({ user }: Readonly<Props>) {
   const status = user.status;
   const isPendingApproval = user.pending_approval;
   const isLocalAuthDisabled =
-    account?.settings.local_auth_disabled === true &&
+    account?.settings?.local_auth_disabled === true &&
     user.idp_id === "local";
 
   const getStatusDisplay = () => {


### PR DESCRIPTION
<img width="1516" height="849" alt="Screenshot 2026-02-12 at 12 15 03" src="https://github.com/user-attachments/assets/50ddbd4d-cc59-453a-8a71-e5dfbe0a2d66" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Shows "Disabled" account status when local authentication is turned off.
  * Contextual tooltip content that displays either a local-auth disabled notice (with Learn more) or user approval guidance (with Settings and help links).
  * Tooltip and help icon now appear only when relevant (disabled auth or pending approval).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->