### PR TITLE
 Refactor FullScreenLoading to use boolean prop

### DIFF
--- a/src/app/(dashboard)/(deprecated)/activity/page.tsx
+++ b/src/app/(dashboard)/(deprecated)/activity/page.tsx
@@ -6,5 +6,5 @@ import React from "react";
 
 export default function Redirect() {
   useRedirect("/events/audit");
-  return <FullScreenLoading height={"auto"} />;
+  return <FullScreenLoading fullScreen={false} />;
 }

--- a/src/app/(dashboard)/dns/page.tsx
+++ b/src/app/(dashboard)/dns/page.tsx
@@ -11,5 +11,5 @@ export default function DNS() {
     router.push("/dns/nameservers");
   }, [router]);
 
-  return <FullScreenLoading height={"auto"} />;
+  return <FullScreenLoading fullScreen={false} />;
 }

--- a/src/app/(dashboard)/reverse-proxy/page.tsx
+++ b/src/app/(dashboard)/reverse-proxy/page.tsx
@@ -11,5 +11,5 @@ export default function ReverseProxyRedirectPage() {
     router.replace("/reverse-proxy/services");
   }, [router]);
 
-  return <FullScreenLoading height={"auto"} />;
+  return <FullScreenLoading fullScreen={false} />;
 }

--- a/src/app/(dashboard)/team/page.tsx
+++ b/src/app/(dashboard)/team/page.tsx
@@ -11,5 +11,5 @@ export default function Team() {
     router.push("/team/users");
   }, [router]);
 
-  return <FullScreenLoading height={"auto"} />;
+  return <FullScreenLoading fullScreen={false} />;
 }

--- a/src/components/ui/FullScreenLoading.tsx
+++ b/src/components/ui/FullScreenLoading.tsx
@@ -2,18 +2,17 @@ import { cn } from "@utils/helpers";
 import LoadingIcon from "@/assets/icons/LoadingIcon";
 
 type Props = {
-  height?: "screen" | "auto";
+  fullScreen?: boolean
 };
-export default function FullScreenLoading({ height = "screen" }: Props) {
+export default function FullScreenLoading({ fullScreen = true }: Props) {
   return (
     <div
       className={cn(
         "flex items-center justify-center w-screen",
-        height == "screen" && "h-screen",
-        height == "auto" && "h-auto",
+        fullScreen && "h-screen",
       )}
     >
-      <LoadingIcon className={"fill-netbird"} size={44} />
+      <LoadingIcon className="fill-netbird" size={44} />
     </div>
   );
 }


### PR DESCRIPTION
Simplified the `FullScreenLoading` component by replacing the `height` string union prop (`"screen" | "auto"`) with a `fullScreen` boolean prop. Since  `h-auto` class is default div behaviour, we can use fullScreen boolean to add `h-screen`

### Changes
- Replaced `height?: "screen" | "auto"` with `fullScreen?: boolean` (defaults to `true`)
- Removed redundant `h-auto` class since it's the default CSS behavior
- Removed unnecessary curly braces around static string classNames

This makes the component API more intuitive — `<FullScreenLoading />` for full viewport and `<FullScreenLoading fullScreen={false} />` for auto height — without any behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized loading screen display across dashboard pages (Activity, DNS, Reverse Proxy, Team) by refining the loading indicator component. The component now uses an improved sizing system, with pages displaying loading states in a compact non-fullscreen layout instead of full-height mode, improving visual consistency and user experience during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->