### PR TITLE
fix: preserve SSH query params across OIDC redirect in new window

### DIFF
--- a/src/modules/remote-access/ssh/SSHCredentialsModal.tsx
+++ b/src/modules/remote-access/ssh/SSHCredentialsModal.tsx
@@ -62,8 +62,12 @@ export const SSHCredentialsModal = ({ open, onOpenChange, peer }: Props) => {
     const encodedUsername = encodeURIComponent(username.trim());
     const encodedPort = encodeURIComponent(port.trim());
 
+    const queryString = `id=${peer.id}&user=${encodedUsername}&port=${encodedPort}`;
+
+    localStorage.setItem("netbird-ssh-query-params", queryString);
+
     window.open(
-      `peer/ssh?id=${peer.id}&user=${encodedUsername}&port=${encodedPort}`,
+      `peer/ssh?${queryString}`,
       "_blank",
       "noopener,noreferrer,width=800,height=450,left=100,top=100,location=no,toolbar=no,menubar=no,status=no",
     );

--- a/src/modules/remote-access/ssh/useSSHQueryParams.ts
+++ b/src/modules/remote-access/ssh/useSSHQueryParams.ts
@@ -16,7 +16,7 @@ export function useSSHQueryParams() {
     username: null,
     port: null,
   });
-  const [, setLocalQueryParams] = useLocalStorage("netbird-query-params", "");
+  const [, setLocalQueryParams] = useLocalStorage("netbird-ssh-query-params", "");
 
   useEffect(() => {
     const peerId = searchParams.get("id");
@@ -30,7 +30,7 @@ export function useSSHQueryParams() {
     }
 
     // Otherwise, try to restore from localStorage
-    const storedParams = localStorage.getItem("netbird-query-params");
+    const storedParams = localStorage.getItem("netbird-ssh-query-params");
     if (!storedParams) return;
 
     // Handle JSON encoded strings from localStorage


### PR DESCRIPTION
On self-hosted deployments, clicking SSH on a peer opens a new window via `window.open()`. The new window has no auth session, so it triggers an OIDC redirect that strips the query parameters (`id`, `user`, `port`). After authentication, the page loads at `/peer/ssh` without any params and hangs at "Starting SSH Session...".

The existing `localStorage` fallback in `useSSHQueryParams` reads from `"netbird-query-params"`, but `SecureProvider` clears that key when `isAuthenticated` becomes `true` — which happens **before** the SSH page component mounts (`OidcSecure` blocks children until authenticated). So even if params were saved, they get wiped before they can be read.

This fix saves the SSH params to a dedicated `"netbird-ssh-query-params"` localStorage key before opening the new window. Since `SecureProvider` does not touch this key, `useSSHQueryParams` can restore the params after the OIDC redirect completes.

Fixes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SSH credential parameter storage and retrieval mechanism for improved consistency in local storage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->