### PR TITLE
Add hover to reverse proxy auth methods

### DIFF
--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -6,24 +6,26 @@ export const ListItem = ({
   label,
   value,
   className,
+  children,
 }: {
   icon?: React.ReactNode;
   label: string;
   value: string | React.ReactNode;
   className?: string;
+  children?: React.ReactNode;
 }) => {
   return (
     <div
-      className={cn(
-        "flex justify-between gap-12 border-b border-nb-gray-920 py-2 px-4 last:border-b-0",
-        className,
-      )}
+      className={cn(" border-b border-nb-gray-920  last:border-b-0", className)}
     >
-      <div className={"flex items-center gap-2 text-nb-gray-100 font-medium"}>
-        {icon}
-        {label}
+      <div className={cn("flex justify-between gap-12 py-2 px-4")}>
+        <div className={"flex items-center gap-2 text-nb-gray-100 font-medium"}>
+          {icon}
+          {label}
+        </div>
+        <div className={"text-nb-gray-300"}>{value}</div>
       </div>
-      <div className={"text-nb-gray-300"}>{value}</div>
+      {children}
     </div>
   );
 };

--- a/src/contexts/UsersProvider.tsx
+++ b/src/contexts/UsersProvider.tsx
@@ -28,14 +28,30 @@ const UserProfileContext = React.createContext(
 );
 
 export default function UsersProvider({ children }: Readonly<Props>) {
-  const { data: users, mutate, isLoading } = useFetchApi<User[]>("/users");
+  const { data: users, mutate, isLoading } = useFetchApi<User[]>(
+    "/users?service_user=false",
+  );
+  const { data: serviceUsers, mutate: mutateServiceUsers, isLoading: isLoadingServiceUsers } = useFetchApi<
+    User[]
+  >("/users?service_user=true");
 
   const refresh = () => {
     mutate().then();
+    mutateServiceUsers().then();
   };
 
+  const allUsers = useMemo(() => {
+    return [...(users ?? []), ...(serviceUsers ?? [])];
+  }, [users, serviceUsers]);
+
   return (
-    <UsersContext.Provider value={{ users, refresh, isLoading }}>
+    <UsersContext.Provider
+      value={{
+        users: allUsers,
+        refresh,
+        isLoading: isLoading || isLoadingServiceUsers,
+      }}
+    >
       <UserProfileProvider>{children}</UserProfileProvider>
     </UsersContext.Provider>
   );

--- a/src/modules/reverse-proxy/table/ReverseProxyAuthCell.tsx
+++ b/src/modules/reverse-proxy/table/ReverseProxyAuthCell.tsx
@@ -1,10 +1,50 @@
 import Badge from "@components/Badge";
 import Button from "@components/Button";
-import { Settings, ShieldCheck, ShieldOff } from "lucide-react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@components/HoverCard";
+import { ListItem } from "@components/ListItem";
+import GroupBadge from "@components/ui/GroupBadge";
+import { UserCountStack } from "@components/ui/MultipleGroups";
+import {
+  ArrowRightIcon,
+  Binary,
+  LucideIcon,
+  RectangleEllipsis,
+  Settings,
+  ShieldCheck,
+  ShieldOff,
+  Users,
+} from "lucide-react";
 import * as React from "react";
+import { useGroups } from "@/contexts/GroupsProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { useReverseProxies } from "@/contexts/ReverseProxiesProvider";
+import { Group } from "@/interfaces/Group";
 import { ReverseProxy } from "@/interfaces/ReverseProxy";
+
+const AUTH_METHODS: {
+  key: "password_auth" | "pin_auth" | "bearer_auth";
+  label: string;
+  hoverLabel: string;
+  Icon: LucideIcon;
+}[] = [
+  {
+    key: "password_auth",
+    label: "Password",
+    hoverLabel: "Password",
+    Icon: RectangleEllipsis,
+  },
+  { key: "pin_auth", label: "PIN Code", hoverLabel: "PIN Code", Icon: Binary },
+  {
+    key: "bearer_auth",
+    label: "SSO",
+    hoverLabel: "SSO (Single Sign On)",
+    Icon: Users,
+  },
+];
 
 type Props = {
   reverseProxy: ReverseProxy;
@@ -15,14 +55,36 @@ export default function ReverseProxyAuthCell({
 }: Readonly<Props>) {
   const { permission } = usePermissions();
   const { openModal } = useReverseProxies();
+  const { groups } = useGroups();
   const auth = reverseProxy.auth;
 
-  const enabledCount = [
-    auth?.bearer_auth?.enabled,
-    auth?.link_auth?.enabled,
-    auth?.password_auth?.enabled,
-    auth?.pin_auth?.enabled,
-  ].filter(Boolean).length;
+  const enabled = AUTH_METHODS.filter((m) => auth?.[m.key]?.enabled);
+
+  const ssoGroups = auth?.bearer_auth?.enabled
+    ? (auth.bearer_auth.distribution_groups ?? [])
+        .map((groupId) => groups?.find((g) => g.id === groupId))
+        .filter((g): g is Group => g != undefined)
+    : [];
+
+  const showHoverContent =
+    enabled.length > 1 || (enabled.length === 1 && auth?.bearer_auth?.enabled);
+
+  const SingleIcon = enabled.length === 1 ? enabled[0].Icon : null;
+
+  const badgeContent =
+    SingleIcon ? (
+      <>
+        <SingleIcon size={12} className="text-green-500" />
+        <span className={"font-medium text-xs"}>{enabled[0].label}</span>
+      </>
+    ) : enabled.length > 1 ? (
+      <>
+        <ShieldCheck size={12} className="text-green-400" />
+        <span className={"font-medium text-xs"}>
+          {enabled.length} Enabled
+        </span>
+      </>
+    ) : null;
 
   return (
     <div
@@ -32,19 +94,66 @@ export default function ReverseProxyAuthCell({
         openModal({ proxy: reverseProxy, initialTab: "auth" });
       }}
     >
-      {enabledCount > 0 ? (
-        <Badge variant={"gray"} useHover={false} className={"cursor-pointer"}>
-          <ShieldCheck size={12} className="text-green-400" />
-          <div>
-            <span className={"font-medium text-xs"}>Enabled</span>
-          </div>
-        </Badge>
-      ) : (
-        <Badge variant={"gray"}>
-          <ShieldOff size={12} className="text-red-500" />
-          <span className={"font-medium text-xs"}>None</span>
-        </Badge>
-      )}
+      <HoverCard openDelay={200} closeDelay={100}>
+        <HoverCardTrigger asChild={true}>
+          {badgeContent ? (
+            <Badge
+              variant={"gray"}
+              useHover={false}
+              className={"cursor-pointer"}
+            >
+              {badgeContent}
+            </Badge>
+          ) : (
+            <Badge variant={"gray"}>
+              <ShieldOff size={12} className="text-red-500" />
+              <span className={"font-medium text-xs"}>None</span>
+            </Badge>
+          )}
+        </HoverCardTrigger>
+        {showHoverContent && (
+          <HoverCardContent
+            className={"p-0"}
+            sideOffset={14}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className={"text-xs"}>
+              {enabled.map(({ key, hoverLabel, Icon }) => (
+                <ListItem
+                  key={key}
+                  className={"py-0.5"}
+                  icon={<Icon size={14} />}
+                  label={hoverLabel}
+                  value={
+                    <div className={"text-green-500"}>
+                      {key === "bearer_auth" && ssoGroups.length === 0
+                        ? "All Users"
+                        : "Enabled"}
+                    </div>
+                  }
+                >
+                  {key === "bearer_auth" && ssoGroups.length > 0 && (
+                    <div className={"flex flex-col gap-2 px-4 pt-2 pb-3"}>
+                      {ssoGroups.map((group) => (
+                        <div
+                          key={group.id}
+                          className={
+                            "flex gap-2 items-center justify-between"
+                          }
+                        >
+                          <GroupBadge group={group} />
+                          <ArrowRightIcon size={14} />
+                          <UserCountStack group={group} />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </ListItem>
+              ))}
+            </div>
+          </HoverCardContent>
+        )}
+      </HoverCard>
 
       <Button
         size={"xs"}

--- a/src/modules/reverse-proxy/table/ReverseProxyTable.tsx
+++ b/src/modules/reverse-proxy/table/ReverseProxyTable.tsx
@@ -75,7 +75,7 @@ const ReverseProxyColumns: ColumnDef<ReverseProxy>[] = [
   {
     accessorKey: "auth",
     header: ({ column }) => {
-      return <DataTableHeader column={column}>Authentication</DataTableHeader>;
+      return <DataTableHeader column={column}>Auth Methods</DataTableHeader>;
     },
     cell: ({ row }) => <ReverseProxyAuthCell reverseProxy={row.original} />,
   },

--- a/src/modules/reverse-proxy/targets/flat/ReverseProxyFlatTargetsTable.tsx
+++ b/src/modules/reverse-proxy/targets/flat/ReverseProxyFlatTargetsTable.tsx
@@ -104,7 +104,7 @@ const FlatTargetsTableColumns: ColumnDef<ReverseProxyFlatTarget>[] = [
   {
     accessorKey: "auth",
     header: ({ column }) => (
-      <DataTableHeader column={column}>Authentication</DataTableHeader>
+      <DataTableHeader column={column}>Auth Methods</DataTableHeader>
     ),
     cell: ({ row }) => (
       <ReverseProxyAuthCell reverseProxy={row.original.proxy} />


### PR DESCRIPTION
If multiple auth methods show count and hover
<img width="435" height="280" alt="CleanShot 2026-02-17 at 15 13 54" src="https://github.com/user-attachments/assets/a22ed1d5-761c-46db-868f-ad23717e6d0d" /><

When only one auth method show it directly
<img width="352" height="152" alt="CleanShot 2026-02-17 at 15 14 23" src="https://github.com/user-attachments/assets/cc27b368-ac2a-4488-af43-a6a0ef2ebc33" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ListItem component now supports rendering additional child content
  * Reverse proxy authentication display now includes interactive hover details showing enabled authentication methods and associated user groups

* **Improvements**
  * User list now includes both regular and service user accounts
  * Authentication column headers renamed to "Auth Methods" for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->