### PR TITLE
Fix stale certificate issued state

### DIFF
--- a/src/modules/reverse-proxy/table/ReverseProxyStatusCell.tsx
+++ b/src/modules/reverse-proxy/table/ReverseProxyStatusCell.tsx
@@ -31,7 +31,7 @@ export default function ReverseProxyStatusCell({
     !!meta?.certificate_issued_at ||
     !!dataRef.current?.meta?.certificate_issued_at;
 
-  const shouldPoll = !!enabled && !certificateIssued;
+  const shouldPoll = !!enabled && !(isActive && certificateIssued);
 
   const { data } = useFetchApi<ReverseProxy>(
     `/reverse-proxies/services/${serviceId}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse proxy status display to more reliably reflect certificate issuance and service readiness.
  * Refined polling so status checks stop/start based on actual readiness and certificate state.
  * Clarified UI status indicators to consistently show "Issuing certificate..." and "Setting up service..." at the correct times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->