### PR TITLE
Add support for multiple targets for the announcement banner

### DIFF
--- a/announcements.json
+++ b/announcements.json
@@ -7,6 +7,6 @@
     "variant": "important",
     "isExternal": true,
     "closeable": true,
-    "isCloudOnly": false
+    "targets": ["selfhosted"]
   }
 ]

--- a/src/contexts/AnnouncementProvider.tsx
+++ b/src/contexts/AnnouncementProvider.tsx
@@ -8,13 +8,14 @@ import React, {
   useState,
 } from "react";
 import { usePermissions } from "@/contexts/PermissionsProvider";
-import { isLocalDev, isNetBirdHosted } from "@utils/netbird";
+import { isLocalDev } from "@utils/netbird";
 import announcementFile from "../../announcements.json";
 
 const ANNOUNCEMENTS_URL =
   "https://raw.githubusercontent.com/netbirdio/dashboard/main/announcements.json";
 const STORAGE_KEY = "netbird-announcements";
 const CACHE_DURATION_MS = 30 * 60 * 1000;
+const TARGET = "selfhosted";
 const BANNER_HEIGHT = 40;
 
 interface AnnouncementStore {
@@ -30,7 +31,7 @@ export interface Announcement extends AnnouncementVariant {
   linkText?: string;
   isExternal?: boolean;
   closeable: boolean;
-  isCloudOnly: boolean;
+  targets?: string[];
 }
 
 interface AnnouncementInfo extends Announcement {
@@ -76,8 +77,7 @@ const getAnnouncements = async (): Promise<AnnouncementInfo[]> => {
       raw = await response.json();
     }
 
-    const isCloud = isNetBirdHosted();
-    const filtered = raw.filter((a) => !a.isCloudOnly || isCloud);
+    const filtered = raw.filter((a) => a.targets?.includes(TARGET));
     const hashes = new Set(filtered.map((a) => md5(a.text).toString()));
     const closed = (stored?.closedAnnouncements ?? []).filter((h) =>
       hashes.has(h),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated announcement targeting system from a simple flag to a flexible array-based deployment targeting approach, enabling more granular control over which deployments receive specific announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->