### PR TITLE
Add IPv6 overlay settings and peer display

### DIFF
--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -526,7 +526,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             copyText={"NetBird IP Address"}
             label={
               <>
-                <MapPin size={16} />
+                <MapPin size={16} className={"shrink-0"} />
                 NetBird IP Address
               </>
             }
@@ -547,7 +547,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
               copyText={"NetBird IPv6 Address"}
               label={
                 <>
-                  <MapPin size={16} />
+                  <MapPin size={16} className={"shrink-0"} />
                   NetBird IPv6 Address
                 </>
               }
@@ -567,7 +567,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             copyText={"Public IP Address"}
             label={
               <>
-                <NetworkIcon size={16} />
+                <NetworkIcon size={16} className={"shrink-0"} />
                 Public IP Address
               </>
             }
@@ -579,7 +579,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             copyText={"DNS label"}
             label={
               <>
-                <Globe size={16} />
+                <Globe size={16} className={"shrink-0"} />
                 Domain Name
               </>
             }
@@ -597,7 +597,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             copyText={"Hostname"}
             label={
               <>
-                <MonitorSmartphoneIcon size={16} />
+                <MonitorSmartphoneIcon size={16} className={"shrink-0"} />
                 Hostname
               </>
             }
@@ -607,7 +607,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
           <Card.ListItem
             label={
               <>
-                <FlagIcon size={16} />
+                <FlagIcon size={16} className={"shrink-0"} />
                 Region
               </>
             }
@@ -637,7 +637,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
           <Card.ListItem
             label={
               <>
-                <Cpu size={16} />
+                <Cpu size={16} className={"shrink-0"} />
                 Operating System
               </>
             }
@@ -648,7 +648,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             <Card.ListItem
               label={
                 <>
-                  <Barcode size={16} />
+                  <Barcode size={16} className={"shrink-0"} />
                   Serial Number
                 </>
               }
@@ -660,7 +660,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             <Card.ListItem
               label={
                 <>
-                  <CalendarDays size={16} />
+                  <CalendarDays size={16} className={"shrink-0"} />
                   Registered on
                 </>
               }
@@ -676,7 +676,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
           <Card.ListItem
             label={
               <>
-                <History size={16} />
+                <History size={16} className={"shrink-0"} />
                 Last seen
               </>
             }
@@ -693,7 +693,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
           <Card.ListItem
             label={
               <>
-                <NetBirdIcon size={16} />
+                <NetBirdIcon size={16} className={"shrink-0"} />
                 Agent Version
               </>
             }
@@ -704,7 +704,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             <Card.ListItem
               label={
                 <>
-                  <NetBirdIcon size={16} />
+                  <NetBirdIcon size={16} className={"shrink-0"} />
                   UI Version
                 </>
               }

--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -2,8 +2,6 @@
 
 import Breadcrumbs from "@components/Breadcrumbs";
 import Button from "@components/Button";
-import { Callout } from "@components/Callout";
-import cidr from "ip-cidr";
 import Card from "@components/Card";
 import HelpText from "@components/HelpText";
 import { Input } from "@components/Input";
@@ -73,6 +71,7 @@ import ReverseProxiesProvider, {
   useReverseProxies,
 } from "@/contexts/ReverseProxiesProvider";
 import { ReverseProxyFlatTargetsTabContent } from "@/modules/reverse-proxy/targets/flat/ReverseProxyFlatTargetsTabContent";
+import { PeerEditIPModal } from "@/modules/peer/PeerEditIPModal";
 import { PeerSSHToggle } from "@/modules/peer/PeerSSHToggle";
 import { RDPButton } from "@/modules/remote-access/rdp/RDPButton";
 import { SSHButton } from "@/modules/remote-access/ssh/SSHButton";
@@ -477,42 +476,48 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
     return getRegionByPeer(peer);
   }, [getRegionByPeer, peer]);
 
+  const handleSaveIP = (newIP: string) => {
+    notify({
+      title: peer.name,
+      description: "NetBird Peer IP was successfully updated",
+      promise: update({ ip: newIP }).then(() => {
+        mutate("/peers/" + peer.id);
+        setShowEditIPModal(false);
+      }),
+      loadingMessage: "Updating peer IP...",
+    });
+  };
+
+  const handleSaveIPv6 = (newIPv6: string) => {
+    notify({
+      title: peer.name,
+      description: "NetBird Peer IPv6 was successfully updated",
+      promise: update({ ipv6: newIPv6 }).then(() => {
+        mutate("/peers/" + peer.id);
+        setShowEditIPv6Modal(false);
+      }),
+      loadingMessage: "Updating peer IPv6...",
+    });
+  };
+
   return (
     <>
-      <Modal open={showEditIPModal} onOpenChange={setShowEditIPModal}>
-        <EditIPModal
-          onSuccess={(newIP) => {
-            notify({
-              title: peer.name,
-              description: "Peer IP was successfully updated",
-              promise: update({ ip: newIP }).then(() => {
-                mutate("/peers/" + peer.id);
-                setShowEditIPModal(false);
-              }),
-              loadingMessage: "Updating peer IP...",
-            });
-          }}
-          peer={peer}
-          key={showEditIPModal ? 1 : 0}
-        />
-      </Modal>
-      <Modal open={showEditIPv6Modal} onOpenChange={setShowEditIPv6Modal}>
-        <EditIPv6Modal
-          onSuccess={(newIPv6) => {
-            notify({
-              title: peer.name,
-              description: "Peer IPv6 was successfully updated",
-              promise: update({ ipv6: newIPv6 }).then(() => {
-                mutate("/peers/" + peer.id);
-                setShowEditIPv6Modal(false);
-              }),
-              loadingMessage: "Updating peer IPv6...",
-            });
-          }}
-          peer={peer}
-          key={showEditIPv6Modal ? 1 : 0}
-        />
-      </Modal>
+      <PeerEditIPModal
+        version="v4"
+        currentIP={peer.ip}
+        open={showEditIPModal}
+        onOpenChange={setShowEditIPModal}
+        onSave={handleSaveIP}
+        key={showEditIPModal ? "v4-open" : "v4-closed"}
+      />
+      <PeerEditIPModal
+        version="v6"
+        currentIP={peer.ipv6 || ""}
+        open={showEditIPv6Modal}
+        onOpenChange={setShowEditIPv6Modal}
+        onSave={handleSaveIPv6}
+        key={showEditIPv6Modal ? "v6-open" : "v6-closed"}
+      />
       <Card className={"w-full xl:w-1/2"}>
         <Card.List>
           <Card.ListItem
@@ -527,20 +532,11 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             }
             valueToCopy={peer.ip}
             value={
-              <div className="flex items-center gap-2 justify-between w-full">
-                <span>{peer.ip}</span>
-                {permission.peers.update && (
-                  <button
-                    className="flex w-7 h-7 items-center justify-center gap-2 text-nb-gray-400 hover:text-neutral-100 transition-all hover:bg-nb-gray-800/60 rounded-md cursor-pointer"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowEditIPModal(true);
-                    }}
-                  >
-                    <PencilIcon size={14} />
-                  </button>
-                )}
-              </div>
+              <EditableValue
+                value={peer.ip}
+                canEdit={permission.peers.update}
+                onEdit={() => setShowEditIPModal(true)}
+              />
             }
           />
 
@@ -557,20 +553,11 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
               }
               valueToCopy={peer.ipv6}
               value={
-                <div className="flex items-center gap-2 justify-between w-full">
-                  <span>{peer.ipv6}</span>
-                  {permission.peers.update && (
-                    <button
-                      className="flex w-7 h-7 items-center justify-center gap-2 text-nb-gray-400 hover:text-neutral-100 transition-all hover:bg-nb-gray-800/60 rounded-md cursor-pointer"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setShowEditIPv6Modal(true);
-                      }}
-                    >
-                      <PencilIcon size={14} />
-                    </button>
-                  )}
-                </div>
+                <EditableValue
+                  value={peer.ipv6}
+                  canEdit={permission.peers.update}
+                  onEdit={() => setShowEditIPv6Modal(true)}
+                />
               }
             />
           )}
@@ -815,160 +802,29 @@ function EditNameModal({ onSuccess, peer, initialName }: Readonly<ModalProps>) {
   );
 }
 
-interface EditIPModalProps {
-  onSuccess: (ip: string) => void;
-  peer: Peer;
-}
-
-function EditIPModal({ onSuccess, peer }: Readonly<EditIPModalProps>) {
-  const [ip, setIP] = useState(peer.ip);
-  const [error, setError] = useState("");
-
-  const validateIP = (ipAddress: string) => {
-    const ipRegex =
-      /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-    return ipRegex.test(ipAddress);
-  };
-
-  const isDisabled = useMemo(() => {
-    if (ip === peer.ip) return true;
-    const trimmedIP = trim(ip);
-    return trimmedIP.length === 0 || !validateIP(ip);
-  }, [ip, peer.ip]);
-
-  React.useEffect(() => {
-    switch (true) {
-      case ip === peer.ip:
-        setError("");
-        break;
-      case !validateIP(ip):
-        setError("Please enter a valid IP, e.g., 100.64.0.15");
-        break;
-      default:
-        setError("");
-        break;
-    }
-  }, [ip, peer.ip]);
-
+function EditableValue({
+  value,
+  canEdit,
+  onEdit,
+}: {
+  value: string;
+  canEdit: boolean;
+  onEdit: () => void;
+}) {
   return (
-    <ModalContent maxWidthClass={"max-w-md"}>
-      <form>
-        <ModalHeader
-          title={"Edit Peer IP Address"}
-          description={"Update the NetBird IP address for this peer."}
-          color={"blue"}
-        />
-
-        <div className={"p-default flex flex-col gap-4"}>
-          <div>
-            <Input
-              placeholder={"e.g., 100.64.0.15"}
-              value={ip}
-              onChange={(e) => setIP(e.target.value)}
-              error={error}
-            />
-          </div>
-
-          <Callout>Changes take effect when the peer reconnects.</Callout>
-        </div>
-
-        <ModalFooter className={"items-center"} separator={false}>
-          <div className={"flex gap-3 w-full justify-end"}>
-            <ModalClose asChild={true}>
-              <Button variant={"secondary"} className={"w-full"}>
-                Cancel
-              </Button>
-            </ModalClose>
-
-            <Button
-              variant={"primary"}
-              className={"w-full"}
-              onClick={() => onSuccess(ip)}
-              disabled={isDisabled}
-            >
-              Save
-            </Button>
-          </div>
-        </ModalFooter>
-      </form>
-    </ModalContent>
-  );
-}
-
-interface EditIPv6ModalProps {
-  onSuccess: (ipv6: string) => void;
-  peer: Peer;
-}
-
-function isValidIPv6(address: string): boolean {
-  return cidr.isValidAddress(address) && address.includes(":");
-}
-
-function EditIPv6Modal({ onSuccess, peer }: Readonly<EditIPv6ModalProps>) {
-  const [ipv6, setIPv6] = useState(peer.ipv6 || "");
-  const [error, setError] = useState("");
-
-  const isDisabled = useMemo(() => {
-    if (ipv6 === peer.ipv6) return true;
-    const trimmed = trim(ipv6);
-    return trimmed.length === 0 || !isValidIPv6(trimmed);
-  }, [ipv6, peer.ipv6]);
-
-  React.useEffect(() => {
-    switch (true) {
-      case ipv6 === peer.ipv6:
-        setError("");
-        break;
-      case !isValidIPv6(trim(ipv6)):
-        setError("Please enter a valid IPv6 address, e.g., fd00:1234::1");
-        break;
-      default:
-        setError("");
-        break;
-    }
-  }, [ipv6, peer.ipv6]);
-
-  return (
-    <ModalContent maxWidthClass={"max-w-md"}>
-      <form>
-        <ModalHeader
-          title={"Edit Peer IPv6 Address"}
-          description={"Update the NetBird IPv6 address for this peer."}
-          color={"blue"}
-        />
-
-        <div className={"p-default flex flex-col gap-4"}>
-          <div>
-            <Input
-              placeholder={"e.g., fd00:1234::1"}
-              value={ipv6}
-              onChange={(e) => setIPv6(e.target.value)}
-              error={error}
-            />
-          </div>
-
-          <Callout>Changes take effect when the peer reconnects.</Callout>
-        </div>
-
-        <ModalFooter className={"items-center"} separator={false}>
-          <div className={"flex gap-3 w-full justify-end"}>
-            <ModalClose asChild={true}>
-              <Button variant={"secondary"} className={"w-full"}>
-                Cancel
-              </Button>
-            </ModalClose>
-
-            <Button
-              variant={"primary"}
-              className={"w-full"}
-              onClick={() => onSuccess(ipv6.trim())}
-              disabled={isDisabled}
-            >
-              Save
-            </Button>
-          </div>
-        </ModalFooter>
-      </form>
-    </ModalContent>
+    <div className="flex items-center gap-2 justify-between w-full">
+      <span>{value}</span>
+      {canEdit && (
+        <button
+          className="flex w-7 h-7 items-center justify-center gap-2 text-nb-gray-400 hover:text-neutral-100 transition-all hover:bg-nb-gray-800/60 rounded-md cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
+        >
+          <PencilIcon size={14} />
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -3,6 +3,7 @@
 import Breadcrumbs from "@components/Breadcrumbs";
 import Button from "@components/Button";
 import { Callout } from "@components/Callout";
+import cidr from "ip-cidr";
 import Card from "@components/Card";
 import HelpText from "@components/HelpText";
 import { Input } from "@components/Input";
@@ -469,6 +470,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
   const { update } = usePeer();
   const { mutate } = useSWRConfig();
   const [showEditIPModal, setShowEditIPModal] = useState(false);
+  const [showEditIPv6Modal, setShowEditIPv6Modal] = useState(false);
   const { permission } = usePermissions();
 
   const countryText = useMemo(() => {
@@ -492,6 +494,23 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
           }}
           peer={peer}
           key={showEditIPModal ? 1 : 0}
+        />
+      </Modal>
+      <Modal open={showEditIPv6Modal} onOpenChange={setShowEditIPv6Modal}>
+        <EditIPv6Modal
+          onSuccess={(newIPv6) => {
+            notify({
+              title: peer.name,
+              description: "Peer IPv6 was successfully updated",
+              promise: update({ ipv6: newIPv6 }).then(() => {
+                mutate("/peers/" + peer.id);
+                setShowEditIPv6Modal(false);
+              }),
+              loadingMessage: "Updating peer IPv6...",
+            });
+          }}
+          peer={peer}
+          key={showEditIPv6Modal ? 1 : 0}
         />
       </Modal>
       <Card className={"w-full xl:w-1/2"}>
@@ -524,6 +543,37 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
               </div>
             }
           />
+
+          {peer.ipv6 && (
+            <Card.ListItem
+              copy
+              tooltip={false}
+              copyText={"NetBird IPv6 Address"}
+              label={
+                <>
+                  <MapPin size={16} />
+                  NetBird IPv6 Address
+                </>
+              }
+              valueToCopy={peer.ipv6}
+              value={
+                <div className="flex items-center gap-2 justify-between w-full">
+                  <span>{peer.ipv6}</span>
+                  {permission.peers.update && (
+                    <button
+                      className="flex w-7 h-7 items-center justify-center gap-2 text-nb-gray-400 hover:text-neutral-100 transition-all hover:bg-nb-gray-800/60 rounded-md cursor-pointer"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowEditIPv6Modal(true);
+                      }}
+                    >
+                      <PencilIcon size={14} />
+                    </button>
+                  )}
+                </div>
+              }
+            />
+          )}
 
           <Card.ListItem
             copy
@@ -834,6 +884,84 @@ function EditIPModal({ onSuccess, peer }: Readonly<EditIPModalProps>) {
               variant={"primary"}
               className={"w-full"}
               onClick={() => onSuccess(ip)}
+              disabled={isDisabled}
+            >
+              Save
+            </Button>
+          </div>
+        </ModalFooter>
+      </form>
+    </ModalContent>
+  );
+}
+
+interface EditIPv6ModalProps {
+  onSuccess: (ipv6: string) => void;
+  peer: Peer;
+}
+
+function isValidIPv6(address: string): boolean {
+  return cidr.isValidAddress(address) && address.includes(":");
+}
+
+function EditIPv6Modal({ onSuccess, peer }: Readonly<EditIPv6ModalProps>) {
+  const [ipv6, setIPv6] = useState(peer.ipv6 || "");
+  const [error, setError] = useState("");
+
+  const isDisabled = useMemo(() => {
+    if (ipv6 === peer.ipv6) return true;
+    const trimmed = trim(ipv6);
+    return trimmed.length === 0 || !isValidIPv6(trimmed);
+  }, [ipv6, peer.ipv6]);
+
+  React.useEffect(() => {
+    switch (true) {
+      case ipv6 === peer.ipv6:
+        setError("");
+        break;
+      case !isValidIPv6(trim(ipv6)):
+        setError("Please enter a valid IPv6 address, e.g., fd00:1234::1");
+        break;
+      default:
+        setError("");
+        break;
+    }
+  }, [ipv6, peer.ipv6]);
+
+  return (
+    <ModalContent maxWidthClass={"max-w-md"}>
+      <form>
+        <ModalHeader
+          title={"Edit Peer IPv6 Address"}
+          description={"Update the NetBird IPv6 address for this peer."}
+          color={"blue"}
+        />
+
+        <div className={"p-default flex flex-col gap-4"}>
+          <div>
+            <Input
+              placeholder={"e.g., fd00:1234::1"}
+              value={ipv6}
+              onChange={(e) => setIPv6(e.target.value)}
+              error={error}
+            />
+          </div>
+
+          <Callout>Changes take effect when the peer reconnects.</Callout>
+        </div>
+
+        <ModalFooter className={"items-center"} separator={false}>
+          <div className={"flex gap-3 w-full justify-end"}>
+            <ModalClose asChild={true}>
+              <Button variant={"secondary"} className={"w-full"}>
+                Cancel
+              </Button>
+            </ModalClose>
+
+            <Button
+              variant={"primary"}
+              className={"w-full"}
+              onClick={() => onSuccess(ipv6.trim())}
               disabled={isDisabled}
             >
               Save

--- a/src/app/(remote-access)/peer/ssh/page.tsx
+++ b/src/app/(remote-access)/peer/ssh/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@utils/version";
 
 export default function SSHPage() {
-  const { peerId, username, port } = useSSHQueryParams();
+  const { peerId, username, port, ipVersion } = useSSHQueryParams();
 
   const {
     data: peer,
@@ -48,6 +48,7 @@ export default function SSHPage() {
           peer={peer}
           username={username}
           port={port}
+          ipVersion={ipVersion}
         />
       ) : (
         <LoadingMessage message={"Starting ssh session..."} />
@@ -60,9 +61,10 @@ type Props = {
   username: string;
   port: string;
   peer: Peer;
+  ipVersion: string | null;
 };
 
-function SSHTerminal({ username, port, peer }: Props) {
+function SSHTerminal({ username, port, peer, ipVersion }: Props) {
   const client = useNetBirdClient();
   const connected = useRef(false);
   const sshConnectedOnce = useRef(false);
@@ -81,9 +83,12 @@ function SSHTerminal({ username, port, peer }: Props) {
   const isClientDisconnected = client.status === NetBirdStatus.DISCONNECTED;
   const isClientConnecting = client.status === NetBirdStatus.CONNECTING;
 
+  // Use the FQDN when an IP version is specified so the dialer resolves to the correct address family.
+  const sshHost = ipVersion ? peer.dns_label || peer.ip : peer.ip;
+
   useEffect(() => {
-    document.title = `${username}@${peer.ip} - ${peer.hostname}`;
-  }, [username, peer, client]);
+    document.title = `${username}@${sshHost} - ${peer.hostname}`;
+  }, [username, peer, client, sshHost]);
 
   const handleReconnect = async () => {
     if (!peer?.id) return;
@@ -97,9 +102,10 @@ function SSHTerminal({ username, port, peer }: Props) {
       const rules = [`${protocol}/${aclPort}`];
       await client?.connectTemporary(peer.id, rules);
       await ssh({
-        hostname: peer.ip,
+        hostname: sshHost,
         port: Number(port),
         username,
+        ipVersion: ipVersion || undefined,
       });
     } catch (error) {
       console.error("Reconnection failed:", error);
@@ -123,9 +129,10 @@ function SSHTerminal({ username, port, peer }: Props) {
         const rules = [`${protocol}/${aclPort}`];
         await client?.connectTemporary(peer.id, rules);
         const res = await ssh({
-          hostname: peer.ip,
+          hostname: sshHost,
           port: Number(port),
           username,
+          ipVersion: ipVersion || undefined,
         });
         if (res === SSHStatus.CONNECTED) {
           sshConnectedOnce.current = true;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -54,7 +54,7 @@ function CardListItem({
         className,
       )}
     >
-      <div className={"flex gap-2.5 items-center text-sm"}>{label}</div>
+      <div className={"flex gap-2.5 items-center text-[0.84rem]"}>{label}</div>
       <div className={"flex flex-col gap-2"}>
         <CardTextItem
           label={label}
@@ -100,7 +100,7 @@ const CardTextItem = ({
   return (
     <div
       className={cn(
-        "text-right text-nb-gray-400 text-sm flex items-center gap-2",
+        "text-right text-nb-gray-400 text-[0.84rem] flex items-center gap-2",
         copy && "cursor-pointer hover:text-nb-gray-300 transition-all",
       )}
       onClick={() =>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -50,7 +50,7 @@ function CardListItem({
   return (
     <li
       className={cn(
-        "flex justify-between px-4 border-b border-nb-gray-900 py-4 last:border-b-0 items-center h-full",
+        "flex justify-between px-4 border-b border-nb-gray-900 py-3.5 last:border-b-0 items-center h-full",
         className,
       )}
     >

--- a/src/components/DeviceCard.tsx
+++ b/src/components/DeviceCard.tsx
@@ -28,8 +28,13 @@ export const DeviceCard = ({
   const descriptionText = useMemo(() => {
     return description !== undefined
       ? description
-      : address || device?.ip || resource?.address;
-  }, [description, address, device]);
+      : address ||
+        (device?.ip
+          ? device.ipv6
+            ? `${device.ip}, ${device.ipv6}`
+            : device.ip
+          : resource?.address);
+  }, [description, address, device, resource]);
 
   return (
     <div

--- a/src/components/DeviceCard.tsx
+++ b/src/components/DeviceCard.tsx
@@ -28,13 +28,8 @@ export const DeviceCard = ({
   const descriptionText = useMemo(() => {
     return description !== undefined
       ? description
-      : address ||
-        (device?.ip
-          ? device.ipv6
-            ? `${device.ip}, ${device.ipv6}`
-            : device.ip
-          : resource?.address);
-  }, [description, address, device, resource]);
+      : address || device?.ip || resource?.address;
+  }, [description, address, device]);
 
   return (
     <div

--- a/src/components/PeerGroupSelector.tsx
+++ b/src/components/PeerGroupSelector.tsx
@@ -290,7 +290,7 @@ export function PeerGroupSelector({
   const searchPlaceholder = useMemo(() => {
     if (tab === "groups") return placeholderForSearch;
     if (tab === "resources") return "Search resource...";
-    if (tab === "peers") return "Search peer...";
+    if (tab === "peers") return "Search peer by name or ip...";
     return "Search...";
   }, [tab, placeholderForSearch]);
 
@@ -537,9 +537,6 @@ export function PeerGroupSelector({
                       const isSelected =
                         values.find((group) => group.name == option.name) !=
                         undefined;
-                      const peerCount =
-                        option.peers?.length ?? option?.peers_count ?? 0;
-
                       const isDisabled = disabledGroups
                         ? disabledGroups?.findIndex(
                             (g) => g.id === option.id,
@@ -1060,7 +1057,6 @@ const PeersList = ({
                   }
                 >
                   {res.ip}
-                  {res.ipv6 && `, ${res.ipv6}`}
                   <RadioItem value={res.id} />
                 </div>
               </div>

--- a/src/components/PeerGroupSelector.tsx
+++ b/src/components/PeerGroupSelector.tsx
@@ -968,7 +968,8 @@ const ResourcesList = ({
 const peersSearchPredicate = (item: Peer, query: string) => {
   const lowerCaseQuery = query.toLowerCase();
   if (item.name.toLowerCase().includes(lowerCaseQuery)) return true;
-  return item.ip.toLowerCase().includes(lowerCaseQuery);
+  if (item.ip.toLowerCase().includes(lowerCaseQuery)) return true;
+  return item.ipv6?.toLowerCase().includes(lowerCaseQuery) ?? false;
 };
 
 const PeersList = ({
@@ -1059,6 +1060,7 @@ const PeersList = ({
                   }
                 >
                   {res.ip}
+                  {res.ipv6 && `, ${res.ipv6}`}
                   <RadioItem value={res.id} />
                 </div>
               </div>

--- a/src/components/PeerSelector.tsx
+++ b/src/components/PeerSelector.tsx
@@ -30,7 +30,8 @@ const searchPredicate = (item: Peer, query: string) => {
   const lowerCaseQuery = query.toLowerCase();
   if (item.name.toLowerCase().includes(lowerCaseQuery)) return true;
   if (item.hostname.toLowerCase().includes(lowerCaseQuery)) return true;
-  return item.ip.toLowerCase().startsWith(lowerCaseQuery);
+  if (item.ip.toLowerCase().startsWith(lowerCaseQuery)) return true;
+  return !!item.ipv6?.toLowerCase().startsWith(lowerCaseQuery);
 };
 
 export function PeerSelector({
@@ -126,6 +127,7 @@ export function PeerSelector({
                 >
                   <MapPinIcon />
                   {value.ip}
+                  {value.ipv6 && `, ${value.ipv6}`}
                 </div>
               </div>
             ) : (
@@ -240,6 +242,7 @@ export function PeerSelector({
                     >
                       <MapPinIcon />
                       {option.ip}
+                      {option.ipv6 && `, ${option.ipv6}`}
                     </div>
                   </FullTooltip>
                 );

--- a/src/components/PeerSelector.tsx
+++ b/src/components/PeerSelector.tsx
@@ -125,9 +125,7 @@ export function PeerSelector({
                     "text-neutral-500 dark:text-nb-gray-300 font-medium flex items-center gap-1 font-mono text-[10px]"
                   }
                 >
-                  <MapPinIcon />
                   {value.ip}
-                  {value.ipv6 && `, ${value.ipv6}`}
                 </div>
               </div>
             ) : (
@@ -240,9 +238,7 @@ export function PeerSelector({
                         !isSupported && "opacity-50",
                       )}
                     >
-                      <MapPinIcon />
                       {option.ip}
-                      {option.ipv6 && `, ${option.ipv6}`}
                     </div>
                   </FullTooltip>
                 );

--- a/src/contexts/PeerProvider.tsx
+++ b/src/contexts/PeerProvider.tsx
@@ -30,6 +30,7 @@ const PeerContext = React.createContext(
       inactivityExpiration?: boolean;
       approval_required?: boolean;
       ip?: string;
+      ipv6?: string;
     }) => Promise<Peer>;
     toggleSSH: (newState: boolean) => Promise<void>;
     setSSHInstructionsModal: (open: boolean) => void;

--- a/src/contexts/PeerProvider.tsx
+++ b/src/contexts/PeerProvider.tsx
@@ -80,6 +80,7 @@ export default function PeerProvider({
     inactivityExpiration?: boolean;
     approval_required?: boolean;
     ip?: string;
+    ipv6?: string;
   }) => {
     return peerRequest.put(
       {
@@ -99,6 +100,7 @@ export default function PeerProvider({
             ? undefined
             : props.approval_required,
         ip: props.ip != undefined ? props.ip : undefined,
+        ipv6: props.ipv6 != undefined ? props.ipv6 : undefined,
       },
       `/${peer.id}`,
     );

--- a/src/interfaces/Account.ts
+++ b/src/interfaces/Account.ts
@@ -28,6 +28,8 @@ export interface Account {
     auto_update_version: string;
     auto_update_always: boolean;
     local_auth_disabled?: boolean;
+    ipv6_enabled_groups?: string[];
+    network_range_v6?: string;
   };
   onboarding?: AccountOnboarding;
 }

--- a/src/interfaces/Peer.ts
+++ b/src/interfaces/Peer.ts
@@ -5,6 +5,7 @@ export interface Peer {
   id?: string;
   name: string;
   ip: string;
+  ipv6?: string;
   connected: boolean;
   created_at?: Date;
   last_seen: Date;

--- a/src/modules/networks/routing-peers/NetworkRoutingPeersTabContent.tsx
+++ b/src/modules/networks/routing-peers/NetworkRoutingPeersTabContent.tsx
@@ -34,7 +34,7 @@ export const NetworkRoutingPeersTabContent = ({
 
       return {
         ...router,
-        search: `${peer?.name ?? ""} ${peer?.ip ?? ""} ${user?.name ?? ""} ${user?.id ?? ""} ${group?.name ?? ""}`,
+        search: `${peer?.name ?? ""} ${peer?.ip ?? ""} ${peer?.ipv6 ?? ""} ${user?.name ?? ""} ${user?.id ?? ""} ${group?.name ?? ""}`,
       };
     });
   }, [users, peers, routers, groups]);

--- a/src/modules/peer/PeerEditIPModal.tsx
+++ b/src/modules/peer/PeerEditIPModal.tsx
@@ -1,0 +1,118 @@
+import Button from "@components/Button";
+import { Callout } from "@components/Callout";
+import { Input } from "@components/Input";
+import {
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+} from "@components/modal/Modal";
+import ModalHeader from "@components/modal/ModalHeader";
+import cidr from "ip-cidr";
+import { trim } from "lodash";
+import React, { useMemo, useState } from "react";
+
+type IPVersion = "v4" | "v6";
+
+interface PeerEditIPModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (ip: string) => void;
+  currentIP: string;
+  version: IPVersion;
+}
+
+const config: Record<
+  IPVersion,
+  {
+    title: string;
+    description: string;
+    placeholder: string;
+    errorMessage: string;
+    validate: (ip: string) => boolean;
+  }
+> = {
+  v4: {
+    title: "Edit Peer IP Address",
+    description: "Update the NetBird IP address for this peer.",
+    placeholder: "e.g., 100.64.0.15",
+    errorMessage: "Please enter a valid IP, e.g., 100.64.0.15",
+    validate: (ip: string) =>
+      /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+        ip,
+      ),
+  },
+  v6: {
+    title: "Edit Peer IPv6 Address",
+    description: "Update the NetBird IPv6 address for this peer.",
+    placeholder: "e.g., fd00:1234::1",
+    errorMessage: "Please enter a valid IPv6 address, e.g., fd00:1234::1",
+    validate: (ip: string) => cidr.isValidAddress(ip) && ip.includes(":"),
+  },
+};
+
+export function PeerEditIPModal({
+  open,
+  onOpenChange,
+  onSave,
+  currentIP,
+  version,
+}: Readonly<PeerEditIPModalProps>) {
+  const { title, description, placeholder, errorMessage, validate } =
+    config[version];
+  const [ip, setIP] = useState(currentIP);
+
+  const isDisabled = useMemo(() => {
+    if (ip === currentIP) return true;
+    const trimmed = trim(ip);
+    return trimmed.length === 0 || !validate(trimmed);
+  }, [ip, currentIP, validate]);
+
+  const error = useMemo(() => {
+    if (ip === currentIP) return "";
+    if (!validate(trim(ip))) return errorMessage;
+    return "";
+  }, [ip, currentIP, validate, errorMessage]);
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent maxWidthClass={"max-w-md"}>
+        <form>
+          <ModalHeader title={title} description={description} color={"blue"} />
+
+          <div className={"p-default flex flex-col gap-4"}>
+            <div>
+              <Input
+                placeholder={placeholder}
+                value={ip}
+                onChange={(e) => setIP(e.target.value)}
+                error={error}
+              />
+            </div>
+
+            <Callout>Changes take effect when the peer reconnects.</Callout>
+          </div>
+
+          <ModalFooter className={"items-center"} separator={false}>
+            <div className={"flex gap-3 w-full justify-end"}>
+              <ModalClose asChild={true}>
+                <Button variant={"secondary"} className={"w-full"}>
+                  Cancel
+                </Button>
+              </ModalClose>
+
+              <Button
+                variant={"primary"}
+                className={"w-full"}
+                onClick={() => onSave(trim(ip))}
+                disabled={isDisabled}
+              >
+                Save
+              </Button>
+            </div>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/modules/peers/PeerAddressCell.tsx
+++ b/src/modules/peers/PeerAddressCell.tsx
@@ -54,6 +54,7 @@ export default function PeerAddressCell({ peer }: Props) {
               className={"dark:text-nb-gray-400 font-mono font-thin text-xs"}
             >
               {peer.ip}
+              {peer.ipv6 && `, ${peer.ipv6}`}
             </span>
           </CopyToClipboardText>
         </div>

--- a/src/modules/peers/PeerAddressCell.tsx
+++ b/src/modules/peers/PeerAddressCell.tsx
@@ -11,6 +11,7 @@ import { PeerAddressTooltipContent } from "@/modules/peers/PeerAddressTooltipCon
 type Props = {
   peer: Peer;
 };
+
 export default function PeerAddressCell({ peer }: Props) {
   return (
     <FullTooltip
@@ -54,7 +55,6 @@ export default function PeerAddressCell({ peer }: Props) {
               className={"dark:text-nb-gray-400 font-mono font-thin text-xs"}
             >
               {peer.ip}
-              {peer.ipv6 && `, ${peer.ipv6}`}
             </span>
           </CopyToClipboardText>
         </div>

--- a/src/modules/peers/PeerAddressTooltipContent.tsx
+++ b/src/modules/peers/PeerAddressTooltipContent.tsx
@@ -40,7 +40,7 @@ export const PeerAddressTooltipContent = ({ peer }: Props) => {
       />
       {peer.ipv6 && (
         <ListItem
-          icon={<NetworkIcon size={14} />}
+          icon={<MapPin size={14} />}
           label={"NetBird IPv6"}
           value={
             <CopyToClipboardText

--- a/src/modules/peers/PeerAddressTooltipContent.tsx
+++ b/src/modules/peers/PeerAddressTooltipContent.tsx
@@ -38,6 +38,21 @@ export const PeerAddressTooltipContent = ({ peer }: Props) => {
           </CopyToClipboardText>
         }
       />
+      {peer.ipv6 && (
+        <ListItem
+          icon={<NetworkIcon size={14} />}
+          label={"NetBird IPv6"}
+          value={
+            <CopyToClipboardText
+              iconAlignment={"right"}
+              message={"NetBird IPv6 has been copied to your clipboard"}
+              alwaysShowIcon={true}
+            >
+              {peer.ipv6}
+            </CopyToClipboardText>
+          }
+        />
+      )}
       <ListItem
         icon={<NetworkIcon size={14} />}
         label={"Public IP"}

--- a/src/modules/peers/PeersTable.tsx
+++ b/src/modules/peers/PeersTable.tsx
@@ -204,6 +204,10 @@ const PeersTableColumns: ColumnDef<Peer>[] = [
       </PeerProvider>
     ),
   },
+  {
+    id: "ipv6",
+    accessorFn: (row) => row.ipv6,
+  },
 ];
 
 type Props = {
@@ -321,6 +325,7 @@ export default function PeersTable({
           connect: permission.peers.update,
           groups: permission.groups.read,
           os: false,
+          ipv6: false,
         }}
         isLoading={isLoading}
         getStartedCard={<NoPeersGettingStarted showBackground={true} />}

--- a/src/modules/remote-access/ssh/useSSH.ts
+++ b/src/modules/remote-access/ssh/useSSH.ts
@@ -5,6 +5,7 @@ interface SSHConfig {
   hostname: string;
   port: number;
   username: string;
+  ipVersion?: string;
 }
 
 interface SSHConnection {
@@ -71,6 +72,7 @@ export const useSSH = (client: any) => {
           config.port,
           config.username,
           requiresJwt ? accessToken : undefined,
+          config.ipVersion,
         );
 
         ssh.onclose = () => {

--- a/src/modules/remote-access/ssh/useSSHQueryParams.ts
+++ b/src/modules/remote-access/ssh/useSSHQueryParams.ts
@@ -6,6 +6,7 @@ interface SSHQueryParams {
   peerId: string | null;
   username: string | null;
   port: string | null;
+  ipVersion: string | null;
 }
 
 export function useSSHQueryParams() {
@@ -15,6 +16,7 @@ export function useSSHQueryParams() {
     peerId: null,
     username: null,
     port: null,
+    ipVersion: null,
   });
   const [, setLocalQueryParams] = useLocalStorage("netbird-query-params", "");
 
@@ -22,10 +24,11 @@ export function useSSHQueryParams() {
     const peerId = searchParams.get("id");
     const username = searchParams.get("user");
     const port = searchParams.get("port");
+    const ipVersion = searchParams.get("ip_version");
 
     // If all params are present in URL, use them
     if (peerId && username && port) {
-      setParams({ peerId, username, port });
+      setParams({ peerId, username, port, ipVersion });
       return;
     }
 
@@ -47,18 +50,23 @@ export function useSSHQueryParams() {
     const storedPeerId = urlParams.get("id");
     const storedUsername = urlParams.get("user");
     const storedPort = urlParams.get("port");
+    const storedIpVersion = urlParams.get("ip_version");
 
     if (storedPeerId && storedUsername && storedPort) {
       const newSearchParams = new URLSearchParams();
       newSearchParams.set("id", storedPeerId);
       newSearchParams.set("user", storedUsername);
       newSearchParams.set("port", storedPort);
+      if (storedIpVersion) {
+        newSearchParams.set("ip_version", storedIpVersion);
+      }
 
       router.replace(`/peer/ssh?${newSearchParams.toString()}`);
       setParams({
         peerId: storedPeerId,
         username: storedUsername,
         port: storedPort,
+        ipVersion: storedIpVersion,
       });
 
       // Clear stored params after restoring

--- a/src/modules/remote-access/useNetBirdClient.ts
+++ b/src/modules/remote-access/useNetBirdClient.ts
@@ -224,6 +224,7 @@ export const useNetBirdClient = () => {
       port: number,
       username: string,
       jwtToken?: string,
+      ipVersion?: string,
     ): Promise<any> => {
       if (!netBirdClient.current?.createSSHConnection) {
         throw new Error("Go client not ready");
@@ -233,6 +234,7 @@ export const useNetBirdClient = () => {
         port,
         username,
         jwtToken,
+        ipVersion,
       );
     },
     [],

--- a/src/modules/settings/NetworkSettingsTab.tsx
+++ b/src/modules/settings/NetworkSettingsTab.tsx
@@ -6,6 +6,7 @@ import InlineLink from "@components/InlineLink";
 import { Input } from "@components/Input";
 import { Label } from "@components/Label";
 import { notify } from "@components/Notification";
+import { PeerGroupSelector } from "@components/PeerGroupSelector";
 import { useHasChanges } from "@hooks/useHasChanges";
 import * as Tabs from "@radix-ui/react-tabs";
 import { useApiCall } from "@utils/api";
@@ -18,6 +19,7 @@ import { useSWRConfig } from "swr";
 import SettingsIcon from "@/assets/icons/SettingsIcon";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { Account } from "@/interfaces/Account";
+import useGroupHelper from "@/modules/groups/useGroupHelper";
 
 type Props = {
   account: Account;
@@ -37,6 +39,16 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
   );
   const [networkRange, setNetworkRange] = useState(
     account.settings.network_range || "",
+  );
+  const [networkRangeV6, setNetworkRangeV6] = useState(
+    account.settings.network_range_v6 || "",
+  );
+  const [ipv6EnabledGroups, setIpv6EnabledGroups] = useGroupHelper({
+    initial: account.settings?.ipv6_enabled_groups,
+  });
+  const ipv6GroupNames = useMemo(
+    () => ipv6EnabledGroups.map((g) => g.name).sort(),
+    [ipv6EnabledGroups],
   );
 
   const toggleNetworkDNSSetting = async (toggle: boolean) => {
@@ -64,19 +76,32 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
   const { hasChanges, updateRef } = useHasChanges([
     customDNSDomain,
     networkRange,
+    networkRangeV6,
+    ipv6GroupNames,
   ]);
 
   const saveChanges = async () => {
     const updatedSettings = {
       ...account.settings,
+      ipv6_enabled_groups: ipv6EnabledGroups.map((g) => g.id).filter((id): id is string => !!id),
     };
 
     if (customDNSDomain !== "" || account.settings.dns_domain) {
       updatedSettings.dns_domain = customDNSDomain;
     }
 
-    if (networkRange !== "") {
+    // Only send network ranges when the user actually changed them, to avoid
+    // triggering a reallocation when the server hasn't stored an explicit override.
+    if (networkRange !== (account.settings.network_range || "")) {
       updatedSettings.network_range = networkRange;
+    } else {
+      delete updatedSettings.network_range;
+    }
+
+    if (networkRangeV6 !== (account.settings.network_range_v6 || "")) {
+      updatedSettings.network_range_v6 = networkRangeV6;
+    } else {
+      delete updatedSettings.network_range_v6;
     }
 
     notify({
@@ -89,7 +114,7 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
         })
         .then(() => {
           mutate("/accounts");
-          updateRef([customDNSDomain, networkRange]);
+          updateRef([customDNSDomain, networkRange, networkRangeV6, ipv6GroupNames]);
         }),
       loadingMessage: "Updating network settings...",
     });
@@ -124,6 +149,17 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
     }
   }, [networkRange, account.settings.network_range]);
 
+  const networkRangeV6Error = useMemo(() => {
+    if (networkRangeV6 == "") return "";
+    if (!networkRangeV6.includes(":") || !cidr.isValidCIDR(networkRangeV6)) {
+      return "Please enter a valid IPv6 CIDR range, e.g. fd00:1234::/64";
+    }
+    const prefixLen = parseInt(networkRangeV6.split("/")[1], 10);
+    if (prefixLen < 48 || prefixLen > 112) {
+      return "Prefix length must be between /48 and /112";
+    }
+  }, [networkRangeV6]);
+
   return (
     <Tabs.Content value={"networks"}>
       <div className={"p-default py-6 max-w-2xl"}>
@@ -150,7 +186,8 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
               !hasChanges ||
               !permission.settings.update ||
               !!domainError ||
-              !!networkRangeError
+              !!networkRangeError ||
+              !!networkRangeV6Error
             }
             onClick={saveChanges}
           >
@@ -215,6 +252,51 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
               </div>
             </div>
           </div>
+
+          <div>
+            <div
+              className={
+                "flex flex-col gap-1 sm:flex-row w-full sm:gap-4 items-center"
+              }
+            >
+              <div className={"min-w-[330px]"}>
+                <Label>IPv6 Network Range</Label>
+                <HelpText>
+                  Specify a custom IPv6 range for your network in CIDR format.
+                  All peer IPv6 addresses will be re-allocated when changed.
+                </HelpText>
+              </div>
+              <div className={"w-full"}>
+                <Input
+                  placeholder={"e.g. fd00:1234:5678::/64"}
+                  errorTooltip={true}
+                  errorTooltipPosition={"top"}
+                  error={networkRangeV6Error}
+                  value={networkRangeV6}
+                  disabled={!permission.settings.update}
+                  onChange={(e) => setNetworkRangeV6(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <Label>IPv6 Enabled Groups</Label>
+            <HelpText>
+              Peers in the selected groups will receive IPv6 overlay
+              addresses (dual-stack). Remove all groups to disable IPv6.
+              Changes apply on save and will restart affected clients.
+            </HelpText>
+            <PeerGroupSelector
+              values={ipv6EnabledGroups}
+              onChange={setIpv6EnabledGroups}
+              placeholder="Select groups to enable IPv6..."
+              showResourceCounter={false}
+              disabled={!permission.settings.update}
+            />
+          </div>
+
+          <div className={"mt-4"} />
 
           <FancyToggleSwitch
             value={routingPeerDNSSetting}

--- a/src/modules/settings/NetworkSettingsTab.tsx
+++ b/src/modules/settings/NetworkSettingsTab.tsx
@@ -46,8 +46,12 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
   const [ipv6EnabledGroups, setIpv6EnabledGroups] = useGroupHelper({
     initial: account.settings?.ipv6_enabled_groups,
   });
-  const ipv6GroupNames = useMemo(
-    () => ipv6EnabledGroups.map((g) => g.name).sort(),
+  const ipv6GroupIds = useMemo(
+    () =>
+      ipv6EnabledGroups
+        .map((g) => g.id)
+        .filter((id): id is string => !!id)
+        .sort(),
     [ipv6EnabledGroups],
   );
 
@@ -77,7 +81,7 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
     customDNSDomain,
     networkRange,
     networkRangeV6,
-    ipv6GroupNames,
+    ipv6GroupIds,
   ]);
 
   const saveChanges = async () => {

--- a/src/modules/settings/NetworkSettingsTab.tsx
+++ b/src/modules/settings/NetworkSettingsTab.tsx
@@ -20,12 +20,24 @@ import SettingsIcon from "@/assets/icons/SettingsIcon";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { Account } from "@/interfaces/Account";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
+import { useGroups } from "@/contexts/GroupsProvider";
+import { SkeletonSettings } from "@components/skeletons/SkeletonSettings";
 
 type Props = {
   account: Account;
 };
 
 export default function NetworkSettingsTab({ account }: Readonly<Props>) {
+  const { isLoading: isGroupsLoading } = useGroups();
+
+  return isGroupsLoading ? (
+    <SkeletonSettings />
+  ) : (
+    <NetworkSettingsTabContent account={account} />
+  );
+}
+
+function NetworkSettingsTabContent({ account }: Readonly<Props>) {
   const { permission } = usePermissions();
 
   const { mutate } = useSWRConfig();
@@ -43,15 +55,12 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
   const [networkRangeV6, setNetworkRangeV6] = useState(
     account.settings.network_range_v6 || "",
   );
-  const [ipv6EnabledGroups, setIpv6EnabledGroups] = useGroupHelper({
-    initial: account.settings?.ipv6_enabled_groups,
-  });
-  const ipv6GroupIds = useMemo(
-    () =>
-      ipv6EnabledGroups
-        .map((g) => g.id)
-        .filter((id): id is string => !!id)
-        .sort(),
+  const [ipv6EnabledGroups, setIpv6EnabledGroups, { save: saveGroups }] =
+    useGroupHelper({
+      initial: account.settings?.ipv6_enabled_groups,
+    });
+  const ipv6GroupNames = useMemo(
+    () => ipv6EnabledGroups.map((g) => g.name).sort(),
     [ipv6EnabledGroups],
   );
 
@@ -81,13 +90,18 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
     customDNSDomain,
     networkRange,
     networkRangeV6,
-    ipv6GroupIds,
+    ipv6GroupNames,
   ]);
 
   const saveChanges = async () => {
+    const groups = await saveGroups();
+    const ipv6EnabledGroupIds = groups
+      .map((group) => group.id)
+      .filter(Boolean) as string[];
+
     const updatedSettings = {
       ...account.settings,
-      ipv6_enabled_groups: ipv6EnabledGroups.map((g) => g.id).filter((id): id is string => !!id),
+      ipv6_enabled_groups: ipv6EnabledGroupIds,
     };
 
     if (customDNSDomain !== "" || account.settings.dns_domain) {
@@ -118,7 +132,12 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
         })
         .then(() => {
           mutate("/accounts");
-          updateRef([customDNSDomain, networkRange, networkRangeV6, ipv6GroupIds]);
+          updateRef([
+            customDNSDomain,
+            networkRange,
+            networkRangeV6,
+            ipv6GroupNames,
+          ]);
         }),
       loadingMessage: "Updating network settings...",
     });
@@ -287,9 +306,9 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
           <div>
             <Label>IPv6 Enabled Groups</Label>
             <HelpText>
-              Peers in the selected groups will receive IPv6 overlay
-              addresses (dual-stack). Remove all groups to disable IPv6.
-              Changes apply on save and will restart affected clients.
+              Peers in the selected groups will receive IPv6 overlay addresses
+              (dual-stack). Remove all groups to disable IPv6. Changes apply on
+              save and will restart affected clients.
             </HelpText>
             <PeerGroupSelector
               values={ipv6EnabledGroups}

--- a/src/modules/settings/NetworkSettingsTab.tsx
+++ b/src/modules/settings/NetworkSettingsTab.tsx
@@ -118,7 +118,7 @@ export default function NetworkSettingsTab({ account }: Readonly<Props>) {
         })
         .then(() => {
           mutate("/accounts");
-          updateRef([customDNSDomain, networkRange, networkRangeV6, ipv6GroupNames]);
+          updateRef([customDNSDomain, networkRange, networkRangeV6, ipv6GroupIds]);
         }),
       loadingMessage: "Updating network settings...",
     });

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -94,3 +94,4 @@ export const isNetbirdSSHProtocolSupported = (version: string) => {
   if (version == "development") return true;
   return compareVersions(version, "0.61.0");
 };
+


### PR DESCRIPTION
## Describe your changes

Dashboard support for the IPv6 overlay feature. Depends on management PR https://github.com/netbirdio/netbird/pull/5698.

- IPv6 network range input with /48-/112 CIDR validation
- Per-group IPv6 enabled selector (replaces simple toggle)
- Peer IPv6 display: table cell, tooltip, detail page, selectors, DeviceCard
- Routing peers tab shows IPv6 when available


<img width="713" height="795" alt="image" src="https://github.com/user-attachments/assets/d6d72934-87fa-4245-aee6-4d7dd76e6ced" />

<img width="971" height="203" alt="image" src="https://github.com/user-attachments/assets/12c1c192-aabb-4e0e-b56a-35691289299a" />

<img width="581" height="367" alt="image" src="https://github.com/user-attachments/assets/5b1a3bf6-b724-4459-8b97-881ecd445450" />

## Issue ticket number and link

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/667
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added IPv6 address support for peers, including editing, search, and display capabilities.
  * Added IPv6 network settings configuration for managing IPv6 ranges and group assignments.
  * Enabled IPv6 support for SSH remote access connections.

* **Style**
  * Adjusted card list item spacing and typography for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
