### PR TITLE
use localized datetime

### DIFF
--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -628,7 +628,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
                 </>
               }
               value={
-                dayjs(peer.created_at).format("D MMMM, YYYY [at] h:mm A") +
+                dayjs(peer.created_at).format("L [at] LT") +
                 " (" +
                 dayjs().to(peer.created_at) +
                 ")"
@@ -646,7 +646,7 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             value={
               peer.connected
                 ? "just now"
-                : dayjs(peer.last_seen).format("D MMMM, YYYY [at] h:mm A") +
+                : dayjs(peer.last_seen).format("L [at] LT") +
                   " (" +
                   dayjs().to(peer.last_seen) +
                   ")"

--- a/src/app/(dashboard)/team/user/page.tsx
+++ b/src/app/(dashboard)/team/user/page.tsx
@@ -402,7 +402,7 @@ function UserInformationCard({ user }: Readonly<{ user: User }>) {
               value={
                 neverLoggedIn
                   ? "Never"
-                  : dayjs(user.last_login).format("D MMMM, YYYY [at] h:mm A") +
+                  : dayjs(user.last_login).format("L [at] LT") +
                     " (" +
                     dayjs().to(user.last_login) +
                     ")"

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -300,7 +300,7 @@ function InviteAcceptContent() {
         </div>
 
         <p className="text-center text-xs text-nb-gray-500">
-          Invite expires on {dayjs(inviteInfo.expires_at).format("D MMMM, YYYY [at] h:mm A")}
+          Invite expires on {dayjs(inviteInfo.expires_at).format("L [at] LT")}
         </p>
       </div>
     </div>

--- a/src/components/DatePickerWithRange.tsx
+++ b/src/components/DatePickerWithRange.tsx
@@ -87,10 +87,10 @@ export function DatePickerWithRange({
     if (isActive.yesterday) return "Yesterday";
     if (isActive.today) return "Today";
 
-    if (!value.to) return dayjs(value.from).format("MMM DD, YYYY").toString();
-    return `${dayjs(value.from).format("MMM DD, YYYY")} - ${dayjs(
+    if (!value.to) return dayjs(value.from).format("L").toString();
+    return `${dayjs(value.from).format("L")} - ${dayjs(
       value.to,
-    ).format("MMM DD, YYYY")}`;
+    ).format("L")}`;
   }, [value, isActive]);
 
   const [calendarOpen, setCalendarOpen] = useState(false);

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@components/Tooltip";
 import { cn } from "@utils/helpers";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import localizedFormat from "dayjs/plugin/localizedFormat";
 import { Viewport } from "next";
 import localFont from "next/font/local";
 import React, { Suspense } from "react";
@@ -28,6 +29,34 @@ const inter = localFont({
 
 // Extend dayjs with relativeTime plugin
 dayjs.extend(relativeTime);
+// Extend dayjs with localizedFormat plugin
+dayjs.extend(localizedFormat);
+
+(() => {
+  if (typeof window !== "undefined") {
+    const languages = Array.of(navigator.language, navigator.languages).flat();
+    let candidates = new Set();
+
+    for (let language of languages) {
+      language = language.toLowerCase();
+      candidates.add(language);
+      candidates.add(language.split("-")[0]);
+    }
+
+    (async () => {
+      for (const locale of candidates) {
+        try {
+          await import(`dayjs/locale/${locale}`);
+          dayjs.locale(locale);
+          return;
+        } catch {
+          // try next candidate
+        }
+      }
+      dayjs.locale("en");
+    })();
+  }
+})();
 
 export const viewport: Viewport = {
   width: "device-width",

--- a/src/modules/activity/ActivityEntryRow.tsx
+++ b/src/modules/activity/ActivityEntryRow.tsx
@@ -120,7 +120,7 @@ export const ActivityEntryRow = ({ event }: { event: ActivityEvent }) => {
             className={"flex gap-2 items-center text-nb-gray-400 text-xs mr-1"}
           >
             <div className={"h-1 w-1 bg-nb-gray-700 rounded-full"}></div>
-            {dayjs(event?.timestamp).format("MMM D, YYYY [at] h:mm:s A")}
+            {dayjs(event?.timestamp).format("L [at] LT")}
           </span>
         </div>
 

--- a/src/modules/common-table-rows/ExpirationDateRow.tsx
+++ b/src/modules/common-table-rows/ExpirationDateRow.tsx
@@ -12,7 +12,7 @@ export default function ExpirationDateRow({ date }: Props) {
       }
     >
       <Calendar size={14} />
-      {dayjs(date).format("ddd, D MMMM YYYY")}
+      {dayjs(date).format("l, L")}
     </div>
   );
 }

--- a/src/modules/common-table-rows/LastTimeRow.tsx
+++ b/src/modules/common-table-rows/LastTimeRow.tsx
@@ -40,7 +40,7 @@ export default function LastTimeRow({
           <div className={"text-neutral-300 flex flex-col gap-1"}>
             <span className={"text-xs"}>{text}</span>
             <span className={"text-neutral-200"}>
-              {dayjs(date).format("D MMMM, YYYY [at] h:mm A")}
+              {dayjs(date).format("L [at] LT")}
             </span>
           </div>
         </TooltipContent>

--- a/src/modules/reverse-proxy/events/ReverseProxyEventsTimeCell.tsx
+++ b/src/modules/reverse-proxy/events/ReverseProxyEventsTimeCell.tsx
@@ -23,10 +23,10 @@ export const ReverseProxyEventsTimeCell = ({ timestamp, className }: Props) => {
           )}
         >
           <span className={"text-nb-gray-200 flex gap-2 items-center"}>
-            {dayjs(timestamp).format("MMM D, YYYY")}
+            {dayjs(timestamp).format("L")}
           </span>
           <span className={"text-nb-gray-400"}>
-            {dayjs(timestamp).format("h:mm:ss A")}
+            {dayjs(timestamp).format("LT")}
           </span>
         </div>
       </div>

--- a/src/modules/users/UserInvitesTable.tsx
+++ b/src/modules/users/UserInvitesTable.tsx
@@ -376,7 +376,7 @@ export const InvitesTableColumns: ColumnDef<UserInvite>[] = [
     sortingFn: "datetime",
     cell: ({ row }) => (
       <span className="text-nb-gray-400">
-        {dayjs(row.original.expires_at).format("D MMM, YYYY")}
+        {dayjs(row.original.expires_at).format("L")}
       </span>
     ),
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic browser language detection to display dates/times using the user's locale.

* **Improvements**
  * Unified and localized date/time formatting across dashboard, admin screens, activity lists, invites, tables, and tooltips for clearer, region-appropriate displays.
  * Minor trailing newline fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->