### PR TITLE
Fix: Prevent storage wipe and logout on failed account deletion

### DIFF
--- a/src/modules/settings/DangerZoneTab.tsx
+++ b/src/modules/settings/DangerZoneTab.tsx
@@ -26,9 +26,8 @@ export default function DangerZoneTab({ account }: Props) {
     const deletePromise = new Promise<void>((resolve, reject) => {
       return deleteRequest
         .del()
-        .catch((error) => reject(error))
         .then(() => {
-          // Clear browser storage after account deletion
+          // Clear browser storage only after confirmed account deletion
           if (typeof window !== "undefined") {
             localStorage.clear();
             sessionStorage.clear();
@@ -37,7 +36,8 @@ export default function DangerZoneTab({ account }: Props) {
           }
           logout().then();
           resolve();
-        });
+        })
+        .catch((error) => reject(error));
     });
 
     notify({


### PR DESCRIPTION
Fixed the promise chain order in `deleteAccount` inside `DangerZoneTab`. Previously, `.catch()` was placed before `.then()`, which caused a subtle but critical bug — when `.catch()` handles a rejection it returns a resolved promise, so `.then()` would always execute regardless of whether the API call succeeded or failed.

### Changes
- Moved `.catch((error) => reject(error))` to after `.then()` in the `deleteAccount` promise chain
- `localStorage.clear()`, `sessionStorage.clear()`, and `logout()` now only run after the server confirms successful account deletion
- No behavior change on the happy path — only the failure path is fixed

This makes the deletion flow safe: if the API returns an error, the user stays logged in with storage intact and sees the error notification instead of being silently wiped and logged out.

**Before:**
```js
.del()
  .catch((error) => reject(error))       // swallows rejection → returns resolved
  .then(() => { localStorage.clear(); logout(); }) // always runs, even on failure ❌
```

**After:**
```js
.del()
  .then(() => { localStorage.clear(); logout(); }) // only runs on API success ✅
  .catch((error) => reject(error))       // only runs on failure, storage untouched ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account deletion process to ensure browser data is cleared only after deletion is successfully confirmed, preventing potential data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->