### PR TITLE
Add Entra device authentication admin UI

### DIFF
--- a/src/app/(dashboard)/integrations/entra-device-auth/layout.tsx
+++ b/src/app/(dashboard)/integrations/entra-device-auth/layout.tsx
@@ -1,0 +1,9 @@
+import { globalMetaTitle } from "@utils/meta";
+import type { Metadata } from "next";
+import BlankLayout from "@/layouts/BlankLayout";
+
+export const metadata: Metadata = {
+  title: `Entra Device Auth - ${globalMetaTitle}`,
+};
+
+export default BlankLayout;

--- a/src/app/(dashboard)/integrations/entra-device-auth/page.tsx
+++ b/src/app/(dashboard)/integrations/entra-device-auth/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Breadcrumbs from "@components/Breadcrumbs";
+import Paragraph from "@components/Paragraph";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@components/Tabs";
+import { RestrictedAccess } from "@components/ui/RestrictedAccess";
+import { FingerprintIcon, FolderGit2Icon, SettingsIcon } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import React, { useMemo } from "react";
+import EntraDeviceIcon from "@/assets/icons/EntraDeviceIcon";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import PageContainer from "@/layouts/PageContainer";
+import EntraDeviceAuthConfig from "@/modules/integrations/entra-device-auth/EntraDeviceAuthConfig";
+import EntraDeviceMappingsTable from "@/modules/integrations/entra-device-auth/EntraDeviceMappingsTable";
+
+/**
+ * Admin UI for the Entra device authentication integration.
+ *
+ * This page is a thin shell that hosts two horizontally-tabbed panels:
+ *  1. Configuration — singleton integration settings.
+ *  2. Mappings — Entra security group → NetBird auto-groups CRUD.
+ *
+ * Permissions use optional chaining (`permission?.entra_device_auth?.read`)
+ * so that the page stays usable against a management server that doesn't
+ * publish the new permission module yet; admin writes will still be rejected
+ * server-side in that case.
+ */
+export default function EntraDeviceAuthPage() {
+  const { permission } = usePermissions();
+  const queryParams = useSearchParams();
+  const initialTab = useMemo(() => queryParams.get("tab") ?? "config", [
+    queryParams,
+  ]);
+
+  const canRead = permission?.entra_device_auth?.read ?? true;
+
+  return (
+    <PageContainer>
+      <div className="p-default py-6">
+        <Breadcrumbs>
+          <Breadcrumbs.Item
+            href="/integrations/entra-device-auth"
+            label="Integrations"
+            icon={<SettingsIcon size={13} />}
+          />
+          <Breadcrumbs.Item
+            href="/integrations/entra-device-auth"
+            label="Entra Device Auth"
+            icon={<EntraDeviceIcon size={14} />}
+            active
+          />
+        </Breadcrumbs>
+        <h1>Entra Device Auth</h1>
+        <Paragraph>
+          Zero-touch device enrollment for Microsoft Entra-joined machines.
+          Devices hitting <code className="text-xs">/join/entra</code> on the
+          management URL prove their identity with the Entra device
+          certificate and are automatically placed into NetBird groups based
+          on their Entra security-group membership.
+        </Paragraph>
+      </div>
+
+      <RestrictedAccess page="Entra Device Auth" hasAccess={canRead}>
+        <Tabs defaultValue={initialTab}>
+          <TabsList justify="start" className="px-default">
+            <TabsTrigger value="config">
+              <FingerprintIcon size={14} />
+              Configuration
+            </TabsTrigger>
+            <TabsTrigger value="mappings">
+              <FolderGit2Icon size={14} />
+              Mappings
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="config">
+            <EntraDeviceAuthConfig />
+          </TabsContent>
+          <TabsContent value="mappings">
+            <EntraDeviceMappingsTable />
+          </TabsContent>
+        </Tabs>
+      </RestrictedAccess>
+    </PageContainer>
+  );
+}

--- a/src/app/(dashboard)/integrations/layout.tsx
+++ b/src/app/(dashboard)/integrations/layout.tsx
@@ -1,0 +1,3 @@
+import BlankLayout from "@/layouts/BlankLayout";
+
+export default BlankLayout;

--- a/src/assets/icons/EntraDeviceIcon.tsx
+++ b/src/assets/icons/EntraDeviceIcon.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+type Props = {
+  size?: number;
+  className?: string;
+};
+
+/**
+ * A small, neutral icon for the Entra device authentication pages.
+ *
+ * We deliberately avoid Microsoft/Entra trademark-coloured assets: this icon
+ * depicts a device with a fingerprint/shield overlay, matching the rest of
+ * NetBird's internal icon set.
+ */
+export default function EntraDeviceIcon({
+  size = 16,
+  className,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* laptop base */}
+      <path d="M3 17h18" />
+      <rect x="5" y="5" width="14" height="10" rx="1.5" />
+      {/* shield/check overlay */}
+      <path d="M12 7.5l3 1.2v2.4c0 2-1.3 3.1-3 3.6-1.7-.5-3-1.6-3-3.6V8.7L12 7.5z" />
+      <path d="M10.8 10.8l.8.9 1.6-1.7" />
+    </svg>
+  );
+}

--- a/src/interfaces/EntraDeviceAuth.ts
+++ b/src/interfaces/EntraDeviceAuth.ts
@@ -1,0 +1,97 @@
+import { Group } from "@/interfaces/Group";
+
+/**
+ * Resolution strategy for a device that matches multiple mappings.
+ * Mirrors the backend's `types.MappingResolution`.
+ */
+export type EntraDeviceMappingResolution = "strict_priority" | "union";
+
+export const EntraDeviceMappingResolutionOptions: {
+  value: EntraDeviceMappingResolution;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "strict_priority",
+    label: "Strict priority",
+    description:
+      "Apply only the single mapping with the lowest priority. Ties are broken deterministically by ID.",
+  },
+  {
+    value: "union",
+    label: "Union",
+    description:
+      "Apply all matched mappings: union of auto-groups, OR on ephemeral, AND on extra DNS labels, earliest expiry wins.",
+  },
+];
+
+/**
+ * Integration-level configuration for Microsoft Entra device authentication.
+ * Mirrors `integrationDTO` in management/server/http/handlers/entra_device_auth/handler.go.
+ */
+export interface EntraDeviceAuth {
+  id?: string;
+  tenant_id: string;
+  client_id: string;
+  /** Write-only; server returns "********" when a secret is already stored. */
+  client_secret?: string;
+  issuer?: string;
+  audience?: string;
+  enabled: boolean;
+  require_intune_compliant: boolean;
+  allow_tenant_only_fallback: boolean;
+  fallback_auto_groups?: string[];
+  mapping_resolution?: EntraDeviceMappingResolution;
+  /** Go-duration string, e.g. "24h". Empty string disables revalidation. */
+  revalidation_interval?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface EntraDeviceAuthRequest {
+  tenant_id: string;
+  client_id: string;
+  client_secret?: string;
+  issuer?: string;
+  audience?: string;
+  enabled: boolean;
+  require_intune_compliant: boolean;
+  allow_tenant_only_fallback: boolean;
+  fallback_auto_groups?: string[];
+  mapping_resolution?: EntraDeviceMappingResolution;
+  revalidation_interval?: string;
+}
+
+/**
+ * A single Entra-group → NetBird-auto-groups mapping.
+ * Mirrors `mappingDTO` in management/server/http/handlers/entra_device_auth/handler.go.
+ */
+export interface EntraDeviceMapping {
+  id?: string;
+  name: string;
+  /** Entra Object ID (GUID) of the source security group. "*" for catch-all. */
+  entra_group_id: string;
+  auto_groups: string[];
+  ephemeral: boolean;
+  allow_extra_dns_labels: boolean;
+  /** RFC3339 timestamp or null for "never". */
+  expires_at?: string | null;
+  revoked: boolean;
+  priority: number;
+  created_at?: string;
+  updated_at?: string;
+
+  // Frontend-only decoration (resolved from /groups).
+  groups?: Group[];
+}
+
+export interface EntraDeviceMappingRequest {
+  name: string;
+  entra_group_id: string;
+  auto_groups: string[];
+  ephemeral: boolean;
+  allow_extra_dns_labels: boolean;
+  expires_at?: string | null;
+  revoked: boolean;
+  priority: number;
+}

--- a/src/interfaces/Permission.ts
+++ b/src/interfaces/Permission.ts
@@ -35,6 +35,13 @@ export interface Permissions {
     proxy_configuration: Permission;
 
     services: Permission;
+
+    /**
+     * Entra device authentication integration (optional so the UI stays
+     * backwards-compatible with management servers that don't expose this
+     * module yet — all call sites use optional chaining).
+     */
+    entra_device_auth?: Permission;
   };
 }
 

--- a/src/layouts/Navigation.tsx
+++ b/src/layouts/Navigation.tsx
@@ -21,6 +21,7 @@ import { SmallBadge } from "@components/ui/SmallBadge";
 import * as React from "react";
 import ReverseProxyIcon from "@/assets/icons/ReverseProxyIcon";
 import ActivityIcon from "@/assets/icons/ActivityIcon";
+import EntraDeviceIcon from "@/assets/icons/EntraDeviceIcon";
 
 type Props = {
   fullWidth?: boolean;
@@ -213,6 +214,7 @@ export default function Navigation({
                   />
                 </SidebarItem>
                 <ActivityNavigationItem />
+                <EntraDeviceAuthNavigationItem />
               </SidebarItemGroup>
 
               <SidebarItemGroup>
@@ -281,5 +283,25 @@ const ActivityNavigationItem = () => {
         visible={permission.events.read}
       />
     </SidebarItem>
+  );
+};
+
+// Entra device authentication admin UI. The permission module is optional on
+// the backend for backwards compatibility, so we default to showing the link
+// when `entra_device_auth` isn't published — the server-side permission
+// check remains the source of truth, and admins on older builds will simply
+// see a 403 when they hit the endpoints.
+const EntraDeviceAuthNavigationItem = () => {
+  const { permission } = usePermissions();
+  const visible = permission?.entra_device_auth?.read ?? true;
+
+  return (
+    <SidebarItem
+      icon={<EntraDeviceIcon size={16} />}
+      label="Entra Device Auth"
+      href={"/integrations/entra-device-auth"}
+      exactPathMatch={false}
+      visible={visible}
+    />
   );
 };

--- a/src/modules/integrations/entra-device-auth/EntraDeviceAuthConfig.tsx
+++ b/src/modules/integrations/entra-device-auth/EntraDeviceAuthConfig.tsx
@@ -1,0 +1,415 @@
+import Button from "@components/Button";
+import FancyToggleSwitch from "@components/FancyToggleSwitch";
+import HelpText from "@components/HelpText";
+import { Input } from "@components/Input";
+import { Label } from "@components/Label";
+import { notify } from "@components/Notification";
+import Paragraph from "@components/Paragraph";
+import { PeerGroupSelector } from "@components/PeerGroupSelector";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@components/Select";
+import Separator from "@components/Separator";
+import { useDialog } from "@/contexts/DialogProvider";
+import useFetchApi, { useApiCall } from "@utils/api";
+import { trim } from "lodash";
+import {
+  AlarmClock,
+  GlobeIcon,
+  IdCard,
+  KeyIcon,
+  SaveIcon,
+  ShieldCheckIcon,
+  TagIcon,
+  Trash2,
+} from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import {
+  EntraDeviceAuth,
+  EntraDeviceAuthRequest,
+  EntraDeviceMappingResolution,
+  EntraDeviceMappingResolutionOptions,
+} from "@/interfaces/EntraDeviceAuth";
+import { Group } from "@/interfaces/Group";
+import useGroupHelper from "@/modules/groups/useGroupHelper";
+
+/**
+ * Entra device auth integration configuration (singleton per account).
+ *
+ * Mirrors the backend admin endpoint `/api/integrations/entra-device-auth`.
+ * Allows creating / updating the integration as well as wiping it.
+ */
+export default function EntraDeviceAuthConfig() {
+  const { permission } = usePermissions();
+  const { mutate } = useSWRConfig();
+  const { confirm } = useDialog();
+
+  // Silently tolerate 404 (integration not yet configured) via ignoreError.
+  const { data, isLoading } = useFetchApi<EntraDeviceAuth>(
+    "/integrations/entra-device-auth",
+    true,
+  );
+
+  const saveRequest = useApiCall<EntraDeviceAuth>(
+    "/integrations/entra-device-auth",
+  );
+  const deleteRequest = useApiCall<EntraDeviceAuth>(
+    "/integrations/entra-device-auth",
+  );
+
+  const canRead = permission?.entra_device_auth?.read ?? true;
+  const canCreate = permission?.entra_device_auth?.create ?? true;
+  const canUpdate = permission?.entra_device_auth?.update ?? true;
+  const canDelete = permission?.entra_device_auth?.delete ?? true;
+
+  // Form state
+  const [tenantId, setTenantId] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [issuer, setIssuer] = useState("");
+  const [audience, setAudience] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [requireIntune, setRequireIntune] = useState(false);
+  const [allowTenantOnlyFallback, setAllowTenantOnlyFallback] = useState(false);
+  const [mappingResolution, setMappingResolution] =
+    useState<EntraDeviceMappingResolution>("strict_priority");
+  const [revalidationInterval, setRevalidationInterval] = useState("");
+
+  const [fallbackGroups, setFallbackGroups, { save: saveFallbackGroups }] =
+    useGroupHelper({
+      initial: [],
+    });
+
+  // Hydrate from server-side config once it arrives.
+  useEffect(() => {
+    if (!data) return;
+    setTenantId(data.tenant_id ?? "");
+    setClientId(data.client_id ?? "");
+    // The server returns "********" when a secret is already stored; keep
+    // the UI empty so we don't accidentally echo it back as plaintext.
+    setClientSecret("");
+    setIssuer(data.issuer ?? "");
+    setAudience(data.audience ?? "");
+    setEnabled(!!data.enabled);
+    setRequireIntune(!!data.require_intune_compliant);
+    setAllowTenantOnlyFallback(!!data.allow_tenant_only_fallback);
+    setMappingResolution(data.mapping_resolution ?? "strict_priority");
+    setRevalidationInterval(data.revalidation_interval ?? "");
+  }, [data]);
+
+  const isEditing = !!data?.id;
+  const hasSecretStored = !!data && !!data.client_secret; // "********" when present
+  const resolvedIssuer = useMemo(
+    () =>
+      issuer ||
+      (tenantId
+        ? `https://login.microsoftonline.com/${tenantId}/v2.0`
+        : "https://login.microsoftonline.com/{tenant}/v2.0"),
+    [issuer, tenantId],
+  );
+
+  const isDisabled = useMemo(() => {
+    if (!trim(tenantId) || !trim(clientId)) return true;
+    // Require a secret only when we don't already have one stored.
+    if (!hasSecretStored && !trim(clientSecret)) return true;
+    return false;
+  }, [tenantId, clientId, clientSecret, hasSecretStored]);
+
+  const buildRequest = async (): Promise<EntraDeviceAuthRequest> => {
+    const groups = await saveFallbackGroups();
+    return {
+      tenant_id: trim(tenantId),
+      client_id: trim(clientId),
+      // Only send the secret when the operator has actually typed a new
+      // one — the backend preserves the existing value otherwise.
+      client_secret: trim(clientSecret) || undefined,
+      issuer: trim(issuer) || undefined,
+      audience: trim(audience) || undefined,
+      enabled,
+      require_intune_compliant: requireIntune,
+      allow_tenant_only_fallback: allowTenantOnlyFallback,
+      fallback_auto_groups: groups.map((g: Group) => g.id!).filter(Boolean),
+      mapping_resolution: mappingResolution,
+      revalidation_interval: trim(revalidationInterval) || undefined,
+    };
+  };
+
+  const submit = async () => {
+    const payload = await buildRequest();
+    notify({
+      title: "Entra Device Auth",
+      description: isEditing
+        ? "Integration updated successfully."
+        : "Integration configured successfully.",
+      promise: (isEditing ? saveRequest.put(payload) : saveRequest.post(payload)).then(
+        () => {
+          mutate("/integrations/entra-device-auth");
+          mutate("/integrations/entra-device-auth/mappings");
+          setClientSecret(""); // prevent the secret from lingering in state
+        },
+      ),
+      loadingMessage: isEditing
+        ? "Updating integration..."
+        : "Configuring integration...",
+    });
+  };
+
+  const handleDelete = async () => {
+    const choice = await confirm({
+      title: "Delete Entra Device Auth integration?",
+      description:
+        "This disables zero-touch Entra enrollment and removes all mappings. Peers already joined via Entra will stay registered but won't re-authenticate.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+    notify({
+      title: "Entra Device Auth",
+      description: "Integration deleted.",
+      promise: deleteRequest.del().then(() => {
+        mutate("/integrations/entra-device-auth");
+        mutate("/integrations/entra-device-auth/mappings");
+      }),
+      loadingMessage: "Deleting integration...",
+    });
+  };
+
+  if (!canRead) {
+    return (
+      <Paragraph className="px-6 py-8">
+        You don&apos;t have permission to view the Entra device authentication
+        integration.
+      </Paragraph>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="px-default py-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1>Configuration</h1>
+            <Paragraph>
+              Connect NetBird to your Microsoft Entra tenant so Entra-joined
+              devices can enroll without user interaction. Dedicated endpoint:{" "}
+              <code className="text-xs">/join/entra</code>
+            </Paragraph>
+          </div>
+          {isEditing && (
+            <Button
+              variant="danger-outline"
+              size="sm"
+              onClick={handleDelete}
+              disabled={!canDelete}
+            >
+              <Trash2 size={14} />
+              Delete integration
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="px-default flex flex-col gap-8 max-w-3xl">
+        <div>
+          <Label>Tenant ID</Label>
+          <HelpText>
+            Microsoft Entra tenant GUID (the directory NetBird will trust).
+          </HelpText>
+          <Input
+            placeholder="00000000-0000-0000-0000-000000000000"
+            value={tenantId}
+            onChange={(e) => setTenantId(e.target.value)}
+            customPrefix={<TagIcon size={16} className="text-nb-gray-300" />}
+            disabled={isLoading}
+          />
+        </div>
+
+        <div>
+          <Label>Application (client) ID</Label>
+          <HelpText>
+            Application registered in Entra used for Microsoft Graph lookups.
+          </HelpText>
+          <Input
+            placeholder="00000000-0000-0000-0000-000000000000"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            customPrefix={<IdCard size={16} className="text-nb-gray-300" />}
+            disabled={isLoading}
+          />
+        </div>
+
+        <div>
+          <Label>Client secret</Label>
+          <HelpText>
+            {hasSecretStored
+              ? "A secret is already stored. Leave empty to keep it, or enter a new value to rotate."
+              : "Client secret for the app registration. Required on first setup."}
+          </HelpText>
+          <Input
+            type="password"
+            placeholder={hasSecretStored ? "••••••••" : "Enter client secret"}
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+            customPrefix={<KeyIcon size={16} className="text-nb-gray-300" />}
+            disabled={isLoading || !(canCreate || canUpdate)}
+          />
+        </div>
+
+        <div>
+          <Label>Issuer (optional)</Label>
+          <HelpText>
+            OIDC issuer used when validating device tokens. Defaults to{" "}
+            <code className="text-xs">{resolvedIssuer}</code> when empty.
+          </HelpText>
+          <Input
+            placeholder={resolvedIssuer}
+            value={issuer}
+            onChange={(e) => setIssuer(e.target.value)}
+            customPrefix={<GlobeIcon size={16} className="text-nb-gray-300" />}
+            disabled={isLoading}
+          />
+        </div>
+
+        <div>
+          <Label>Audience (optional)</Label>
+          <HelpText>
+            Expected <code className="text-xs">aud</code> claim for Entra
+            device tokens. Leave empty when using the default Entra app URI.
+          </HelpText>
+          <Input
+            placeholder="api://netbird.example.com"
+            value={audience}
+            onChange={(e) => setAudience(e.target.value)}
+            customPrefix={<TagIcon size={16} className="text-nb-gray-300" />}
+            disabled={isLoading}
+          />
+        </div>
+
+        <Separator />
+
+        <FancyToggleSwitch
+          value={enabled}
+          onChange={setEnabled}
+          label={
+            <>
+              <ShieldCheckIcon size={15} />
+              Enabled
+            </>
+          }
+          helpText="When disabled, the /join/entra endpoint rejects all requests for this account."
+          disabled={!canUpdate && isEditing}
+        />
+
+        <FancyToggleSwitch
+          value={requireIntune}
+          onChange={setRequireIntune}
+          label={
+            <>
+              <ShieldCheckIcon size={15} />
+              Require Intune compliance
+            </>
+          }
+          helpText="Only allow devices marked as compliant by Microsoft Intune. Requires DeviceManagementManagedDevices.Read.All."
+          disabled={!canUpdate && isEditing}
+        />
+
+        <FancyToggleSwitch
+          value={allowTenantOnlyFallback}
+          onChange={setAllowTenantOnlyFallback}
+          label={
+            <>
+              <GlobeIcon size={15} />
+              Allow tenant-only fallback
+            </>
+          }
+          helpText="If no group-scoped mapping matches, apply the fallback auto-groups below for any valid device from this tenant."
+          disabled={!canUpdate && isEditing}
+        />
+
+        {allowTenantOnlyFallback && (
+          <div>
+            <Label>Fallback auto-groups</Label>
+            <HelpText>
+              NetBird groups applied when the tenant-only fallback kicks in.
+            </HelpText>
+            <PeerGroupSelector
+              onChange={setFallbackGroups}
+              values={fallbackGroups}
+              hideAllGroup
+              disabled={!canUpdate && isEditing}
+            />
+          </div>
+        )}
+
+        <div>
+          <Label>Mapping resolution</Label>
+          <HelpText>
+            How to combine results when a device matches multiple mappings.
+          </HelpText>
+          <Select
+            value={mappingResolution}
+            onValueChange={(v) =>
+              setMappingResolution(v as EntraDeviceMappingResolution)
+            }
+            disabled={!canUpdate && isEditing}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select strategy..." />
+            </SelectTrigger>
+            <SelectContent>
+              {EntraDeviceMappingResolutionOptions.map((opt) => (
+                <SelectItem
+                  key={opt.value}
+                  value={opt.value}
+                  description={opt.description}
+                >
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label>Revalidation interval (optional)</Label>
+          <HelpText>
+            Go-duration string (e.g. <code className="text-xs">24h</code>,{" "}
+            <code className="text-xs">12h30m</code>). Leave empty to disable
+            background revalidation.
+          </HelpText>
+          <Input
+            placeholder="24h"
+            value={revalidationInterval}
+            onChange={(e) => setRevalidationInterval(e.target.value)}
+            customPrefix={<AlarmClock size={16} className="text-nb-gray-300" />}
+            disabled={!canUpdate && isEditing}
+          />
+        </div>
+
+        <Separator />
+
+        <div className="flex justify-end gap-3 pb-10">
+          <Button
+            variant="primary"
+            onClick={submit}
+            disabled={
+              isDisabled ||
+              isLoading ||
+              (isEditing ? !canUpdate : !canCreate)
+            }
+          >
+            <SaveIcon size={16} />
+            {isEditing ? "Save changes" : "Create integration"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/integrations/entra-device-auth/EntraDeviceMappingActionCell.tsx
+++ b/src/modules/integrations/entra-device-auth/EntraDeviceMappingActionCell.tsx
@@ -1,0 +1,108 @@
+import Button from "@components/Button";
+import { notify } from "@components/Notification";
+import { useApiCall } from "@utils/api";
+import { Trash2, Undo2Icon } from "lucide-react";
+import * as React from "react";
+import { useSWRConfig } from "swr";
+import { useDialog } from "@/contexts/DialogProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import {
+  EntraDeviceMapping,
+  EntraDeviceMappingRequest,
+} from "@/interfaces/EntraDeviceAuth";
+
+type Props = {
+  mapping: EntraDeviceMapping;
+  onEdit?: (mapping: EntraDeviceMapping) => void;
+};
+
+/**
+ * Per-row revoke / delete controls for a mapping, mirroring
+ * SetupKeyActionCell.
+ */
+export default function EntraDeviceMappingActionCell({
+  mapping,
+}: Readonly<Props>) {
+  const { confirm } = useDialog();
+  const { mutate } = useSWRConfig();
+  const { permission } = usePermissions();
+  const request = useApiCall<EntraDeviceMapping>(
+    `/integrations/entra-device-auth/mappings/${mapping.id}`,
+  );
+
+  const canUpdate = permission?.entra_device_auth?.update ?? true;
+  const canDelete = permission?.entra_device_auth?.delete ?? true;
+
+  const handleRevoke = async () => {
+    const choice = await confirm({
+      title: `Revoke '${mapping.name || "mapping"}'?`,
+      description:
+        "Revoked mappings are ignored during enrollment. Existing peers stay registered.",
+      confirmText: "Revoke",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+    const payload: EntraDeviceMappingRequest = {
+      name: mapping.name,
+      entra_group_id: mapping.entra_group_id,
+      auto_groups: mapping.auto_groups ?? [],
+      ephemeral: mapping.ephemeral,
+      allow_extra_dns_labels: mapping.allow_extra_dns_labels,
+      expires_at: mapping.expires_at ?? null,
+      revoked: true,
+      priority: mapping.priority ?? 0,
+    };
+    notify({
+      title: mapping.name || "Entra mapping",
+      description: "Mapping revoked.",
+      promise: request.put(payload).then(() => {
+        mutate("/integrations/entra-device-auth/mappings");
+      }),
+      loadingMessage: "Revoking mapping...",
+    });
+  };
+
+  const handleDelete = async () => {
+    const choice = await confirm({
+      title: `Delete '${mapping.name || "mapping"}'?`,
+      description:
+        "Deleting a mapping is permanent. Existing peers stay registered but will no longer re-evaluate against this mapping.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+    notify({
+      title: mapping.name || "Entra mapping",
+      description: "Mapping deleted.",
+      promise: request.del().then(() => {
+        mutate("/integrations/entra-device-auth/mappings");
+      }),
+      loadingMessage: "Deleting mapping...",
+    });
+  };
+
+  return (
+    <div className="flex justify-end pr-4">
+      <Button
+        variant="danger-outline"
+        size="sm"
+        onClick={handleRevoke}
+        disabled={mapping.revoked || !canUpdate}
+      >
+        <Undo2Icon size={16} />
+        Revoke
+      </Button>
+      <Button
+        variant="danger-outline"
+        size="sm"
+        onClick={handleDelete}
+        disabled={!canDelete}
+      >
+        <Trash2 size={16} />
+        Delete
+      </Button>
+    </div>
+  );
+}

--- a/src/modules/integrations/entra-device-auth/EntraDeviceMappingModal.tsx
+++ b/src/modules/integrations/entra-device-auth/EntraDeviceMappingModal.tsx
@@ -1,0 +1,295 @@
+import Button from "@components/Button";
+import FancyToggleSwitch from "@components/FancyToggleSwitch";
+import HelpText from "@components/HelpText";
+import { Input } from "@components/Input";
+import { Label } from "@components/Label";
+import {
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+} from "@components/modal/Modal";
+import ModalHeader from "@components/modal/ModalHeader";
+import { notify } from "@components/Notification";
+import { PeerGroupSelector } from "@components/PeerGroupSelector";
+import Separator from "@components/Separator";
+import { useApiCall } from "@utils/api";
+import { trim } from "lodash";
+import {
+  AlarmClock,
+  FingerprintIcon,
+  GlobeIcon,
+  PlusCircle,
+  PowerOffIcon,
+  SaveIcon,
+  TagIcon,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import {
+  EntraDeviceMapping,
+  EntraDeviceMappingRequest,
+} from "@/interfaces/EntraDeviceAuth";
+import useGroupHelper from "@/modules/groups/useGroupHelper";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  mapping?: EntraDeviceMapping | null;
+};
+
+/**
+ * Create / edit modal for a single Entra device auth mapping, modelled after
+ * SetupKeyModal so admins see consistent controls (auto-groups, ephemeral,
+ * extra-DNS labels, expires-in, priority, revoked).
+ */
+export default function EntraDeviceMappingModal({
+  open,
+  onClose,
+  mapping,
+}: Readonly<Props>) {
+  const isEditing = !!mapping?.id;
+  const { mutate } = useSWRConfig();
+
+  const createRequest = useApiCall<EntraDeviceMapping>(
+    "/integrations/entra-device-auth/mappings",
+  );
+  const updateRequest = useApiCall<EntraDeviceMapping>(
+    `/integrations/entra-device-auth/mappings/${mapping?.id ?? ""}`,
+  );
+
+  const [name, setName] = useState(mapping?.name ?? "");
+  const [entraGroupId, setEntraGroupId] = useState(mapping?.entra_group_id ?? "");
+  const [ephemeral, setEphemeral] = useState(mapping?.ephemeral ?? false);
+  const [allowExtraDNSLabels, setAllowExtraDNSLabels] = useState(
+    mapping?.allow_extra_dns_labels ?? false,
+  );
+  const [revoked, setRevoked] = useState(mapping?.revoked ?? false);
+  const [priority, setPriority] = useState(String(mapping?.priority ?? 0));
+  const [expiresInDays, setExpiresInDays] = useState(() => {
+    if (!mapping?.expires_at) return "";
+    const diffMs =
+      new Date(mapping.expires_at).getTime() - Date.now();
+    if (diffMs <= 0) return "";
+    return String(Math.ceil(diffMs / (24 * 60 * 60 * 1000)));
+  });
+
+  const [selectedGroups, setSelectedGroups, { save: saveGroups }] =
+    useGroupHelper({
+      initial: mapping?.auto_groups ?? [],
+    });
+
+  const isDisabled = useMemo(() => {
+    if (trim(name).length === 0) return true;
+    if (trim(entraGroupId).length === 0) return true;
+    if (priority !== "" && isNaN(parseInt(priority, 10))) return true;
+    if (expiresInDays !== "" && isNaN(parseInt(expiresInDays, 10))) return true;
+    return false;
+  }, [name, entraGroupId, priority, expiresInDays]);
+
+  const buildRequest = async (): Promise<EntraDeviceMappingRequest> => {
+    const groups = await saveGroups();
+    let expiresAt: string | null = null;
+    if (trim(expiresInDays).length > 0) {
+      const days = parseInt(expiresInDays, 10);
+      if (!isNaN(days) && days > 0) {
+        expiresAt = new Date(
+          Date.now() + days * 24 * 60 * 60 * 1000,
+        ).toISOString();
+      }
+    }
+    return {
+      name: trim(name),
+      entra_group_id: trim(entraGroupId),
+      auto_groups: groups.map((g) => g.id!).filter(Boolean),
+      ephemeral,
+      allow_extra_dns_labels: allowExtraDNSLabels,
+      expires_at: expiresAt,
+      revoked,
+      priority: parseInt(priority || "0", 10) || 0,
+    };
+  };
+
+  const submit = async () => {
+    const payload = await buildRequest();
+    const call = isEditing ? updateRequest.put(payload) : createRequest.post(payload);
+    notify({
+      title: isEditing ? "Update mapping" : "Create mapping",
+      description: isEditing
+        ? "Mapping updated successfully."
+        : "Mapping created successfully.",
+      promise: call.then(() => {
+        mutate("/integrations/entra-device-auth/mappings");
+        mutate("/groups");
+        onClose();
+      }),
+      loadingMessage: isEditing
+        ? "Saving mapping..."
+        : "Creating mapping...",
+    });
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(state) => !state && onClose()}
+      key={open ? 1 : 0}
+    >
+      <ModalContent maxWidthClass="max-w-xl">
+        <ModalHeader
+          icon={<FingerprintIcon size={18} />}
+          title={isEditing ? "Edit mapping" : "Create mapping"}
+          description={
+            isEditing
+              ? "Update the Entra → NetBird mapping configuration"
+              : "Map an Entra security group onto NetBird auto-groups"
+          }
+          color="netbird"
+        />
+
+        <Separator />
+
+        <div className="px-8 py-6 flex flex-col gap-8">
+          <div>
+            <Label>Name</Label>
+            <HelpText>
+              Friendly name shown in the admin UI and activity logs.
+            </HelpText>
+            <Input
+              placeholder="e.g., Corporate Laptops"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              customPrefix={<TagIcon size={16} className="text-nb-gray-300" />}
+            />
+          </div>
+
+          <div>
+            <Label>Entra group ID</Label>
+            <HelpText>
+              Microsoft Entra security group Object ID (GUID). Use{" "}
+              <code className="text-xs">*</code> to match any device from the
+              configured tenant.
+            </HelpText>
+            <Input
+              placeholder="00000000-0000-0000-0000-000000000000 or *"
+              value={entraGroupId}
+              onChange={(e) => setEntraGroupId(e.target.value)}
+              customPrefix={
+                <FingerprintIcon size={16} className="text-nb-gray-300" />
+              }
+            />
+          </div>
+
+          <div>
+            <Label>Auto-assigned NetBird groups</Label>
+            <HelpText>
+              Peers enrolled via this mapping are automatically placed in these
+              groups.
+            </HelpText>
+            <PeerGroupSelector
+              onChange={setSelectedGroups}
+              values={selectedGroups}
+              hideAllGroup
+            />
+          </div>
+
+          <div className="flex justify-between gap-6">
+            <div className="flex-1">
+              <Label>Priority</Label>
+              <HelpText>
+                Lower values win in{" "}
+                <code className="text-xs">strict_priority</code> mode. Ignored
+                in <code className="text-xs">union</code> mode.
+              </HelpText>
+              <Input
+                type="number"
+                value={priority}
+                placeholder="0"
+                onChange={(e) => setPriority(e.target.value)}
+              />
+            </div>
+            <div className="flex-1">
+              <Label>Expires in</Label>
+              <HelpText>
+                Days until this mapping stops matching. Leave empty for no
+                expiry.
+              </HelpText>
+              <Input
+                type="number"
+                min={1}
+                value={expiresInDays}
+                placeholder="Never"
+                onChange={(e) => setExpiresInDays(e.target.value)}
+                customPrefix={
+                  <AlarmClock size={16} className="text-nb-gray-300" />
+                }
+                customSuffix="Day(s)"
+              />
+            </div>
+          </div>
+
+          <FancyToggleSwitch
+            value={ephemeral}
+            onChange={setEphemeral}
+            label={
+              <>
+                <PowerOffIcon size={15} />
+                Ephemeral peers
+              </>
+            }
+            helpText="Peers offline for more than 10 minutes are removed automatically."
+          />
+
+          <FancyToggleSwitch
+            value={allowExtraDNSLabels}
+            onChange={setAllowExtraDNSLabels}
+            label={
+              <>
+                <GlobeIcon size={15} />
+                Allow extra DNS labels
+              </>
+            }
+            helpText="Enable multiple subdomain labels (e.g. host.dev.example.com)."
+          />
+
+          <FancyToggleSwitch
+            value={revoked}
+            onChange={setRevoked}
+            label={
+              <>
+                <PowerOffIcon size={15} />
+                Revoked
+              </>
+            }
+            helpText="Revoked mappings are ignored during enrollment but kept for audit."
+          />
+        </div>
+
+        <ModalFooter className="items-center">
+          <div className="flex gap-3 w-full justify-end">
+            <ModalClose asChild>
+              <Button variant="secondary">Cancel</Button>
+            </ModalClose>
+            <Button
+              variant="primary"
+              onClick={submit}
+              disabled={isDisabled}
+            >
+              {isEditing ? (
+                <>
+                  <SaveIcon size={16} />
+                  Save changes
+                </>
+              ) : (
+                <>
+                  <PlusCircle size={16} />
+                  Create mapping
+                </>
+              )}
+            </Button>
+          </div>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/modules/integrations/entra-device-auth/EntraDeviceMappingsTable.tsx
+++ b/src/modules/integrations/entra-device-auth/EntraDeviceMappingsTable.tsx
@@ -1,0 +1,304 @@
+import Badge from "@components/Badge";
+import Button from "@components/Button";
+import Paragraph from "@components/Paragraph";
+import SquareIcon from "@components/SquareIcon";
+import { DataTable } from "@components/table/DataTable";
+import DataTableHeader from "@components/table/DataTableHeader";
+import DataTableRefreshButton from "@components/table/DataTableRefreshButton";
+import { DataTableRowsPerPage } from "@components/table/DataTableRowsPerPage";
+import GetStartedTest from "@components/ui/GetStartedTest";
+import MultipleGroups from "@components/ui/MultipleGroups";
+import { ColumnDef, SortingState } from "@tanstack/react-table";
+import dayjs from "dayjs";
+import useFetchApi from "@utils/api";
+import {
+  FingerprintIcon,
+  GlobeIcon,
+  PlusCircle,
+  PowerOffIcon,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import { useGroups } from "@/contexts/GroupsProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import {
+  EntraDeviceAuth,
+  EntraDeviceMapping,
+} from "@/interfaces/EntraDeviceAuth";
+import { Group } from "@/interfaces/Group";
+import EmptyRow from "@/modules/common-table-rows/EmptyRow";
+import ExpirationDateRow from "@/modules/common-table-rows/ExpirationDateRow";
+import EntraDeviceMappingActionCell from "@/modules/integrations/entra-device-auth/EntraDeviceMappingActionCell";
+import EntraDeviceMappingModal from "@/modules/integrations/entra-device-auth/EntraDeviceMappingModal";
+
+/**
+ * CRUD data-table for Entra device auth mappings.
+ *
+ * Blocked with a friendly empty state when the integration itself isn't
+ * configured yet — the backend refuses to accept mappings in that state
+ * (HTTP 409 no_integration) and the admin can't meaningfully create them.
+ */
+export default function EntraDeviceMappingsTable() {
+  const { mutate } = useSWRConfig();
+  const { permission } = usePermissions();
+  const { groups: allGroups } = useGroups();
+
+  const { data: integration } = useFetchApi<EntraDeviceAuth>(
+    "/integrations/entra-device-auth",
+    true,
+  );
+
+  const { data: mappings, isLoading } = useFetchApi<EntraDeviceMapping[]>(
+    "/integrations/entra-device-auth/mappings",
+    true,
+  );
+
+  const canRead = permission?.entra_device_auth?.read ?? true;
+  const canCreate = permission?.entra_device_auth?.create ?? true;
+
+  const hasIntegration = !!integration?.id;
+
+  // Decorate each mapping with resolved Group objects so the Groups column
+  // can render real names rather than bare IDs.
+  const decorated = useMemo(() => {
+    if (!mappings) return [];
+    if (!allGroups) return mappings;
+    return mappings.map((m) => ({
+      ...m,
+      groups: (m.auto_groups ?? [])
+        .map((id) => allGroups.find((g) => g.id === id))
+        .filter(Boolean) as Group[],
+    }));
+  }, [mappings, allGroups]);
+
+  const [sorting, setSorting] = useLocalStorage<SortingState>(
+    "netbird-table-sort-entra-device-mappings",
+    [
+      { id: "priority", desc: false },
+      { id: "name", desc: false },
+    ],
+  );
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editMapping, setEditMapping] = useState<EntraDeviceMapping | null>(
+    null,
+  );
+
+  const handleCreate = () => {
+    setEditMapping(null);
+    setModalOpen(true);
+  };
+
+  const handleEdit = (mapping: EntraDeviceMapping) => {
+    setEditMapping(mapping);
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setEditMapping(null);
+  };
+
+  const columns: ColumnDef<EntraDeviceMapping>[] = [
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <DataTableHeader column={column}>Name</DataTableHeader>
+      ),
+      sortingFn: "text",
+      cell: ({ row }) => (
+        <div className="flex items-center gap-3">
+          <FingerprintIcon size={16} className="text-nb-gray-400" />
+          <span className="font-medium">{row.original.name}</span>
+          {row.original.revoked && (
+            <Badge variant="gray" useHover={false}>
+              Revoked
+            </Badge>
+          )}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "entra_group_id",
+      header: ({ column }) => (
+        <DataTableHeader column={column}>Entra group</DataTableHeader>
+      ),
+      cell: ({ row }) => (
+        <span className="text-xs text-nb-gray-400 font-mono">
+          {row.original.entra_group_id === "*" ? (
+            <Badge variant="blue" useHover={false}>
+              <GlobeIcon size={12} />
+              Any device in tenant
+            </Badge>
+          ) : (
+            row.original.entra_group_id
+          )}
+        </span>
+      ),
+    },
+    {
+      id: "groups",
+      accessorFn: (m) => m.auto_groups?.length ?? 0,
+      header: ({ column }) => (
+        <DataTableHeader column={column}>Auto-groups</DataTableHeader>
+      ),
+      cell: ({ row }) => (
+        <MultipleGroups
+          groups={row.original.groups ?? []}
+          label="Auto-assigned Groups"
+          description="Groups automatically assigned to peers enrolled via this mapping."
+        />
+      ),
+    },
+    {
+      accessorKey: "priority",
+      header: ({ column }) => (
+        <DataTableHeader column={column}>Priority</DataTableHeader>
+      ),
+      cell: ({ row }) => (
+        <span className="text-nb-gray-400">{row.original.priority ?? 0}</span>
+      ),
+    },
+    {
+      accessorKey: "ephemeral",
+      header: ({ column }) => (
+        <DataTableHeader column={column}>Ephemeral</DataTableHeader>
+      ),
+      cell: ({ row }) =>
+        row.original.ephemeral ? (
+          <Badge variant="gray" useHover={false}>
+            <PowerOffIcon size={12} />
+            Ephemeral
+          </Badge>
+        ) : (
+          <EmptyRow />
+        ),
+    },
+    {
+      accessorKey: "expires_at",
+      header: ({ column }) => (
+        <DataTableHeader column={column}>Expires</DataTableHeader>
+      ),
+      cell: ({ row }) => {
+        const exp = row.original.expires_at;
+        if (!exp) return <EmptyRow className="px-3" />;
+        const d = dayjs(exp);
+        if (!d.isValid() || d.year() <= 1) return <EmptyRow className="px-3" />;
+        return <ExpirationDateRow date={new Date(exp)} />;
+      },
+    },
+    {
+      id: "actions",
+      accessorKey: "id",
+      header: "",
+      cell: ({ row }) => (
+        <EntraDeviceMappingActionCell
+          mapping={row.original}
+          onEdit={handleEdit}
+        />
+      ),
+    },
+  ];
+
+  if (!canRead) {
+    return (
+      <Paragraph className="px-6 py-8">
+        You don&apos;t have permission to view mappings.
+      </Paragraph>
+    );
+  }
+
+  if (!hasIntegration) {
+    return (
+      <div className="px-default py-8">
+        <GetStartedTest
+          icon={
+            <SquareIcon
+              icon={<FingerprintIcon size={20} />}
+              color="gray"
+              size="large"
+            />
+          }
+          title="Configure the integration first"
+          description="Set up the Entra Device Auth integration (Configuration tab) before adding mappings. The backend refuses mappings while the integration is missing."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <EntraDeviceMappingModal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        mapping={editMapping}
+        key={modalOpen ? (editMapping?.id ?? "new") : "closed"}
+      />
+      <DataTable
+        isLoading={isLoading}
+        text="Mappings"
+        sorting={sorting}
+        setSorting={setSorting}
+        columns={columns}
+        data={decorated}
+        onRowClick={(row) => handleEdit(row.original)}
+        searchPlaceholder="Search by name or Entra group ID..."
+        getStartedCard={
+          <GetStartedTest
+            icon={
+              <SquareIcon
+                icon={<FingerprintIcon size={20} />}
+                color="gray"
+                size="large"
+              />
+            }
+            title="Add your first mapping"
+            description="Map an Entra security group (or the catch-all '*') to a set of NetBird auto-groups. Peers enrolled via /join/entra will be placed accordingly."
+            button={
+              <Button
+                variant="primary"
+                onClick={handleCreate}
+                disabled={!canCreate}
+              >
+                <PlusCircle size={16} />
+                Add mapping
+              </Button>
+            }
+          />
+        }
+        rightSide={() => (
+          <>
+            {mappings && mappings.length > 0 && (
+              <Button
+                variant="primary"
+                className="ml-auto"
+                onClick={handleCreate}
+                disabled={!canCreate}
+              >
+                <PlusCircle size={16} />
+                Add mapping
+              </Button>
+            )}
+          </>
+        )}
+      >
+        {(table) => (
+          <>
+            <DataTableRowsPerPage
+              table={table}
+              disabled={!mappings || mappings.length === 0}
+            />
+            <DataTableRefreshButton
+              isDisabled={!mappings || mappings.length === 0}
+              onClick={() => {
+                mutate("/integrations/entra-device-auth/mappings");
+                mutate("/groups");
+              }}
+            />
+          </>
+        )}
+      </DataTable>
+    </>
+  );
+}


### PR DESCRIPTION
## Describe your changes

Adds the dashboard-facing half of the Microsoft Entra device authentication integration already implemented in the management server (netbirdio/netbird#5977).

This PR **only** adds UI — no API contract changes are required beyond what the linked backend PR already ships.

### New page `/integrations/entra-device-auth`

A new admin page with two horizontally-tabbed panels:

1. **Configuration** — singleton integration config per account. Covers everything the backend `integrationDTO` accepts:
   * tenant ID, application (client) ID, client secret (write-only; the server masks returned values so we never echo the existing secret back).
   * optional issuer and audience overrides.
   * toggles for `enabled`, `require_intune_compliant`, `allow_tenant_only_fallback`.
   * `fallback_auto_groups` picker (shown when tenant-only fallback is enabled).
   * `mapping_resolution` selector (`strict_priority` | `union`).
   * optional `revalidation_interval` as a Go-duration string.
   * "Delete integration" action with a danger-style confirmation.

2. **Mappings** — CRUD list for Entra security group → NetBird auto-groups mappings, modelled after the Setup Keys table:
   * columns: name (with "Revoked" badge), Entra group ID (catch-all `*` rendered as a pill), auto-groups (`MultipleGroups` hover-card), priority, ephemeral, expires.
   * create/edit modal reuses `PeerGroupSelector`, `FancyToggleSwitch`, and the same "expires in days" input as `SetupKeyModal`.
   * row actions: revoke (PUT with `revoked: true`) and delete.
   * empty-state card when the integration hasn't been configured yet (the backend returns 409 `no_integration` in that case).

### Sidebar entry

New `Entra Device Auth` item in the main sidebar, gated on `permission?.entra_device_auth?.read`. Because the permission module is optional on the backend for backwards compatibility, the link stays visible by default and the server-side permission check remains the source of truth.

### TypeScript additions

* `src/interfaces/EntraDeviceAuth.ts` mirrors the backend's `integrationDTO`, `mappingDTO`, and `types.MappingResolution`.
* `src/interfaces/Permission.ts` gains an **optional** `entra_device_auth?: Permission` field so the UI stays compatible with management servers that don't publish the new module.

### Files

* `src/app/(dashboard)/integrations/layout.tsx`
* `src/app/(dashboard)/integrations/entra-device-auth/{layout.tsx,page.tsx}`
* `src/modules/integrations/entra-device-auth/{EntraDeviceAuthConfig.tsx,EntraDeviceMappingsTable.tsx,EntraDeviceMappingModal.tsx,EntraDeviceMappingActionCell.tsx}`
* `src/interfaces/EntraDeviceAuth.ts`
* `src/assets/icons/EntraDeviceIcon.tsx`
* `src/interfaces/Permission.ts` (optional new module)
* `src/layouts/Navigation.tsx` (sidebar wiring)

## Test your changes

1. Run the backend from netbirdio/netbird#5977.
2. `npm run dev` in the dashboard.
3. Sign in as an admin, open **Entra Device Auth** from the sidebar.
4. Configure the integration (tenant ID, client ID, client secret, issuer). Confirm that:
   * After save, the secret is never echoed back in plaintext.
   * Rotating the secret works (entering a new value while leaving the old masked input untouched produces a write).
   * Toggling `Allow tenant-only fallback` reveals/hides the fallback group picker.
   * Changing `Mapping resolution` and `Revalidation interval` round-trips correctly.
   * Deleting the integration prompts for confirmation and clears the Mappings tab.
5. Switch to **Mappings**, verify:
   * Empty-state card appears before the integration is configured.
   * Create / edit mapping round-trips all fields (`name`, `entra_group_id`, `auto_groups`, `priority`, `ephemeral`, `allow_extra_dns_labels`, `expires_at`, `revoked`).
   * `*` as the Entra group ID renders the "Any device in tenant" pill.
   * Revoke sets `revoked: true` via PUT; Delete removes the row via DELETE.

## Additional information

* Linked backend PR: netbirdio/netbird#5977.
* Cypress tests are intentionally out of scope for this PR; they can be added once the backend merges and a seeded test account is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Entra Device Auth integration management interface with a new navigation menu item.
  * Configuration panel for managing Entra Device authentication settings.
  * Device mapping interface to associate Entra security groups with auto-groups.
  * Permission-based access control for Entra Device Auth features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->