### PR TITLE
feat: Add UI for PKCE and JWKS URL upstream OIDC options

### DIFF
--- a/src/interfaces/IdentityProvider.ts
+++ b/src/interfaces/IdentityProvider.ts
@@ -77,6 +77,8 @@ export interface SSOIdentityProvider {
   issuer: string;
   client_id: string;
   redirect_url?: string;
+  pkce: boolean;
+  jwks_url: string;
 }
 
 export interface SSOIdentityProviderRequest {
@@ -85,4 +87,6 @@ export interface SSOIdentityProviderRequest {
   issuer: string;
   client_id: string;
   client_secret: string;
+  pkce: boolean;
+  jwks_url: string;
 }

--- a/src/modules/settings/IdentityProviderModal.tsx
+++ b/src/modules/settings/IdentityProviderModal.tsx
@@ -1,5 +1,6 @@
 import Button from "@components/Button";
 import Code from "@components/Code";
+import FancyToggleSwitch from "@components/FancyToggleSwitch";
 import HelpText from "@components/HelpText";
 import { Input } from "@components/Input";
 import { Label } from "@components/Label";
@@ -30,6 +31,8 @@ import {
   PlusCircle,
   SaveIcon,
   TagIcon,
+  ShieldCheck,
+  FileLock2,
 } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -94,6 +97,8 @@ export default function IdentityProviderModal({
   const [issuer, setIssuer] = useState(provider?.issuer ?? "");
   const [clientId, setClientId] = useState(provider?.client_id ?? "");
   const [clientSecret, setClientSecret] = useState("");
+  const [pkce, setPkce] = useState(provider?.pkce ?? false);
+  const [jwksUrl, setJwksUrl] = useState(provider?.jwks_url ?? "");
 
   const requiresIssuer = type !== "google" && type !== "microsoft";
 
@@ -108,12 +113,13 @@ export default function IdentityProviderModal({
     if (trimmedName.length === 0) return true;
     if (requiresIssuer && trimmedIssuer.length === 0) return true;
     if (trimmedClientId.length === 0) return true;
-    // Client secret required for new providers, or when client ID changed during edit
-    if ((!isEditing || clientIdChanged) && trimmedClientSecret.length === 0)
+    // Client secret required for new providers, or when client ID changed during edit,
+    // unless PKCE is enabled which allows public clients without a secret.
+    if ((!isEditing || clientIdChanged) && trimmedClientSecret.length === 0 && !pkce)
       return true;
 
     return false;
-  }, [name, issuer, clientId, clientSecret, isEditing, clientIdChanged, requiresIssuer]);
+  }, [name, issuer, clientId, clientSecret, isEditing, clientIdChanged, requiresIssuer, pkce]);
 
   const submit = () => {
     const payload: SSOIdentityProviderRequest = {
@@ -122,6 +128,8 @@ export default function IdentityProviderModal({
       issuer: trim(issuer),
       client_id: trim(clientId),
       client_secret: trim(clientSecret),
+      pkce,
+      jwks_url: trim(jwksUrl),
     };
 
     if (isEditing) {
@@ -258,6 +266,35 @@ export default function IdentityProviderModal({
                 }
               />
             </div>
+
+            <div>
+              <Label>JWKS URL (Optional)</Label>
+              <HelpText>
+                Override the default JSON Web Key Set URL from discovery
+              </HelpText>
+              <Input
+                placeholder={"https://login.example.com/common/discovery/keys"}
+                value={jwksUrl}
+                onChange={(e) => setJwksUrl(e.target.value)}
+                customPrefix={
+                  <FileLock2 size={16} className="text-nb-gray-300" />
+                }
+              />
+            </div>
+
+            <FancyToggleSwitch
+              value={pkce}
+              onChange={setPkce}
+              label={
+                <div className={"flex items-center gap-2"}>
+                  <ShieldCheck size={16} />
+                  Enable PKCE
+                </div>
+              }
+              helpText={
+                "Use Proof Key for Code Exchange (PKCE) for more secure authentication flows"
+              }
+            />
 
             <Separator />
 


### PR DESCRIPTION
This PR adds UI toggles and inputs for configuring PKCE and JWKS URLs for upstream OIDC identity providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added PKCE (Proof Key for Code Exchange) configuration option to Identity Provider settings with a dedicated toggle control
* Introduced JWKS URL input field for Identity Provider configuration
* Updated client secret validation to make it optional when PKCE is enabled, providing greater flexibility in authentication setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->