### PR TITLE
Add Microsoft AD FS support for embedded Dex identity providers

### DIFF
--- a/src/assets/icons/IdentityProviderIcons.tsx
+++ b/src/assets/icons/IdentityProviderIcons.tsx
@@ -23,6 +23,7 @@ export const idpIcon = (
     zitadel: <ZitadelIcon size={size} />,
     authentik: <AuthentikIcon size={size} />,
     keycloak: <KeycloakIcon size={size} />,
+    adfs: <MicrosoftIcon size={size} />,
     oidc: <KeyRound size={size} className="text-nb-gray-400" />,
   };
 

--- a/src/interfaces/IdentityProvider.ts
+++ b/src/interfaces/IdentityProvider.ts
@@ -44,7 +44,8 @@ export type SSOIdentityProviderType =
   | "pocketid"
   | "microsoft"
   | "authentik"
-  | "keycloak";
+  | "keycloak"
+  | "adfs";
 
 export const SSOIdentityProviderOptions: {
   value: SSOIdentityProviderType;
@@ -59,6 +60,7 @@ export const SSOIdentityProviderOptions: {
   { value: "pocketid", label: "PocketID" },
   { value: "authentik", label: "Authentik" },
   { value: "keycloak", label: "Keycloak" },
+  { value: "adfs", label: "Microsoft AD FS" },
 ];
 
 export const getSSOIdentityProviderLabelByType = (

--- a/src/modules/settings/IdentityProviderModal.tsx
+++ b/src/modules/settings/IdentityProviderModal.tsx
@@ -49,6 +49,7 @@ const issuerHints: Partial<Record<SSOIdentityProviderType, string>> = {
   okta: "https://{ORG}.okta.com",
   entra: "https://login.microsoftonline.com/{TENANT_ID}/v2.0",
   pocketid: "https://pocketid.example.com",
+  adfs: "https://adfs.example.com/adfs",
 };
 
 const defaultNames: Record<SSOIdentityProviderType, string> = {
@@ -61,6 +62,7 @@ const defaultNames: Record<SSOIdentityProviderType, string> = {
   pocketid: "PocketID",
   authentik: "Authentik",
   keycloak: "Keycloak",
+  adfs: "Microsoft AD FS",
 };
 
 type Props = {

--- a/src/modules/settings/IdentityProvidersTab.tsx
+++ b/src/modules/settings/IdentityProvidersTab.tsx
@@ -49,6 +49,7 @@ export const idpTypeLabels: Record<SSOIdentityProviderType, string> = {
   microsoft: "Microsoft",
   authentik: "Authentik",
   keycloak: "Keycloak",
+  adfs: "Microsoft AD FS",
 };
 
 type ActionCellProps = {


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Microsoft AD FS as a new identity provider option with full configuration UI and default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->