### PR TITLE
Fix IPv6 input across reverse proxy, routes and resources

### DIFF
--- a/src/contexts/ReverseProxiesProvider.tsx
+++ b/src/contexts/ReverseProxiesProvider.tsx
@@ -2,6 +2,7 @@
 
 import { notify } from "@components/Notification";
 import useFetchApi, { useApiCall } from "@utils/api";
+import { wrapIPv6 } from "@utils/ip";
 import React, {
   createContext,
   useCallback,
@@ -604,7 +605,7 @@ function formatTargetDestination(
   target: ReverseProxyTarget,
   resolvedHost?: string,
 ): string {
-  const host = target.host || resolvedHost || "localhost";
+  const host = wrapIPv6(target.host || resolvedHost || "localhost");
   const isDefault =
     (target.protocol === "http" && target.port === 80) ||
     (target.protocol === "https" && target.port === 443) ||

--- a/src/modules/networks/resources/NetworkResourceModal.tsx
+++ b/src/modules/networks/resources/NetworkResourceModal.tsx
@@ -19,6 +19,7 @@ import { HelpTooltip } from "@components/HelpTooltip";
 import { PeerGroupSelector } from "@components/PeerGroupSelector";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@components/Tabs";
 import { useApiCall } from "@utils/api";
+import { normalizeHostCIDR } from "@utils/ip";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePolicies } from "@/contexts/PoliciesProvider";
 import { useNetworksContext } from "@/modules/networks/NetworkProvider";
@@ -172,7 +173,7 @@ export function ResourceModalContent({
     const promise = create({
       name,
       description,
-      address,
+      address: normalizeHostCIDR(address),
       groups: savedGroups ? savedGroups.map((g) => g.id) : undefined,
       enabled,
     }).then(async (r) => {
@@ -196,7 +197,7 @@ export function ResourceModalContent({
     const promise = update({
       name,
       description,
-      address,
+      address: normalizeHostCIDR(address),
       groups: savedGroups ? savedGroups.map((g) => g.id) : undefined,
       enabled,
     }).then(async (r) => {

--- a/src/modules/networks/resources/ResourceSingleAddressInput.tsx
+++ b/src/modules/networks/resources/ResourceSingleAddressInput.tsx
@@ -58,7 +58,7 @@ export const ResourceSingleAddressInput = ({
 
     // Case 2: If it's not a valid domain, check if it's a valid CIDR
     if (!cidr.isValidAddress(value)) {
-      return "Please enter a valid IP or CIDR, e.g., 10.0.0.21, 192.168.1.0/24";
+      return "Please enter a valid IP or CIDR, e.g., 10.0.0.21, 192.168.1.0/24 or 2001:db8::/64";
     }
 
     return ""; // Valid CIDR

--- a/src/modules/networks/resources/ResourceSingleAddressInput.tsx
+++ b/src/modules/networks/resources/ResourceSingleAddressInput.tsx
@@ -58,7 +58,7 @@ export const ResourceSingleAddressInput = ({
 
     // Case 2: If it's not a valid domain, check if it's a valid CIDR
     if (!cidr.isValidAddress(value)) {
-      return "Please enter a valid IP or CIDR, e.g., 10.0.0.21, 192.168.1.0/24 or 2001:db8::/64";
+      return "Please enter a valid IP or CIDR, e.g., 10.0.0.21, 192.168.1.0/24, 2001:db8::1 or 2001:db8::/64";
     }
 
     return ""; // Valid CIDR

--- a/src/modules/onboarding/networks/OnboardingAddResource.tsx
+++ b/src/modules/onboarding/networks/OnboardingAddResource.tsx
@@ -179,15 +179,15 @@ export const OnboardingAddResource = ({
 
   const description = useMemo(() => {
     if (resourceType === "ip")
-      return "Enter a single IPv4 address of your resource";
+      return "Enter a single IPv4 or IPv6 address of your resource";
     if (resourceType === "subnet") return "Enter a CIDR range of your network";
     if (resourceType === "domain")
       return "Enter a domain name of your resource";
   }, [resourceType]);
 
   const placeholder = useMemo(() => {
-    if (resourceType === "ip") return "e.g., 192.168.31.45";
-    if (resourceType === "subnet") return "e.g., 192.168.1.0/24";
+    if (resourceType === "ip") return "e.g., 192.168.31.45 or 2001:db8::1";
+    if (resourceType === "subnet") return "e.g., 192.168.1.0/24 or 2001:db8::/64";
     if (resourceType === "domain")
       return "e.g., service.internal or *.services.internal";
   }, [resourceType]);
@@ -212,13 +212,13 @@ export const OnboardingAddResource = ({
             value={"ip"}
             title={"Single IP Address"}
             icon={<WorkflowIcon size={12} />}
-            description={"IPv4 address like 192.168.31.45"}
+            description={"IPv4 or IPv6 address like 192.168.31.45"}
           />
           <RadioCard
             value={"subnet"}
             title={"Entire Subnet"}
             icon={<NetworkIcon size={12} />}
-            description={"CIDR range like 192.168.0.0/24"}
+            description={"CIDR range like 192.168.0.0/24 or 2001:db8::/64"}
           />
           <RadioCard
             value={"domain"}

--- a/src/modules/onboarding/networks/OnboardingAddResource.tsx
+++ b/src/modules/onboarding/networks/OnboardingAddResource.tsx
@@ -2,6 +2,7 @@ import Button from "@components/Button";
 import { notify } from "@components/Notification";
 import { RadioCard, RadioCardGroup } from "@components/RadioCard";
 import { useApiCall } from "@utils/api";
+import { normalizeHostCIDR } from "@utils/ip";
 import { GlobeIcon, NetworkIcon, WorkflowIcon } from "lucide-react";
 import * as React from "react";
 import { useMemo, useState } from "react";
@@ -67,7 +68,7 @@ export const OnboardingAddResource = ({
           {
             name: resourceType === "subnet" ? "My Subnet" : "My Resource",
             description: "Created during onboarding",
-            address: resourceAddress,
+            address: normalizeHostCIDR(resourceAddress),
             enabled: true,
             groups: [],
           },

--- a/src/modules/onboarding/networks/OnboardingTestResource.tsx
+++ b/src/modules/onboarding/networks/OnboardingTestResource.tsx
@@ -32,8 +32,9 @@ export const OnboardingTestResource = ({
 
   const pingAddress = useMemo(() => {
     let a = resource?.address || "";
-    if (isHost && a.endsWith("/32")) {
-      a = a.slice(0, -3);
+    if (isHost) {
+      if (a.endsWith("/32")) a = a.slice(0, -3);
+      else if (a.endsWith("/128")) a = a.slice(0, -4);
     }
     if (isWildCard) return `(any subdomain of ${a})`;
     return isSubnet ? `(resource ip in your subnet)` : a;

--- a/src/modules/reverse-proxy/ReverseProxyAccessControlRules.tsx
+++ b/src/modules/reverse-proxy/ReverseProxyAccessControlRules.tsx
@@ -4,6 +4,7 @@ import HelpText from "@components/HelpText";
 import Button from "@components/Button";
 import { Input } from "@components/Input";
 import cidr from "ip-cidr";
+import { isIPv6 } from "@utils/ip";
 import {
   FlagIcon,
   MinusCircleIcon,
@@ -180,13 +181,17 @@ type Props = {
 function validateRule(rule: AccessRule): string {
   if (rule.type === "country" || !rule.value) return "";
   if (rule.type === "ip") {
-    const val = rule.value.includes("/") ? rule.value : `${rule.value}/32`;
+    let val = rule.value;
+    if (!val.includes("/")) {
+      const suffix = isIPv6(val) ? 128 : 32;
+      val = `${val}/${suffix}`;
+    }
     if (!cidr.isValidAddress(val)) {
-      return "Please enter a valid IP address, e.g., 85.203.15.42";
+      return "Please enter a valid IP address, e.g., 85.203.15.42 or 2001:db8::1";
     }
   } else {
     if (!rule.value.includes("/") || !cidr.isValidAddress(rule.value)) {
-      return "Please enter a valid CIDR block, e.g., 74.125.0.0/16";
+      return "Please enter a valid CIDR block, e.g., 74.125.0.0/16 or 2001:db8::/64";
     }
   }
   return "";
@@ -312,8 +317,8 @@ export const ReverseProxyAccessControlRules = ({
                   <Input
                     placeholder={
                       rule.type === "ip"
-                        ? "e.g., 85.203.15.42"
-                        : "e.g., 74.125.0.0/16"
+                        ? "e.g., 85.203.15.42 or 2001:db8::1"
+                        : "e.g., 74.125.0.0/16 or 2001:db8::/64"
                     }
                     value={rule.value}
                     onChange={(e) =>

--- a/src/modules/reverse-proxy/events/ReverseProxyEventsRequestCell.tsx
+++ b/src/modules/reverse-proxy/events/ReverseProxyEventsRequestCell.tsx
@@ -1,5 +1,6 @@
 import CopyToClipboardText from "@components/CopyToClipboardText";
 import TruncatedText from "@components/ui/TruncatedText";
+import { wrapIPv6 } from "@utils/ip";
 import * as React from "react";
 import {
   isL4Event,
@@ -32,9 +33,10 @@ export const ReverseProxyEventsUrlCell = ({ event, service }: Props) => {
   const isL4 = isL4Event(event);
   const listenPort = service?.listen_port;
 
+  const wrappedHost = wrapIPv6(event.host || "");
   const hostWithPort =
-    isL4 && listenPort ? `${event.host}:${listenPort}` : event.host || "-";
-  const fullUrl = isL4 ? hostWithPort : `${event.host}${event.path}`;
+    isL4 && listenPort ? `${wrappedHost}:${listenPort}` : wrappedHost || "-";
+  const fullUrl = isL4 ? hostWithPort : `${wrappedHost}${event.path}`;
 
   return (
     <TruncatedText
@@ -51,7 +53,7 @@ export const ReverseProxyEventsUrlCell = ({ event, service }: Props) => {
     >
       <CopyToClipboardText message={"URL has been copied to your clipboard"}>
         <span className="font-mono text-[0.82rem] whitespace-nowrap">
-          <span className="text-nb-gray-200">{event.host}</span>
+          <span className="text-nb-gray-200">{wrappedHost}</span>
           {isL4 && listenPort && (
             <span className="text-nb-gray-300">:{listenPort}</span>
           )}

--- a/src/modules/reverse-proxy/table/ReverseProxyTargetsCell.tsx
+++ b/src/modules/reverse-proxy/table/ReverseProxyTargetsCell.tsx
@@ -1,5 +1,6 @@
 import Badge from "@components/Badge";
 import Button from "@components/Button";
+import { wrapIPv6 } from "@utils/ip";
 import { PlusCircle, Server } from "lucide-react";
 import * as React from "react";
 import { usePermissions } from "@/contexts/PermissionsProvider";
@@ -20,7 +21,7 @@ export default function ReverseProxyTargetsCell({
   if (isL4Mode(reverseProxy.mode)) {
     const target = reverseProxy?.targets?.[0];
     const address = target.host
-      ? `${target.host}:${target.port}`
+      ? `${wrapIPv6(target.host)}:${target.port}`
       : `:${target.port}`;
 
     return (

--- a/src/modules/reverse-proxy/targets/ReverseProxyAddressInput.tsx
+++ b/src/modules/reverse-proxy/targets/ReverseProxyAddressInput.tsx
@@ -20,8 +20,10 @@ export function useReverseProxyAddress(target: Target | undefined) {
     if (!resourceAddress) return false;
     if (!cidr.isValidCIDR(resourceAddress)) return false;
     const parts = resourceAddress.split("/");
-    const mask = parts.length === 2 ? parseInt(parts[1], 10) : 32;
-    return mask < 32;
+    if (parts.length !== 2) return false;
+    const mask = parseInt(parts[1], 10);
+    const hostMask = resourceAddress.includes(":") ? 128 : 32;
+    return mask < hostMask;
   }, [target?.type, resourceAddress]);
 
   const cidrInfo = useMemo(() => {
@@ -84,13 +86,13 @@ export default function ReverseProxyAddressInput({
       value={target?.host ?? ""}
       onChange={(e) => {
         const host = isHostEditable
-          ? e.target.value.replace(/[^0-9.]/g, "")
+          ? e.target.value.replace(/[^0-9a-fA-F.:]/g, "")
           : e.target.value;
         onChange((prev) => prev && { ...prev, host });
       }}
       maxWidthClass={"w-full"}
       customSuffix={":"}
-      placeholder="e.g., 192.168.0.10"
+      placeholder="e.g., 192.168.0.10 or 2001:db8::1"
       disabled={!target}
       readOnly={target && !isHostEditable ? true : undefined}
       className={cn("rounded-r-none border-r-0", className)}

--- a/src/modules/routes/RouteModal.tsx
+++ b/src/modules/routes/RouteModal.tsx
@@ -335,7 +335,7 @@ export function RouteModalContent({
   const cidrError = useMemo(() => {
     if (networkRange == "") return "";
     const validCIDR = cidr.isValidAddress(networkRange);
-    if (!validCIDR) return "Please enter a valid CIDR, e.g., 192.168.1.0/24 or 2001:db8::/64";
+    if (!validCIDR) return "Please enter a valid IP or CIDR, e.g., 192.168.1.1, 192.168.1.0/24 or 2001:db8::/64";
   }, [networkRange]);
 
   const isGroupsEntered = useMemo(() => {
@@ -501,11 +501,11 @@ export function RouteModalContent({
                 )}
               >
                 <Label>Network Range</Label>
-                <HelpText>Add a private IPv4 or IPv6 address range</HelpText>
+                <HelpText>Add a private IPv4 or IPv6 address or range</HelpText>
                 <Input
                   ref={networkRangeRef}
                   customPrefix={<NetworkIcon size={16} />}
-                  placeholder={"e.g., 172.16.0.0/16 or 2001:db8::/64"}
+                  placeholder={"e.g., 172.16.0.1, 172.16.0.0/16 or 2001:db8::/64"}
                   value={networkRange}
                   data-cy={"network-range"}
                   className={"font-mono !text-[13px]"}

--- a/src/modules/routes/RouteModal.tsx
+++ b/src/modules/routes/RouteModal.tsx
@@ -505,7 +505,7 @@ export function RouteModalContent({
                 <Input
                   ref={networkRangeRef}
                   customPrefix={<NetworkIcon size={16} />}
-                  placeholder={"e.g., 172.16.0.1, 172.16.0.0/16 or 2001:db8::/64"}
+                  placeholder={"e.g., 172.16.0.1, 172.16.0.0/16, 2001:db8::1 or 2001:db8::/64"}
                   value={networkRange}
                   data-cy={"network-range"}
                   className={"font-mono !text-[13px]"}

--- a/src/modules/routes/RouteModal.tsx
+++ b/src/modules/routes/RouteModal.tsx
@@ -26,6 +26,7 @@ import InputDomain, { domainReducer } from "@components/ui/InputDomain";
 import { getOperatingSystem } from "@hooks/useOperatingSystem";
 import { IconDirectionSign } from "@tabler/icons-react";
 import { cn } from "@utils/helpers";
+import { normalizeHostCIDR } from "@utils/ip";
 import cidr from "ip-cidr";
 import { uniqBy } from "lodash";
 import {
@@ -308,7 +309,7 @@ export function RouteModalContent({
         enabled: enabled,
         peer: useSinglePeer ? routingPeer?.id : undefined,
         peer_groups: useSinglePeer ? undefined : peerGroups || undefined,
-        network: routeType === "ip-range" ? networkRange : undefined,
+        network: routeType === "ip-range" ? normalizeHostCIDR(networkRange) : undefined,
         domains: domainRouteNames,
         keep_route: useKeepRoute,
         metric: Number(metric) || 9999,
@@ -334,7 +335,7 @@ export function RouteModalContent({
   const cidrError = useMemo(() => {
     if (networkRange == "") return "";
     const validCIDR = cidr.isValidAddress(networkRange);
-    if (!validCIDR) return "Please enter a valid CIDR, e.g., 192.168.1.0/24";
+    if (!validCIDR) return "Please enter a valid CIDR, e.g., 192.168.1.0/24 or 2001:db8::/64";
   }, [networkRange]);
 
   const isGroupsEntered = useMemo(() => {
@@ -500,11 +501,11 @@ export function RouteModalContent({
                 )}
               >
                 <Label>Network Range</Label>
-                <HelpText>Add a private IPv4 address range</HelpText>
+                <HelpText>Add a private IPv4 or IPv6 address range</HelpText>
                 <Input
                   ref={networkRangeRef}
                   customPrefix={<NetworkIcon size={16} />}
-                  placeholder={"e.g., 172.16.0.0/16"}
+                  placeholder={"e.g., 172.16.0.0/16 or 2001:db8::/64"}
                   value={networkRange}
                   data-cy={"network-range"}
                   className={"font-mono !text-[13px]"}

--- a/src/utils/ip.test.ts
+++ b/src/utils/ip.test.ts
@@ -1,0 +1,87 @@
+import {
+  hostSuffixFor,
+  isIPv4,
+  isIPv6,
+  normalizeHostCIDR,
+  wrapIPv6,
+} from "./ip.js";
+
+type Case<T> = { input: string; expected: T; desc?: string };
+
+function run<T>(name: string, cases: Case<T>[], fn: (s: string) => T): number {
+  console.log(`\n=== ${name} ===`);
+  let failures = 0;
+  for (const { input, expected, desc } of cases) {
+    const actual = fn(input);
+    const ok = actual === expected;
+    if (!ok) failures++;
+    const label = desc ? `${JSON.stringify(input)} (${desc})` : JSON.stringify(input);
+    console.log(
+      `${ok ? "✓" : "✗"} ${label.padEnd(40)} → ${JSON.stringify(actual)}` +
+        (ok ? "" : ` (expected: ${JSON.stringify(expected)})`),
+    );
+  }
+  return failures;
+}
+
+let failures = 0;
+
+failures += run<boolean>("isIPv4", [
+  { input: "10.0.0.1", expected: true },
+  { input: "192.168.1.0", expected: true },
+  { input: "10.0.0.1/32", expected: true, desc: "v4 with prefix" },
+  { input: "10.0.0.0/24", expected: true, desc: "v4 subnet" },
+  { input: "2001:db8::1", expected: false, desc: "v6" },
+  { input: "::1", expected: false, desc: "v6 loopback" },
+  { input: "service.internal", expected: false, desc: "domain" },
+  { input: "*.example.com", expected: false, desc: "wildcard" },
+  { input: "", expected: false },
+  { input: "not-an-ip", expected: false },
+], isIPv4);
+
+failures += run<boolean>("isIPv6", [
+  { input: "2001:db8::1", expected: true },
+  { input: "::1", expected: true, desc: "loopback" },
+  { input: "::", expected: true, desc: "unspecified" },
+  { input: "2620:fe::fe", expected: true, desc: "anycast" },
+  { input: "2001:db8::1/128", expected: true, desc: "v6 host CIDR" },
+  { input: "2001:db8::/64", expected: true, desc: "v6 subnet" },
+  { input: "10.0.0.1", expected: false, desc: "v4" },
+  { input: "service.internal", expected: false, desc: "domain" },
+  { input: "", expected: false },
+], isIPv6);
+
+failures += run<string>("normalizeHostCIDR", [
+  { input: "10.0.0.1", expected: "10.0.0.1/32", desc: "bare v4 → /32" },
+  { input: "2001:db8::1", expected: "2001:db8::1/128", desc: "bare v6 → /128" },
+  { input: "2620:fe::fe", expected: "2620:fe::fe/128" },
+  { input: "10.0.0.0/24", expected: "10.0.0.0/24", desc: "v4 CIDR unchanged" },
+  { input: "2001:db8::/64", expected: "2001:db8::/64", desc: "v6 CIDR unchanged" },
+  { input: "10.0.0.1/32", expected: "10.0.0.1/32", desc: "v4 /32 unchanged" },
+  { input: "2001:db8::1/128", expected: "2001:db8::1/128", desc: "v6 /128 unchanged" },
+  { input: "service.internal", expected: "service.internal", desc: "domain passthrough" },
+  { input: "*.example.com", expected: "*.example.com", desc: "wildcard passthrough" },
+  { input: "", expected: "" },
+  { input: "  10.0.0.1  ", expected: "10.0.0.1/32", desc: "trims whitespace" },
+  { input: "not-an-ip", expected: "not-an-ip", desc: "invalid passthrough" },
+], normalizeHostCIDR);
+
+failures += run<number | null>("hostSuffixFor", [
+  { input: "10.0.0.1", expected: 32 },
+  { input: "2001:db8::1", expected: 128 },
+  { input: "service.internal", expected: null, desc: "domain" },
+  { input: "", expected: null },
+], hostSuffixFor);
+
+failures += run<string>("wrapIPv6", [
+  { input: "2001:db8::1", expected: "[2001:db8::1]" },
+  { input: "2620:fe::fe", expected: "[2620:fe::fe]" },
+  { input: "::1", expected: "[::1]" },
+  { input: "[2001:db8::1]", expected: "[2001:db8::1]", desc: "already wrapped" },
+  { input: "10.0.0.1", expected: "10.0.0.1", desc: "v4 unchanged" },
+  { input: "example.com", expected: "example.com", desc: "domain unchanged" },
+  { input: "", expected: "", desc: "empty" },
+], wrapIPv6);
+
+console.log(`\n${failures} test(s) failed`);
+process.exit(failures > 0 ? 1 : 0);

--- a/src/utils/ip.ts
+++ b/src/utils/ip.ts
@@ -1,0 +1,35 @@
+import { Address4, Address6 } from "ip-address";
+
+export function isIPv6(value: string): boolean {
+  const bare = value.split("/")[0];
+  return bare.includes(":") && Address6.isValid(bare);
+}
+
+export function isIPv4(value: string): boolean {
+  const bare = value.split("/")[0];
+  return !bare.includes(":") && Address4.isValid(bare);
+}
+
+// normalizeHostCIDR adds a host-suffix (/32 for IPv4, /128 for IPv6) to bare IP
+// addresses. Existing CIDR strings and non-IP values are returned unchanged.
+export function normalizeHostCIDR(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes("/")) return trimmed;
+  if (isIPv4(trimmed)) return `${trimmed}/32`;
+  if (isIPv6(trimmed)) return `${trimmed}/128`;
+  return trimmed;
+}
+
+// hostSuffixFor returns the host suffix (32 or 128) for a given address family.
+export function hostSuffixFor(value: string): number | null {
+  if (isIPv6(value)) return 128;
+  if (isIPv4(value)) return 32;
+  return null;
+}
+
+// wrapIPv6 wraps a bare IPv6 host in square brackets for use in URL/host:port
+// contexts. Bracketed IPv6 ("[...]"), IPv4, and hostnames are returned as-is.
+export function wrapIPv6(host: string): string {
+  if (!host || host.startsWith("[")) return host;
+  return isIPv6(host) ? `[${host}]` : host;
+}


### PR DESCRIPTION
## Description

Adds IPv6 support across the dashboard inputs that previously only accepted IPv4 and fixes a few display bugs where IPv6 hosts produced ambiguous or unusable URLs.

- Accept IPv6 in the reverse proxy target address input (the input filter stripped colons and hex)
- Treat IPv6 subnets correctly in the reverse proxy target host/range detection
- Normalize bare IPv4 and IPv6 to /32 and /128 on submit for routes and network resources so a single host can be entered without a prefix
- Wrap IPv6 hosts in brackets when composing host:port URLs (Destination column, L4 targets cell, events URL cell) so copy/paste produces a valid URL like http://[2620:fe::fe]:8080
- Update placeholders, help text and error messages to mention IPv6
- Handle /128 in onboarding ping display
- Add unit tests for the new ip helper

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved IPv6 handling and display across reverse-proxy, network, routing, and onboarding UIs (correct IPv6 host and host:port formatting).

* **Bug Fixes**
  * Consistent address normalization when creating/updating resources and routes.
  * Enhanced IP/CIDR validation with IPv6-aware suffix inference and clearer error/placeholder guidance for IPv4 and IPv6.

* **Tests**
  * Added tests covering IP utility behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/dashboard/pull/638)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->