### PR TITLE
Add Logout URL to the Identity Provider dialog

### DIFF
--- a/src/modules/settings/IdentityProviderModal.tsx
+++ b/src/modules/settings/IdentityProviderModal.tsx
@@ -1,6 +1,7 @@
 import Button from "@components/Button";
 import Code from "@components/Code";
 import HelpText from "@components/HelpText";
+import InlineLink from "@components/InlineLink";
 import { Input } from "@components/Input";
 import { Label } from "@components/Label";
 import {
@@ -265,25 +266,38 @@ export default function IdentityProviderModal({
 
             <Separator />
 
-            <div>
-              <Label>Redirect / Callback URL</Label>
-              <HelpText>
-                Copy this URL to your identity provider configuration
-              </HelpText>
-              <Code codeToCopy={redirectUrl} message={copyMessage}>
-                <Code.Line>{redirectUrl}</Code.Line>
-              </Code>
-            </div>
+            <div className={"flex flex-col gap-3"}>
+              <div>
+                <Label>Endpoint URLs</Label>
+                <HelpText margin={false}>
+                  Add these to your identity provider configuration
+                </HelpText>
+              </div>
 
-            <div>
-              <Label>Logout URL</Label>
-              <HelpText>
-                Copy this URL to your identity provider&apos;s logout / post-logout
-                redirect configuration
-              </HelpText>
-              <Code codeToCopy={logoutUrl} message={logoutCopyMessage}>
-                <Code.Line>{logoutUrl}</Code.Line>
-              </Code>
+              <div>
+                <Label className={"text-xs mb-1"}>Redirect / Callback</Label>
+                <Code codeToCopy={redirectUrl} message={copyMessage}>
+                  <Code.Line>{redirectUrl}</Code.Line>
+                </Code>
+              </div>
+
+              <div>
+                <Label className={"text-xs mb-1"}>Logout</Label>
+                <Code codeToCopy={logoutUrl} message={logoutCopyMessage}>
+                  <Code.Line>{logoutUrl}</Code.Line>
+                </Code>
+                <HelpText margin={false} className={"mt-1.5"}>
+                  Not all identity providers support logout.{" "}
+                  <InlineLink
+                    href={
+                      "https://docs.netbird.io/selfhosted/identity-providers"
+                    }
+                    target={"_blank"}
+                  >
+                    Learn more
+                  </InlineLink>
+                </HelpText>
+              </div>
             </div>
           </div>
 

--- a/src/modules/settings/IdentityProviderModal.tsx
+++ b/src/modules/settings/IdentityProviderModal.tsx
@@ -72,8 +72,10 @@ type Props = {
 };
 
 const copyMessage = "Redirect URL was copied to your clipboard!";
+const logoutCopyMessage = "Logout URL was copied to your clipboard!";
 const config = loadConfig();
 const redirectUrl = `${config.apiOrigin}/oauth2/callback`;
+const logoutUrl = `${config.apiOrigin}/oauth2/logout/callback`;
 
 export default function IdentityProviderModal({
   open,
@@ -270,6 +272,17 @@ export default function IdentityProviderModal({
               </HelpText>
               <Code codeToCopy={redirectUrl} message={copyMessage}>
                 <Code.Line>{redirectUrl}</Code.Line>
+              </Code>
+            </div>
+
+            <div>
+              <Label>Logout URL</Label>
+              <HelpText>
+                Copy this URL to your identity provider&apos;s logout / post-logout
+                redirect configuration
+              </HelpText>
+              <Code codeToCopy={logoutUrl} message={logoutCopyMessage}>
+                <Code.Line>{logoutUrl}</Code.Line>
               </Code>
             </div>
           </div>


### PR DESCRIPTION
## Description

When configuring an identity provider (Settings → Identity Providers → Add Identity Provider), the dialog already surfaces a copyable **Redirect / Callback URL** that admins paste into their IdP. Setting up single logout requires a second value — the post-logout callback URL — which the dialog did not expose.

<img width="1200" height="636" alt="Screenshot From 2026-06-02 13-14-42" src="https://github.com/user-attachments/assets/fc27f2f9-7189-46d6-96c1-5aacc294cd98" />

This adds a read-only, click-to-copy **Logout URL** field at the bottom of the dialog so it can be copied straight into the identity provider's logout / post-logout redirect configuration.

## Summary

- Added a **Logout URL** section directly below the existing Redirect / Callback URL field in `src/modules/settings/IdentityProviderModal.tsx`.
- The URL is derived from the runtime config as `${config.apiOrigin}/oauth2/logout/callback` (e.g. `https://netbird.example.com/oauth2/logout/callback`), mirroring how the redirect URL is built from `/oauth2/callback`.
- Reuses the existing `Code` / `Label` / `HelpText` components, so copy-to-clipboard behavior and styling are consistent with the redirect URL block, with its own clipboard confirmation toast.
- Shown in both Add and Edit modes. No new dependencies, interfaces, or API changes — display-only.

## Issue ticket number and link

## Documentation
Select exactly one:

- [X] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:
https://github.com/netbirdio/docs/pull/775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Logout URL display in identity provider endpoint configuration, alongside the Redirect/Callback URL.
  * Endpoint URLs are now organized in a dedicated section with copy-to-clipboard functionality for both URLs.
  * Enhanced documentation links for endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->