### PR TITLE
Group Networks and Routes under Network Routing

### DIFF
--- a/src/app/(dashboard)/network-routes/page.tsx
+++ b/src/app/(dashboard)/network-routes/page.tsx
@@ -37,12 +37,12 @@ export default function NetworkRoutes() {
           <div className={"p-default py-6"}>
             <Breadcrumbs>
               <Breadcrumbs.Item
-                href={"/network-routes"}
-                label={"Network Routes"}
+                label={"Network Routing"}
                 icon={<NetworkRoutesIcon size={13} />}
               />
+              <Breadcrumbs.Item href={"/network-routes"} label={"Routes"} />
             </Breadcrumbs>
-            <h1 ref={headingRef}>Network Routes</h1>
+            <h1 ref={headingRef}>Routes</h1>
             <Paragraph>
               Access other networks like LANs and VPCs without installing
               NetBird on every resource.{" "}

--- a/src/app/(dashboard)/networks/page.tsx
+++ b/src/app/(dashboard)/networks/page.tsx
@@ -26,10 +26,10 @@ export default function Networks() {
       <div className={"p-default py-6"}>
         <Breadcrumbs>
           <Breadcrumbs.Item
-            href={"/networks"}
-            label={"Networks"}
+            label={"Network Routing"}
             icon={<NetworkRoutesIcon size={13} />}
           />
+          <Breadcrumbs.Item href={"/networks"} label={"Networks"} />
         </Breadcrumbs>
         <h1 ref={headingRef}>Networks</h1>
         <Paragraph>

--- a/src/components/SidebarItem.tsx
+++ b/src/components/SidebarItem.tsx
@@ -38,11 +38,31 @@ export default function SidebarItem({
 }: Readonly<SidebarItemProps>) {
   const path = usePathname();
 
+  // Hrefs of nested child items, so a collapsible parent without its
+  // own href (e.g. "Network Routing") can still tell when one of its
+  // children matches the current route.
+  const childRoutes = useMemo(() => {
+    const routes: { href: string; exact: boolean }[] = [];
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
+      const props = child.props as Partial<SidebarItemProps>;
+      if (props.href) {
+        routes.push({ href: props.href, exact: !!props.exactPathMatch });
+      }
+    });
+    return routes;
+  }, [children]);
+
   // Check if any child route is active (for collapsible items)
   const hasActiveChild = useMemo(() => {
-    if (!collapsible || !href) return false;
-    return path === href || path.startsWith(href + "/");
-  }, [collapsible, href, path]);
+    if (!collapsible) return false;
+    if (href && (path === href || path.startsWith(href + "/"))) return true;
+    return childRoutes.some(({ href: childHref, exact }) =>
+      exact
+        ? path === childHref
+        : path === childHref || path.startsWith(childHref + "/"),
+    );
+  }, [collapsible, href, path, childRoutes]);
 
   const [open, setOpen] = React.useState(hasActiveChild);
 

--- a/src/modules/networks/misc/NetworkNavigation.tsx
+++ b/src/modules/networks/misc/NetworkNavigation.tsx
@@ -6,19 +6,26 @@ import { usePermissions } from "@/contexts/PermissionsProvider";
 export const NetworkNavigation = () => {
   const { permission } = usePermissions();
   return (
-    <>
+    <SidebarItem
+      icon={<NetworkRoutesIcon />}
+      label={"Network Routing"}
+      collapsible
+      visible={permission.networks.read || permission.routes.read}
+    >
       <SidebarItem
-        icon={<NetworkRoutesIcon />}
         label={"Networks"}
+        isChild
         href={"/networks"}
+        exactPathMatch={true}
         visible={permission.networks.read}
       />
       <SidebarItem
-        icon={<NetworkRoutesIcon />}
+        label={"Routes"}
+        isChild
         href={"/network-routes"}
-        label={"Network Routes"}
+        exactPathMatch={true}
         visible={permission.routes.read}
       />
-    </>
+    </SidebarItem>
   );
 };


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
<img width="500" height="509" alt="Screenshot 2026-06-04 at 19 19 47" src="https://github.com/user-attachments/assets/c3c3535d-a982-430e-82d7-21a28085bd29" />
<img width="448" height="511" alt="Screenshot 2026-06-04 at 19 20 14" src="https://github.com/user-attachments/assets/d38e65a8-b13f-4199-ac27-654d091af054" />

Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why). Will be done separately 

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized network navigation with a collapsible "Network Routing" parent menu containing nested "Networks" and "Routes" items for improved navigation hierarchy.

* **UI Improvements**
  * Enhanced breadcrumb navigation structure across network pages.
  * Improved active state detection for nested navigation items, ensuring correct highlighting when navigating through hierarchical menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->