### PR TITLE
Update reverse proxy modals

### DIFF
--- a/src/interfaces/ReverseProxy.ts
+++ b/src/interfaces/ReverseProxy.ts
@@ -244,6 +244,12 @@ export const REVERSE_PROXY_SETTINGS_DOCS_LINK =
 export const REVERSE_PROXY_CLUSTERS_DOCS_LINK =
   "https://docs.netbird.io/manage/reverse-proxy/bring-your-own-proxy#shared-and-account-clusters";
 
+export const REVERSE_PROXY_SELFHOSTED_ROUTING_DOCS_LINK =
+  "https://docs.netbird.io/selfhosted/migration/enable-reverse-proxy#connecting-through-traefik-instead-of-docker-network";
+
+export const REVERSE_PROXY_ENV_REFERENCE_DOCS_LINK =
+  "https://docs.netbird.io/selfhosted/migration/enable-reverse-proxy#environment-variable-reference";
+
 export const REVERSE_PROXY_CUSTOM_DOMAINS_DOCS_LINK =
   "https://docs.netbird.io/manage/reverse-proxy/custom-domains";
 

--- a/src/modules/reverse-proxy/ReverseProxyModal.tsx
+++ b/src/modules/reverse-proxy/ReverseProxyModal.tsx
@@ -37,7 +37,7 @@ import {
 } from "lucide-react";
 import { Callout } from "@components/Callout";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import ReverseProxyIcon from "@/assets/icons/ReverseProxyIcon";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
@@ -316,17 +316,19 @@ export default function ReverseProxyModal({
   );
   const effectiveDirectUpstream = hasClusterTarget || directUpstream;
 
-  // When the operator changes the only cluster target to another type, the
-  // auto-applied NetBird-only state no longer matches reality: revert it so
-  // the auth, access, and advanced steps return to their public-service
-  // layout. Explicit NetBird-only choices (privateFromCluster === false) are
-  // left untouched.
-  useEffect(() => {
-    if (privateFromCluster && !hasClusterTarget) {
+  // Reverts the NetBird-only state that was auto-applied when a cluster
+  // target was picked, once the committed targets no longer include a
+  // cluster. Explicit NetBird-only choices (privateFromCluster === false)
+  // are left untouched.
+  const resetClusterPrivateIfNeeded = (next: ReverseProxyTarget[]) => {
+    if (
+      privateFromCluster &&
+      !next.some((t) => t.target_type === ReverseProxyTargetType.CLUSTER)
+    ) {
       togglePrivate(false);
       setPrivateFromCluster(false);
     }
-  }, [privateFromCluster, hasClusterTarget]);
+  };
 
   const [linkAuthEnabled, setLinkAuthEnabled] = useState(
     reverseProxy?.auth?.link_auth?.enabled ?? false,
@@ -408,17 +410,14 @@ export default function ReverseProxyModal({
   }, [canContinueToSettings, isPrivate, accessGroups.length]);
 
   const saveTarget = (targetData: ReverseProxyTarget) => {
-    if (editingTargetIndex !== null) {
-      // Update existing target
-      setTargets(
-        targets.map((t, i) =>
-          i === editingTargetIndex ? { ...t, ...targetData } : t,
-        ),
-      );
-    } else {
-      // Add new target
-      setTargets([...targets, targetData]);
-    }
+    const next =
+      editingTargetIndex !== null
+        ? targets.map((t, i) =>
+            i === editingTargetIndex ? { ...t, ...targetData } : t,
+          )
+        : [...targets, targetData];
+    setTargets(next);
+    resetClusterPrivateIfNeeded(next);
     setTargetModalOpen(false);
     setEditingTargetIndex(null);
   };
@@ -429,7 +428,9 @@ export default function ReverseProxyModal({
   };
 
   const removeTarget = (index: number) => {
-    setTargets(targets.filter((_, i) => i !== index));
+    const next = targets.filter((_, i) => i !== index);
+    setTargets(next);
+    resetClusterPrivateIfNeeded(next);
   };
 
   const toggleTargetEnabled = (index: number) => {

--- a/src/modules/reverse-proxy/ReverseProxyModal.tsx
+++ b/src/modules/reverse-proxy/ReverseProxyModal.tsx
@@ -37,7 +37,7 @@ import {
 } from "lucide-react";
 import { Callout } from "@components/Callout";
 import { useRouter } from "next/navigation";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import ReverseProxyIcon from "@/assets/icons/ReverseProxyIcon";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
@@ -209,6 +209,12 @@ export default function ReverseProxyModal({
     reverseProxy?.private ?? false,
   );
 
+  // Tracks whether NetBird-only was switched on automatically because the
+  // operator picked a cluster target (see onClusterPick), as opposed to an
+  // explicit choice in the NetBird-Only modal. Only auto-enabled private is
+  // reverted when the cluster target is later removed or changed.
+  const [privateFromCluster, setPrivateFromCluster] = useState(false);
+
   // togglePrivate normalises related state when the operator flips
   // NetBird-only access. Private services are HTTP-only, so we drop out
   // of L4 mode. NetBird-only and the other auth modes are mutually
@@ -309,6 +315,18 @@ export default function ReverseProxyModal({
     [targets],
   );
   const effectiveDirectUpstream = hasClusterTarget || directUpstream;
+
+  // When the operator changes the only cluster target to another type, the
+  // auto-applied NetBird-only state no longer matches reality: revert it so
+  // the auth, access, and advanced steps return to their public-service
+  // layout. Explicit NetBird-only choices (privateFromCluster === false) are
+  // left untouched.
+  useEffect(() => {
+    if (privateFromCluster && !hasClusterTarget) {
+      togglePrivate(false);
+      setPrivateFromCluster(false);
+    }
+  }, [privateFromCluster, hasClusterTarget]);
 
   const [linkAuthEnabled, setLinkAuthEnabled] = useState(
     reverseProxy?.auth?.link_auth?.enabled ?? false,
@@ -1073,6 +1091,7 @@ export default function ReverseProxyModal({
           // already private.
           if (!isPrivate) {
             togglePrivate(true);
+            setPrivateFromCluster(true);
           }
         }}
       />
@@ -1127,11 +1146,13 @@ export default function ReverseProxyModal({
           setTimeout(() => {
             setAccessGroups(groups);
             togglePrivate(true);
+            setPrivateFromCluster(false);
           }, 200);
         }}
         onRemove={() => {
           setTimeout(() => {
             togglePrivate(false);
+            setPrivateFromCluster(false);
           }, 200);
         }}
       />

--- a/src/modules/reverse-proxy/auth/AuthNetBirdOnlyModal.tsx
+++ b/src/modules/reverse-proxy/auth/AuthNetBirdOnlyModal.tsx
@@ -65,7 +65,6 @@ export default function AuthNetBirdOnlyModal({
               </div>
             }
             users={users}
-            hideAllGroup={true}
           />
           <div className="flex gap-3 w-full justify-between mt-6">
             {isEditing ? (

--- a/src/modules/reverse-proxy/clusters/ClustersModal.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersModal.tsx
@@ -29,8 +29,11 @@ import { useSWRConfig } from "swr";
 import { useApiCall } from "@/utils/api";
 import { cn, validator } from "@utils/helpers";
 import { GRPC_API_ORIGIN, isNetBirdHosted } from "@/utils/netbird";
+import { SelectDropdown } from "@components/select/SelectDropdown";
 import {
   REVERSE_PROXY_CLUSTERS_DOCS_LINK,
+  REVERSE_PROXY_ENV_REFERENCE_DOCS_LINK,
+  REVERSE_PROXY_SELFHOSTED_ROUTING_DOCS_LINK,
   ReverseProxyClusterToken,
 } from "@/interfaces/ReverseProxy";
 
@@ -39,12 +42,43 @@ type Props = {
   onOpenChange: (open: boolean) => void;
 };
 
+type DeployMethod = "docker" | "compose" | "kubernetes";
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+
+const renderHighlightedCommand = (command: string, highlights: string[]) => {
+  const valid = highlights.filter((h) => h && h.trim().length > 0);
+  const pattern =
+    valid.length > 0
+      ? new RegExp(`(${valid.map(escapeRegExp).join("|")})`, "g")
+      : null;
+
+  return command.split("\n").map((line, lineIndex) => (
+    <Code.Line key={lineIndex}>
+      {pattern
+        ? line.split(pattern).map((part, partIndex) =>
+            valid.includes(part) ? (
+              <span key={partIndex} className={"text-netbird"}>
+                {part}
+              </span>
+            ) : (
+              part
+            ),
+          )
+        : line}
+    </Code.Line>
+  ));
+};
+
 export const ClustersModal = ({ open, onOpenChange }: Props) => {
   const { mutate } = useSWRConfig();
   const [tab, setTab] = useState("domain");
   const [domain, setDomain] = useState("");
   const [token, setToken] = useState("");
   const [isGeneratingToken, setIsGeneratingToken] = useState(true);
+  const [deployMethod, setDeployMethod] = useState<DeployMethod>("docker");
 
   const tokenRequest = useApiCall<ReverseProxyClusterToken>(
     "/reverse-proxies/proxy-tokens",
@@ -67,17 +101,121 @@ export const ClustersModal = ({ open, onOpenChange }: Props) => {
     ? "https://api.netbird.io"
     : GRPC_API_ORIGIN || "";
 
+  const tokenValue = token || "<TOKEN>";
+
   const dockerCommand = `docker run -d \\
- -v /var/lib/certs:/certs \\
+ -v proxy_certs:/certs \\
  -e NB_PROXY_CERTIFICATE_DIRECTORY=/certs \\
  -e NB_PROXY_ALLOW_INSECURE=true \\
  -e NB_PROXY_MANAGEMENT_ADDRESS=${managementUrl} \\
  -e NB_PROXY_ACME_CERTIFICATES=true \\
  -e NB_PROXY_DOMAIN=${domain} \\
  -e NB_PROXY_LOG_LEVEL=info \\
- -e NB_PROXY_TOKEN=${token || "<TOKEN>"} \\
+ -e NB_PROXY_TOKEN=${tokenValue} \\
+ -e NB_PROXY_PRIVATE=true \\
+ -e NB_PROXY_ADDRESS=:443 \\
  -p 80:80 -p 443:443 \\
  netbirdio/reverse-proxy:latest`;
+
+  const composeCommand = `services:
+  reverse-proxy:
+    image: netbirdio/reverse-proxy:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      NB_PROXY_CERTIFICATE_DIRECTORY: /certs
+      NB_PROXY_ALLOW_INSECURE: "true"
+      NB_PROXY_MANAGEMENT_ADDRESS: "${managementUrl}"
+      NB_PROXY_ACME_CERTIFICATES: "true"
+      NB_PROXY_DOMAIN: "${domain}"
+      NB_PROXY_LOG_LEVEL: info
+      NB_PROXY_TOKEN: "${tokenValue}"
+      NB_PROXY_PRIVATE: "true"
+      NB_PROXY_ADDRESS: ":443"
+    volumes:
+      - proxy_certs:/certs
+volumes:
+  proxy_certs:`;
+
+  const kubernetesCommand = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netbird-reverse-proxy
+  labels:
+    app: netbird-reverse-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: netbird-reverse-proxy
+  template:
+    metadata:
+      labels:
+        app: netbird-reverse-proxy
+    spec:
+      containers:
+        - name: reverse-proxy
+          image: netbirdio/reverse-proxy:latest
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          env:
+            - name: NB_PROXY_CERTIFICATE_DIRECTORY
+              value: /certs
+            - name: NB_PROXY_ALLOW_INSECURE
+              value: "true"
+            - name: NB_PROXY_MANAGEMENT_ADDRESS
+              value: "${managementUrl}"
+            - name: NB_PROXY_ACME_CERTIFICATES
+              value: "true"
+            - name: NB_PROXY_DOMAIN
+              value: "${domain}"
+            - name: NB_PROXY_LOG_LEVEL
+              value: info
+            - name: NB_PROXY_TOKEN
+              value: "${tokenValue}"
+            - name: NB_PROXY_PRIVATE
+              value: "true"              
+            - name: NB_PROXY_ADDRESS
+              value: ":443"
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+      volumes:
+        - name: certs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbird-reverse-proxy
+spec:
+  type: LoadBalancer
+  selector:
+    app: netbird-reverse-proxy
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443`;
+
+  const deployment = {
+    docker: { label: "Docker", title: "Run the Proxy with Docker", command: dockerCommand },
+    compose: {
+      label: "Docker Compose",
+      title: "Run the Proxy with Docker Compose",
+      command: composeCommand,
+    },
+    kubernetes: {
+      label: "Kubernetes",
+      title: "Deploy the Proxy on Kubernetes",
+      command: kubernetesCommand,
+    },
+  }[deployMethod];
 
   const generateToken = useCallback(async () => {
     setIsGeneratingToken(true);
@@ -230,15 +368,48 @@ export const ClustersModal = ({ open, onOpenChange }: Props) => {
           </TabsContent>
 
           <TabsContent value={"install"} className={"pb-8"}>
-            <div className={"px-8 flex flex-col"}>
-              <div>
-                <Label>Run the Proxy with Docker</Label>
-                <HelpText>
-                  Run the following command on your machine to start the proxy.
-                </HelpText>
+            <div className={"px-8 flex flex-col gap-4"}>
+              <div className={"flex items-end justify-between gap-4"}>
+                <div>
+                  <Label>{deployment.title}</Label>
+                  <HelpText className={"mb-0"}>
+                    {deployMethod === "kubernetes"
+                      ? "Apply the following manifest to your cluster to start the proxy."
+                      : "Run the following on your machine to start the proxy."}
+                  </HelpText>
+                </div>
+                <div className={"w-[180px] shrink-0"}>
+                  <SelectDropdown
+                    value={deployMethod}
+                    onChange={(v) => setDeployMethod(v as DeployMethod)}
+                    options={[
+                      { value: "docker", label: "Docker" },
+                      { value: "compose", label: "Docker Compose" },
+                      { value: "kubernetes", label: "Kubernetes" },
+                    ]}
+                  />
+                </div>
               </div>
+
+              {!isNetBirdHosted() && (
+                <Callout variant={"warning"}>
+                  For self-hosted deployments, make sure the proxy service
+                  routes are configured on your NetBird management server before
+                  starting the proxy.&nbsp;
+                  <InlineLink
+                    href={REVERSE_PROXY_SELFHOSTED_ROUTING_DOCS_LINK}
+                    target={"_blank"}
+                    className={"block mt-1"}
+                  >
+                     Required routing endpoints
+                    <ExternalLinkIcon size={12} />
+                  </InlineLink>
+                </Callout>
+              )}
+
               <Code
-                codeToCopy={dockerCommand}
+                key={deployMethod}
+                codeToCopy={deployment.command}
                 className={cn(
                   "overflow-hidden",
                   isGeneratingToken && "!border-nb-gray-930",
@@ -252,33 +423,23 @@ export const ClustersModal = ({ open, onOpenChange }: Props) => {
                   </div>
                 )}
 
-                <Code.Line>docker run -d \</Code.Line>
-                <Code.Line> -v /var/lib/certs:/certs \</Code.Line>
-                <Code.Line>
-                  {" "}
-                  -e NB_PROXY_CERTIFICATE_DIRECTORY=/certs \
-                </Code.Line>
-                <Code.Line> -e NB_PROXY_ALLOW_INSECURE=true \</Code.Line>
-                <Code.Line>
-                  {" "}
-                  -e NB_PROXY_MANAGEMENT_ADDRESS=
-                  <span className={"text-netbird"}>{managementUrl}</span> \
-                </Code.Line>
-                <Code.Line> -e NB_PROXY_ACME_CERTIFICATES=true \</Code.Line>
-                <Code.Line>
-                  {" "}
-                  -e NB_PROXY_DOMAIN=
-                  <span className={"text-netbird"}>{domain}</span> \
-                </Code.Line>
-                <Code.Line> -e NB_PROXY_LOG_LEVEL=info \</Code.Line>
-                <Code.Line>
-                  {" "}
-                  -e NB_PROXY_TOKEN=
-                  <span className={"text-netbird"}>{token || "<TOKEN>"}</span> \
-                </Code.Line>
-                <Code.Line> -p 80:80 -p 443:443 \</Code.Line>
-                <Code.Line> netbirdio/reverse-proxy:latest</Code.Line>
+                {renderHighlightedCommand(deployment.command, [
+                  managementUrl,
+                  domain,
+                  tokenValue,
+                ])}
               </Code>
+
+              <HelpText className={"mb-0"}>
+                Need to fine-tune the proxy? See all available&nbsp;
+                <InlineLink
+                  href={REVERSE_PROXY_ENV_REFERENCE_DOCS_LINK}
+                  target={"_blank"}
+                >
+                  environment variables
+                  <ExternalLinkIcon size={12} />
+                </InlineLink>
+              </HelpText>
             </div>
           </TabsContent>
         </Tabs>

--- a/src/modules/reverse-proxy/domain/CustomDomainSelector.tsx
+++ b/src/modules/reverse-proxy/domain/CustomDomainSelector.tsx
@@ -35,7 +35,7 @@ export function CustomDomainSelector({
     domains
       ?.filter((d) => d.type === ReverseProxyDomainType.FREE)
       .forEach((domain) => {
-        const isSelfHosted = isSelfHostedCluster(
+        const isAccountCluster = isSelfHostedCluster(
           domain?.target_cluster ?? domain?.domain,
         );
         opts.push({
@@ -46,12 +46,12 @@ export function CustomDomainSelector({
               <div className="flex items-center gap-2">
                 <TruncatedText text={`.${domain.domain}`} maxWidth={"260px"} />
               </div>
-              {isSelfHosted ? (
-                <SmallBadge text="Self-hosted" variant="sky" size="md" />
+              {isAccountCluster ? (
+                <SmallBadge text="Account" variant="sky" size="md" />
               ) : isNetBirdHosted() ? (
                 <SmallBadge text="Free" variant="green" size="md" />
               ) : (
-                <SmallBadge text="Cluster" variant="green" size="md" />
+                <SmallBadge text="Shared" variant="green" size="md" />
               )}
             </div>
           ),


### PR DESCRIPTION
## Issue ticket number and link

  1. NetBird-Only access — allow the "All" group
  The NetBird-Only auth modal previously hid the All group from the group selector (hideAllGroup). It's now selectable, so a service can be made reachable from all NetBird peers.

  2. Fix stuck NetBird-Only state when switching away from a cluster target
  Picking a cluster target auto-enables NetBird-only access (a cluster target is only reachable over the WireGuard overlay, so public auth modes don't apply). Previously, if the operator changed their mind and committed a
  peer/resource target instead, the auto-applied NetBird-only state stuck around — leaving the warning banner up, the Authentication tab locked to NetBird-only, and Direct Upstream stuck on.

  Now, when the committed targets no longer include a cluster, the auto-applied NetBird-only state resets so it's not enforced by default. An explicit NetBird-only choice (made via the modal) is tracked separately and never
  auto-reset. The reset runs on target save/remove against the committed target list, so picking a cluster correctly keeps NetBird-only enabled until the operator actually swaps the target.

  3. Cluster setup — Docker Compose & Kubernetes deployment options
  The "Run the Proxy" step now offers a deployment-method picker (Docker / Docker Compose / Kubernetes) in addition to the existing docker run command. Each generates the equivalent config with the same env vars, and the
  live-substituted values (management URL, domain, token) are highlighted via a shared renderer. This also unified the Docker command's display with what actually gets copied (previously the shown lines and the copied command
  differed on the certs volume and NB_PROXY_ADDRESS).

  4. Cluster setup — self-hosted routing notice + env var reference
  - Added a warning callout (shown only for self-hosted deployments) reminding operators to configure the proxy service routes on their management server, linking to the Traefik routing docs.
  - Added a link to the environment-variable reference for additional proxy tuning options. 
  
  5. Cluster tags — align with Account / Shared terminology
  In the domain picker shown when adding a service/target, cluster tags now read Account (was "Self-hosted") and Shared (was "Cluster"), matching the current cluster-type model. Free and Custom tags are unchanged.

## Screenshots

<img width="588" height="884" alt="Screenshot 2026-06-04 at 19 39 44" src="https://github.com/user-attachments/assets/e660dbe7-bad7-44a7-b0fa-0e9aed1741ee" />


<img width="561" height="707" alt="Screenshot 2026-06-04 at 19 39 34" src="https://github.com/user-attachments/assets/87775f7e-d3ff-49df-962e-b3b8d7affee8" />


<img width="794" height="879" alt="image" src="https://github.com/user-attachments/assets/6e5d1134-cd5f-43c8-bf8c-c73da9196e3e" />



## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/767
