### PR TITLE
Edit banner to IPv6 kh link

### DIFF
--- a/announcements.json
+++ b/announcements.json
@@ -1,8 +1,8 @@
 [
   {
     "tag": "New",
-    "text": "NetBird Reverse Proxy - Expose internal services to the public with automatic TLS and optional authentication.",
-    "link": "https://docs.netbird.io/manage/reverse-proxy",
+    "text": "IPv6 Overlay Addressing - Peers can now receive both IPv4 and IPv6 overlay addresses, with full DNS and routing support.",
+    "link": "https://netbird.io/knowledge-hub/ipv6-overlay-addressing",
     "linkText": "Learn more",
     "variant": "important",
     "isExternal": true,


### PR DESCRIPTION
## Summary

Update `announcements.json` to link to the IPv6 Overlay Addressing on Knowledge Hub.

```
[
  {
    "tag": "New",
    "text": "IPv6 Overlay Addressing - Peers can now receive both IPv4 and IPv6 overlay addresses, with full DNS and routing support.",
    "link": "https://netbird.io/knowledge-hub/ipv6-overlay-addressing",
    "linkText": "Learn more",
    "variant": "important",
    "isExternal": true,
    "closeable": true,
    "isCloudOnly": false
  }
]
```

## Issue ticket number and link
none

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated in-app announcement to highlight IPv6 Overlay Addressing information with relevant resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->