### PR TITLE
Insert link to remote jobs documentation

### DIFF
--- a/src/modules/peer/PeerRemoteJobsSection.tsx
+++ b/src/modules/peer/PeerRemoteJobsSection.tsx
@@ -26,7 +26,7 @@ export const PeerRemoteJobsSection = ({ peerID }: Props) => {
             <Paragraph>
               Remotely trigger actions such as debug bundles or other tasks on
               this peer, without requiring CLI access.{" "}
-              <InlineLink href={"https://docs.netbird.io"} target={"_blank"}>
+              <InlineLink href={"https://docs.netbird.io/manage/peers/remote-jobs"} target={"_blank"}>
                 Learn more
                 <ExternalLinkIcon size={12} />
               </InlineLink>


### PR DESCRIPTION
Replaced general link to docs homepage with exact Documentation link for Remote Jobs

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): Minor update without any interaction with documented behavior. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Learn more" documentation link in the Peer Remote Jobs section to point to the specific remote jobs documentation page instead of the general documentation root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->