### PR TITLE
fix: support punycode TLDs in URL regex

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -130,7 +130,7 @@ export const validator = {
   isValidUrl: (urlString: string) => {
     const urlPattern = new RegExp(
       "^(https?:\\/\\/)?" + // validate protocol
-        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+([a-z]{2,}|xn--[a-z\\d-]+)|localhost|" + // validate domain name
+        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+([a-z]{2,}|xn--[a-z\\d](?:[a-z\\d-]*[a-z\\d])?)|localhost|" + // validate domain name
         "((\\d{1,3}\\.){3}\\d{1,3}))" + // validate OR ip (v4) address
         "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // validate port and path
         "(\\?[;&a-z\\d%_.~+=-]*)?" + // validate query string

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -130,7 +130,7 @@ export const validator = {
   isValidUrl: (urlString: string) => {
     const urlPattern = new RegExp(
       "^(https?:\\/\\/)?" + // validate protocol
-        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|localhost|" + // validate domain name
+        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+([a-z]{2,}|xn--[a-z\\d-]+)|localhost|" + // validate domain name
         "((\\d{1,3}\\.){3}\\d{1,3}))" + // validate OR ip (v4) address
         "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // validate port and path
         "(\\?[;&a-z\\d%_.~+=-]*)?" + // validate query string


### PR DESCRIPTION
## Issue ticket number and link

No related issue — this is a small self-contained fix.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal regex fix in URL validation — no user-facing behavior or API changes, so documentation update is not required.

---

## Summary

Update the URL validation regex to support internationalized domain names (IDN) in Punycode format.

## Problem

The current regex rejects valid IDN TLDs because the TLD part only allows letters:

```js
(([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}
//                              ^^^^^^^^
//                      only letters allowed
```

As a result, URLs with Punycode TLDs fail validation, even though they are perfectly valid. Examples of such TLDs:
- `.xn--p1ai`
- `.xn--fiqs8s`
- `.xn--qxam`
- `.xn--mgba3a4f16a`

## Solution

Split the TLD matching into two cases:
- Regular TLDs: letters only, 2+ chars (e.g. `.com`, `.org`, `.net`)
- Punycode TLDs: `xn--` prefix followed by letters, digits and hyphens (e.g. `.xn--p1ai`, `.xn--fiqs8s`)

```js
(([a-z\d]([a-z\d-]*[a-z\d])*)\.)+([a-z]{2,}|xn--[a-z\d-]+)
```

## Test cases

| URL | Before | After |
|---|---|---|
| `https://example.com` | ✅ | ✅ |
| `https://example.org` | ✅ | ✅ |
| `https://example.xn--p1ai` | ❌ | ✅ |
| `https://example.xn--fiqs8s` | ❌ | ✅ |
| `https://xn--80adjurfhd.xn--c1aao5a.xn--p1ai` | ❌ | ✅ |
| `http://localhost:3000` | ✅ | ✅ |
| `https://192.168.0.1/path` | ✅ | ✅ |

## Notes

- Backwards compatible: all previously valid URLs remain valid.
- The fix is generic and covers all IDN TLDs that follow the Punycode encoding standard (RFC 3492), not just specific ones.
- For production-grade TLD validation, consider using a dedicated library (e.g. `tldts`) with the Public Suffix List, since the set of TLDs changes over time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation to support internationalized domain names by accepting Punycode-form domains (e.g., xn--...). This enhances compatibility with global domain names and reduces false negatives when entering non-ASCII domains.
  * No changes to public interfaces or exported behavior visible to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->