### PR TITLE
Restore combined Peers page with server and device filters

### DIFF
--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -17,6 +17,13 @@ import ModalHeader from "@components/modal/ModalHeader";
 import { notify } from "@components/Notification";
 import Paragraph from "@components/Paragraph";
 import { PeerGroupSelector } from "@components/PeerGroupSelector";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@components/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@components/Tabs";
 import FullScreenLoading from "@components/ui/FullScreenLoading";
 import LoginExpiredBadge from "@components/ui/LoginExpiredBadge";
@@ -61,7 +68,6 @@ import RoutesProvider from "@/contexts/RoutesProvider";
 import { useHasChanges } from "@/hooks/useHasChanges";
 import type { Group } from "@/interfaces/Group";
 import type { Peer } from "@/interfaces/Peer";
-import type { User } from "@/interfaces/User";
 import PageContainer from "@/layouts/PageContainer";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
 import { AccessiblePeersSection } from "@/modules/peer/AccessiblePeersSection";
@@ -74,6 +80,14 @@ import ReverseProxiesProvider, {
 import { ReverseProxyFlatTargetsTabContent } from "@/modules/reverse-proxy/targets/flat/ReverseProxyFlatTargetsTabContent";
 import { PeerEditIPModal } from "@/modules/peer/PeerEditIPModal";
 import { PeerSSHToggle } from "@/modules/peer/PeerSSHToggle";
+import {
+  inferPeerKind,
+  normalizePeerKind,
+  PEER_KIND_LABELS,
+  supportsPeerKind,
+  type PeerKind,
+  type ResolvedPeerKind,
+} from "@/modules/peers/peerKind";
 import { RDPButton } from "@/modules/remote-access/rdp/RDPButton";
 import { SSHButton } from "@/modules/remote-access/ssh/SSHButton";
 import { PeerExpirationSettings } from "@/modules/peer/PeerExpirationSettings";
@@ -119,17 +133,8 @@ export default function PeerPage() {
   );
 }
 
-// Route the user back to the list view that matches the peer's kind
-// (a real user owner → /peers/users, otherwise /peers/servers). Used
-// for the breadcrumb and the Cancel back-button so they don't bounce
-// through the legacy /peers redirect.
-function peerListPath(user: User | undefined): string {
-  const hasRealUser = !!user && !user.is_service_user;
-  return hasRealUser ? "/peers/users" : "/peers/servers";
-}
-
 function PeerOverview() {
-  const { peer, user } = usePeer();
+  const { peer } = usePeer();
 
   return (
     <PageContainer>
@@ -138,7 +143,7 @@ function PeerOverview() {
           <div className={"p-default py-6 pb-0"}>
             <Breadcrumbs>
               <Breadcrumbs.Item
-                href={peerListPath(user)}
+                href={"/peers"}
                 label={"Peers"}
                 icon={<PeerIcon size={13} />}
               />
@@ -307,7 +312,7 @@ const PeerHeader = () => {
             <Button
               variant={"default"}
               className={"w-full"}
-              onClick={() => router.push(peerListPath(user))}
+              onClick={() => router.push("/peers")}
             >
               Cancel
             </Button>
@@ -481,6 +486,9 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
   const [showEditIPModal, setShowEditIPModal] = useState(false);
   const [showEditIPv6Modal, setShowEditIPv6Modal] = useState(false);
   const { permission } = usePermissions();
+  const hasPeerKind = supportsPeerKind(peer);
+  const selectedPeerKind = normalizePeerKind(peer.kind);
+  const inferredPeerKind = inferPeerKind(peer);
 
   const countryText = useMemo(() => {
     return getRegionByPeer(peer);
@@ -507,6 +515,22 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
         setShowEditIPv6Modal(false);
       }),
       loadingMessage: "Updating peer IPv6...",
+    });
+  };
+
+  const handleSavePeerKind = (kind: PeerKind) => {
+    if (!hasPeerKind || !permission.peers.update || kind === selectedPeerKind) {
+      return;
+    }
+
+    notify({
+      title: peer.name,
+      description: "Peer type was successfully updated",
+      promise: update({ kind }).then(() => {
+        mutate("/peers/" + peer.id);
+        mutate("/peers");
+      }),
+      loadingMessage: "Updating peer type...",
     });
   };
 
@@ -613,6 +637,32 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
             }
             value={peer.hostname}
           />
+
+          {hasPeerKind && (
+            <Card.ListItem
+              tooltip={false}
+              label={
+                <>
+                  <MonitorSmartphoneIcon size={16} className={"shrink-0"} />
+                  Peer Type
+                </>
+              }
+              value={
+                permission.peers.update ? (
+                  <PeerKindSelect
+                    value={selectedPeerKind}
+                    inferredKind={inferredPeerKind}
+                    onChange={handleSavePeerKind}
+                  />
+                ) : (
+                  <PeerKindValue
+                    value={selectedPeerKind}
+                    inferredKind={inferredPeerKind}
+                  />
+                )
+              }
+            />
+          )}
 
           <Card.ListItem
             label={
@@ -724,6 +774,63 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
         </Card.List>
       </Card>
     </>
+  );
+}
+
+function PeerKindValue({
+  value,
+  inferredKind,
+}: Readonly<{
+  value: PeerKind;
+  inferredKind: ResolvedPeerKind;
+}>) {
+  return (
+    <>
+      {PEER_KIND_LABELS[value]}
+      {value === "auto" && (
+        <span className={"text-nb-gray-300"}>
+          {" "}
+          ({PEER_KIND_LABELS[inferredKind]})
+        </span>
+      )}
+    </>
+  );
+}
+
+function PeerKindSelect({
+  value,
+  inferredKind,
+  onChange,
+}: Readonly<{
+  value: PeerKind;
+  inferredKind: ResolvedPeerKind;
+  onChange: (kind: PeerKind) => void;
+}>) {
+  return (
+    <Select value={value} onValueChange={(kind) => onChange(kind as PeerKind)}>
+      <SelectTrigger className={"h-9 min-w-[190px] text-left"}>
+        <div className={"flex items-center gap-1.5 whitespace-nowrap"}>
+          <SelectValue />
+          {value === "auto" && (
+            <span className={"text-nb-gray-300"}>
+              ({PEER_KIND_LABELS[inferredKind]})
+            </span>
+          )}
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem
+          value={"auto"}
+          description={`Uses the current ${PEER_KIND_LABELS[
+            inferredKind
+          ].toLowerCase()} classification.`}
+        >
+          {PEER_KIND_LABELS.auto}
+        </SelectItem>
+        <SelectItem value={"device"}>{PEER_KIND_LABELS.device}</SelectItem>
+        <SelectItem value={"server"}>{PEER_KIND_LABELS.server}</SelectItem>
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/src/app/(dashboard)/peers/page.tsx
+++ b/src/app/(dashboard)/peers/page.tsx
@@ -1,5 +1,150 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function PeersIndex() {
-  redirect("/peers/users");
+import Breadcrumbs from "@components/Breadcrumbs";
+import FullTooltip from "@components/FullTooltip";
+import InlineLink from "@components/InlineLink";
+import Paragraph from "@components/Paragraph";
+import SkeletonTable from "@components/skeletons/SkeletonTable";
+import { usePortalElement } from "@hooks/usePortalElement";
+import { ExternalLinkIcon, InfoIcon } from "lucide-react";
+import React, { lazy, Suspense, useMemo } from "react";
+import PeerIcon from "@/assets/icons/PeerIcon";
+import PeersProvider, { usePeers } from "@/contexts/PeersProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useUsers } from "@/contexts/UsersProvider";
+import PageContainer from "@/layouts/PageContainer";
+import { SetupModalContent } from "@/modules/setup-netbird-modal/SetupModal";
+
+const PeersTable = lazy(() => import("@/modules/peers/PeersTable"));
+
+export default function PeersPage() {
+  const { isRestricted } = usePermissions();
+
+  return (
+    <PageContainer>
+      {isRestricted ? (
+        <PeersBlockedView />
+      ) : (
+        <PeersProvider>
+          <PeersView />
+        </PeersProvider>
+      )}
+    </PageContainer>
+  );
+}
+
+function PeersView() {
+  const { peers, isLoading: isPeersLoading } = usePeers();
+  const { users, isLoading: isUsersLoading } = useUsers();
+  const { ref: headingRef, portalTarget } =
+    usePortalElement<HTMLHeadingElement>();
+
+  const isLoading = isPeersLoading || isUsersLoading;
+  const peersWithUser = useMemo(() => {
+    if (!peers || !users) return undefined;
+    return peers.map((peer) => ({
+      ...peer,
+      user: users.find((u) => u.id === peer.user_id),
+    }));
+  }, [peers, users]);
+
+  return (
+    <>
+      <div className={"p-default py-6"}>
+        <Breadcrumbs>
+          <Breadcrumbs.Item
+            href={"/peers"}
+            label={"Peers"}
+            icon={<PeerIcon size={13} />}
+            active
+          />
+        </Breadcrumbs>
+        <h1 ref={headingRef}>
+          Peers
+          <FullTooltip
+            side={"right"}
+            align={"center"}
+            className={"ml-2 align-middle"}
+            content={
+              <div className={"max-w-md space-y-3 text-xs leading-relaxed"}>
+                <div>
+                  <div className={"font-medium text-nb-gray-100"}>Servers</div>
+                  <div>
+                    Servers, VMs, autonomous agents and other unattended
+                    machines with no user behind them, typically enrolled with a
+                    setup key.
+                  </div>
+                </div>
+                <div>
+                  <div className={"font-medium text-nb-gray-100"}>Devices</div>
+                  <div>
+                    Laptops, phones and other personal devices with a user
+                    behind them, typically added when the user signs in with
+                    SSO.
+                  </div>
+                </div>
+              </div>
+            }
+          >
+            <span
+              className={
+                "inline-flex h-5 w-5 cursor-help items-center justify-center rounded-full text-nb-gray-500 transition-colors hover:text-nb-gray-200"
+              }
+            >
+              <InfoIcon size={14} />
+            </span>
+          </FullTooltip>
+        </h1>
+        <Paragraph>
+          A list of all machines and devices connected to your private network.{" "}
+          <InlineLink
+            href={"https://docs.netbird.io/how-to/add-machines-to-your-network"}
+            target={"_blank"}
+          >
+            Learn more
+            <ExternalLinkIcon size={12} />
+          </InlineLink>
+        </Paragraph>
+      </div>
+      <Suspense fallback={<SkeletonTable />}>
+        <PeersTable
+          isLoading={isLoading}
+          peers={peersWithUser}
+          headingTarget={portalTarget}
+          showKindFilters
+        />
+      </Suspense>
+    </>
+  );
+}
+
+function PeersBlockedView() {
+  return (
+    <div className={"flex items-center justify-center flex-col"}>
+      <div className={"p-default py-6 max-w-3xl text-center"}>
+        <h1>Add new device to your network</h1>
+        <Paragraph className={"inline"}>
+          To get started, install NetBird and log in using your email account.
+          After that you should be connected. If you have further questions
+          check out our{" "}
+          <InlineLink
+            href={"https://docs.netbird.io/how-to/getting-started#installation"}
+            target={"_blank"}
+          >
+            Installation Guide
+            <ExternalLinkIcon size={12} />
+          </InlineLink>
+        </Paragraph>
+      </div>
+      <div className={"px-3 pt-1 pb-8 max-w-3xl w-full"}>
+        <div
+          className={
+            "rounded-md border border-nb-gray-900/70 grid w-full bg-nb-gray-930/40 stepper-bg-variant"
+          }
+        >
+          <SetupModalContent header={false} footer={false} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -160,6 +160,7 @@ interface DataTableProps<TData, TValue> {
   setRowSelection?: React.Dispatch<React.SetStateAction<RowSelectionState>>;
   useRowId?: boolean;
   headingTarget?: HTMLHeadingElement | null;
+  headingCountLabel?: string;
   showResetFilterButton?: boolean;
   serverSidePagination?: boolean;
   hasServerSideFilters?: boolean;
@@ -224,6 +225,7 @@ export function DataTable<TData, TValue>({
   setRowSelection,
   useRowId,
   headingTarget,
+  headingCountLabel,
   showResetFilterButton = true,
   serverSidePagination = false,
   hasServerSideFilters,
@@ -643,6 +645,7 @@ export function DataTable<TData, TValue>({
       <DataTableHeadingPortal
         table={table}
         headingTarget={headingTarget}
+        countLabel={headingCountLabel}
         totalRecords={totalRecords}
         manualPagination={manualPagination}
         hasActiveFilters={hasServerSideFilters}

--- a/src/components/table/DataTableHeadingPortal.tsx
+++ b/src/components/table/DataTableHeadingPortal.tsx
@@ -1,11 +1,12 @@
 import { Table } from "@tanstack/react-table";
 import * as React from "react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
 type Props<TData> = {
   table: Table<TData> | null;
   headingTarget?: HTMLHeadingElement | null;
+  countLabel?: string;
   totalRecords?: number;
   manualPagination?: boolean;
   hasActiveFilters?: boolean;
@@ -14,12 +15,18 @@ type Props<TData> = {
 export const DataTableHeadingPortal = function <TData>({
   table,
   headingTarget,
+  countLabel = "",
   totalRecords,
   manualPagination,
   hasActiveFilters,
 }: Props<TData>) {
   const hasMounted = useRef(false);
   const initialTotalRecords = useRef<number | undefined>(undefined);
+  const portalContainer = useRef<HTMLSpanElement | null>(null);
+
+  if (!portalContainer.current && typeof document !== "undefined") {
+    portalContainer.current = document.createElement("span");
+  }
 
   if (
     manualPagination &&
@@ -29,7 +36,6 @@ export const DataTableHeadingPortal = function <TData>({
     initialTotalRecords.current = totalRecords;
   }
 
-  if (!headingTarget) return;
   if (!hasMounted.current) hasMounted.current = true;
 
   const filteredItems = manualPagination
@@ -48,8 +54,6 @@ export const DataTableHeadingPortal = function <TData>({
     ? getTotalRecords()
     : table?.getPreFilteredRowModel().rows.length;
 
-  if (!totalItems || totalItems == 1) return;
-
   const hasAnyFiltersActive = manualPagination
     ? hasActiveFilters ?? totalRecords !== initialTotalRecords.current
     : table &&
@@ -58,27 +62,48 @@ export const DataTableHeadingPortal = function <TData>({
         table?.getState().globalFilter === ""
       );
 
-  const portalContainer = document.createElement("span");
-  headingTarget.prepend(portalContainer);
+  const showHeadingCount = !!totalItems && totalItems !== 1;
+
+  useEffect(() => {
+    const container = portalContainer.current;
+    if (!container) return;
+
+    if (!headingTarget || !showHeadingCount) {
+      container.remove();
+      return;
+    }
+
+    headingTarget.prepend(container);
+    return () => {
+      container.remove();
+    };
+  }, [headingTarget, showHeadingCount]);
+
+  if (!headingTarget || !showHeadingCount || !portalContainer.current) {
+    return null;
+  }
 
   return createPortal(
     <Heading
       hasAnyFilterActive={hasAnyFiltersActive}
+      countLabel={countLabel}
       totalItems={totalItems}
       filteredItems={filteredItems}
     />,
-    portalContainer,
+    portalContainer.current,
   );
 };
 
 type HeadingProps = {
   hasAnyFilterActive: boolean | null;
+  countLabel: string;
   filteredItems?: number;
   totalItems?: number;
 };
 
 const Heading = ({
   hasAnyFilterActive,
+  countLabel,
   filteredItems,
   totalItems,
 }: HeadingProps) => {
@@ -86,9 +111,10 @@ const Heading = ({
     return (
       <>
         <span className={"text-netbird"}>{filteredItems}</span> of {totalItems}{" "}
+        {countLabel}
       </>
     );
   }
 
-  return `${totalItems} `;
+  return `${totalItems} ${countLabel}`;
 };

--- a/src/contexts/PeerProvider.tsx
+++ b/src/contexts/PeerProvider.tsx
@@ -11,6 +11,7 @@ import { Group, GroupPeer } from "@/interfaces/Group";
 import { Peer } from "@/interfaces/Peer";
 import { User } from "@/interfaces/User";
 import { PeerSSHInstructions } from "@/modules/peer/PeerSSHInstructions";
+import type { PeerKind } from "@/modules/peers/peerKind";
 
 type Props = {
   children: React.ReactNode;
@@ -31,6 +32,7 @@ const PeerContext = React.createContext(
       approval_required?: boolean;
       ip?: string;
       ipv6?: string;
+      kind?: PeerKind;
     }) => Promise<Peer>;
     toggleSSH: (newState: boolean) => Promise<void>;
     setSSHInstructionsModal: (open: boolean) => void;
@@ -46,8 +48,7 @@ export default function PeerProvider({
 }: Props) {
   const { user, isLoading: isUserLoading } = usePeerUser(peer);
   const { peerGroups, isLoading: isGroupsLoading } = usePeerGroups(peer);
-  const isLoading =
-    isGroupsLoading || (peer.user_id ? isUserLoading : false);
+  const isLoading = isGroupsLoading || (peer.user_id ? isUserLoading : false);
   const peerRequest = useApiCall<Peer>("/peers", true);
   const { confirm } = useDialog();
   const { mutate } = useSWRConfig();
@@ -84,29 +85,43 @@ export default function PeerProvider({
     approval_required?: boolean;
     ip?: string;
     ipv6?: string;
+    kind?: PeerKind;
   }) => {
-    return peerRequest.put(
-      {
-        peerId: peer?.id,
-        name: props.name != undefined ? props.name : peer.name,
-        ssh_enabled: props.ssh != undefined ? props.ssh : peer.ssh_enabled,
-        login_expiration_enabled:
-          props.loginExpiration != undefined
-            ? props.loginExpiration
-            : peer.login_expiration_enabled,
-        inactivity_expiration_enabled:
-          props?.inactivityExpiration == undefined
-            ? undefined
-            : props.inactivityExpiration,
-        approval_required:
-          props?.approval_required == undefined
-            ? undefined
-            : props.approval_required,
-        ip: props.ip != undefined ? props.ip : undefined,
-        ipv6: props.ipv6 != undefined ? props.ipv6 : undefined,
-      },
-      `/${peer.id}`,
-    );
+    const payload: {
+      peerId?: string;
+      name: string;
+      ssh_enabled: boolean;
+      login_expiration_enabled: boolean;
+      inactivity_expiration_enabled?: boolean;
+      approval_required?: boolean;
+      ip?: string;
+      ipv6?: string;
+      kind?: PeerKind;
+    } = {
+      peerId: peer?.id,
+      name: props.name != undefined ? props.name : peer.name,
+      ssh_enabled: props.ssh != undefined ? props.ssh : peer.ssh_enabled,
+      login_expiration_enabled:
+        props.loginExpiration != undefined
+          ? props.loginExpiration
+          : peer.login_expiration_enabled,
+      inactivity_expiration_enabled:
+        props?.inactivityExpiration == undefined
+          ? undefined
+          : props.inactivityExpiration,
+      approval_required:
+        props?.approval_required == undefined
+          ? undefined
+          : props.approval_required,
+      ip: props.ip != undefined ? props.ip : undefined,
+      ipv6: props.ipv6 != undefined ? props.ipv6 : undefined,
+    };
+
+    if (props.kind !== undefined) {
+      payload.kind = props.kind;
+    }
+
+    return peerRequest.put(payload, `/${peer.id}`);
   };
 
   const toggleSSH = async (enable: boolean) => {

--- a/src/interfaces/Peer.ts
+++ b/src/interfaces/Peer.ts
@@ -1,5 +1,6 @@
 import { Group } from "@/interfaces/Group";
 import { User } from "@/interfaces/User";
+import type { PeerKind } from "@/modules/peers/peerKind";
 
 export interface Peer {
   id?: string;
@@ -31,6 +32,7 @@ export interface Peer {
   connection_ip: string;
   serial_number: string;
   ephemeral: boolean;
+  kind?: PeerKind;
   local_flags?: PeerLocalFlags;
 }
 

--- a/src/layouts/Navigation.tsx
+++ b/src/layouts/Navigation.tsx
@@ -83,24 +83,8 @@ export default function Navigation({
                   icon={<PeerIcon />}
                   label="Peers"
                   href={"/peers"}
-                  collapsible
                   visible={!isRestricted}
-                >
-                  <SidebarItem
-                    label="User Devices"
-                    isChild
-                    href={"/peers/users"}
-                    exactPathMatch={true}
-                    visible={!isRestricted}
-                  />
-                  <SidebarItem
-                    label="Servers"
-                    isChild
-                    href={"/peers/servers"}
-                    exactPathMatch={true}
-                    visible={!isRestricted}
-                  />
-                </SidebarItem>
+                />
 
                 <SidebarItem
                   icon={<AccessControlIcon />}

--- a/src/modules/common-table-rows/ActiveInactiveRow.tsx
+++ b/src/modules/common-table-rows/ActiveInactiveRow.tsx
@@ -9,6 +9,7 @@ type Props = {
   inactiveDot?: "gray" | "red";
   leftSection?: React.ReactNode;
   text?: string | React.ReactNode;
+  textPrefix?: React.ReactNode;
   className?: string;
   additionalInfo?: React.ReactNode;
   dataCy?: string;
@@ -18,6 +19,7 @@ export default function ActiveInactiveRow({
   active,
   children,
   text,
+  textPrefix,
   leftSection,
   inactiveDot = "gray",
   className,
@@ -45,6 +47,7 @@ export default function ActiveInactiveRow({
             <div
               className={"font-medium flex gap-2 items-center justify-start"}
             >
+              {textPrefix}
               <TextWithTooltip text={text as string} maxChars={25} />
               {additionalInfo}
             </div>

--- a/src/modules/peers/PeerNameCell.tsx
+++ b/src/modules/peers/PeerNameCell.tsx
@@ -1,4 +1,6 @@
+import FullTooltip from "@components/FullTooltip";
 import { cn } from "@utils/helpers";
+import { MonitorSmartphoneIcon, ServerIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import * as React from "react";
 import { useMemo } from "react";
@@ -9,16 +11,26 @@ import { ExitNodePeerIndicator } from "@/modules/exit-node/ExitNodePeerIndicator
 import { EphemeralPeerIndicator } from "@/modules/peer/EphemeralPeerIndicator";
 import { ExpirationDisabledIndicator } from "@/modules/peer/ExpirationDisabledIndicator";
 import { usePeerIssueIcon } from "@/modules/peer/PeerIssueIcon";
+import {
+  getEffectivePeerKind,
+  PEER_KIND_LABELS,
+} from "@/modules/peers/peerKind";
 
 type Props = {
   peer: Peer;
   linkToPeer?: boolean;
+  showPeerKindIcon?: boolean;
 };
-export default function PeerNameCell({ peer, linkToPeer = true }: Props) {
+export default function PeerNameCell({
+  peer,
+  linkToPeer = true,
+  showPeerKindIcon = false,
+}: Props) {
   const { users } = useUsers();
   const router = useRouter();
   const { isOwnerOrAdmin } = useLoggedInUser();
   const issueIcon = usePeerIssueIcon(peer);
+  const peerKind = getEffectivePeerKind(peer);
 
   const userOfPeer = useMemo(() => {
     return users?.find((user) => user.id === peer.user_id);
@@ -47,6 +59,14 @@ export default function PeerNameCell({ peer, linkToPeer = true }: Props) {
         <ActiveInactiveRow
           active={peer.connected}
           text={peer.name}
+          textPrefix={
+            showPeerKindIcon && (
+              <PeerKindIndicator
+                kind={peerKind}
+                label={PEER_KIND_LABELS[peerKind]}
+              />
+            )
+          }
           additionalInfo={
             isOwnerOrAdmin && (
               <>
@@ -73,5 +93,32 @@ export default function PeerNameCell({ peer, linkToPeer = true }: Props) {
         )}
       </div>
     </div>
+  );
+}
+
+function PeerKindIndicator({
+  kind,
+  label,
+}: {
+  kind: "device" | "server";
+  label: string;
+}) {
+  const Icon = kind === "server" ? ServerIcon : MonitorSmartphoneIcon;
+
+  return (
+    <FullTooltip
+      content={<div className={"text-xs"}>{label}</div>}
+      interactive={false}
+      sideOffset={6}
+    >
+      <span
+        className={
+          "inline-flex h-4 w-4 shrink-0 items-center justify-center text-nb-gray-400 dark:text-nb-gray-500"
+        }
+        aria-label={label}
+      >
+        <Icon size={15} strokeWidth={1.8} />
+      </span>
+    </FullTooltip>
   );
 }

--- a/src/modules/peers/PeersTable.tsx
+++ b/src/modules/peers/PeersTable.tsx
@@ -1,4 +1,5 @@
 import Button from "@components/Button";
+import ButtonGroup from "@components/ButtonGroup";
 import { Checkbox } from "@components/Checkbox";
 import FullTooltip from "@components/FullTooltip";
 import { NoPeersGettingStarted } from "@components/NoPeersGettingStarted";
@@ -30,6 +31,7 @@ import {
   TableFiltersButton,
 } from "@components/table/TableFilters";
 import AddPeerButton from "@components/ui/AddPeerButton";
+import NoResults from "@components/ui/NoResults";
 import { NotificationCountBadge } from "@components/ui/NotificationCountBadge";
 import {
   ColumnDef,
@@ -37,10 +39,15 @@ import {
   SortingState,
 } from "@tanstack/react-table";
 import { trim, uniqBy } from "lodash";
-import { MonitorDotIcon } from "lucide-react";
+import {
+  MonitorDotIcon,
+  MonitorSmartphoneIcon,
+  ServerIcon,
+} from "lucide-react";
 import { usePathname } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
+import PeerIcon from "@/assets/icons/PeerIcon";
 import PeerProvider from "@/contexts/PeerProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { useLoggedInUser } from "@/contexts/UsersProvider";
@@ -58,7 +65,12 @@ import PeerNameCell from "@/modules/peers/PeerNameCell";
 import { PeerOSCell } from "@/modules/peers/PeerOSCell";
 import PeerStatusCell from "@/modules/peers/PeerStatusCell";
 import PeerVersionCell from "@/modules/peers/PeerVersionCell";
-import { removeAllSpaces } from "@utils/helpers";
+import {
+  matchesPeerTableKind,
+  PEERS_TABLE_KIND_LABELS,
+  PeersTableKind,
+} from "@/modules/peers/peerKind";
+import { cn, removeAllSpaces } from "@utils/helpers";
 
 // Stable key per OS family for the filter column. Mirrors the icon
 // selection in PeerOSCell so the chip label and the displayed OS icon
@@ -79,7 +91,9 @@ function peerOsKey(os: string | undefined): string {
   }
 }
 
-const PeersTableColumns: ColumnDef<Peer>[] = [
+const getPeersTableColumns = (
+  showPeerKindIcons: boolean,
+): ColumnDef<Peer>[] => [
   {
     id: "select",
     header: ({ table }) => (
@@ -111,7 +125,9 @@ const PeersTableColumns: ColumnDef<Peer>[] = [
       return <DataTableHeader column={column}>Name</DataTableHeader>;
     },
     sortingFn: "text",
-    cell: ({ row }) => <PeerNameCell peer={row.original} />,
+    cell: ({ row }) => (
+      <PeerNameCell peer={row.original} showPeerKindIcon={showPeerKindIcons} />
+    ),
   },
   {
     id: "approval_required",
@@ -257,22 +273,17 @@ const PeersTableColumns: ColumnDef<Peer>[] = [
   },
 ];
 
-export type PeersTableKind = "users" | "servers";
+const DEFAULT_ENABLED_KINDS: Record<PeersTableKind, boolean> = {
+  users: true,
+  servers: true,
+};
 
 type Props = {
   peers?: Peer[];
   isLoading: boolean;
   headingTarget?: HTMLHeadingElement | null;
   kind?: PeersTableKind;
-};
-
-// Peers split into two kinds:
-//   users   – owner is a real (non-service) user, typically added via SSO
-//   servers – no owner, or owner is a service user, typically enrolled via setup key
-const matchesKind = (peer: Peer, kind?: PeersTableKind) => {
-  if (!kind) return true;
-  const hasRealUser = !!peer.user && !peer.user.is_service_user;
-  return kind === "users" ? hasRealUser : !hasRealUser;
+  showKindFilters?: boolean;
 };
 
 export default function PeersTable({
@@ -280,6 +291,7 @@ export default function PeersTable({
   isLoading,
   headingTarget,
   kind,
+  showKindFilters = false,
 }: Readonly<Props>) {
   const { mutate } = useSWRConfig();
   const { permission } = usePermissions();
@@ -299,10 +311,30 @@ export default function PeersTable({
       },
     ],
   );
+  const [enabledKinds, setEnabledKinds] = useLocalStorage<
+    Record<PeersTableKind, boolean>
+  >(
+    "netbird-peer-kind-filters",
+    DEFAULT_ENABLED_KINDS,
+    showKindFilters && !kind,
+  );
+  const currentEnabledKinds = useMemo(
+    () => ({ ...DEFAULT_ENABLED_KINDS, ...enabledKinds }),
+    [enabledKinds],
+  );
 
   const kindFilteredPeers = useMemo(
-    () => peers?.filter((p) => matchesKind(p, kind)),
-    [peers, kind],
+    () =>
+      peers?.filter((peer) => {
+        if (kind) return matchesPeerTableKind(peer, kind);
+        if (!showKindFilters) return true;
+
+        const peerKind = matchesPeerTableKind(peer, "users")
+          ? "users"
+          : "servers";
+        return currentEnabledKinds[peerKind];
+      }),
+    [peers, kind, showKindFilters, currentEnabledKinds],
   );
 
   const pendingApprovalCount =
@@ -330,6 +362,32 @@ export default function PeersTable({
     return Array.from(map.values());
   }, [kindFilteredPeers]);
 
+  const selectedKindCount =
+    Object.values(currentEnabledKinds).filter(Boolean).length;
+  const headingCountLabel =
+    showKindFilters && !kind
+      ? currentEnabledKinds.servers && !currentEnabledKinds.users
+        ? "Server "
+        : currentEnabledKinds.users && !currentEnabledKinds.servers
+        ? "Device "
+        : ""
+      : "";
+  const showPeerKindIcons =
+    showKindFilters &&
+    !kind &&
+    currentEnabledKinds.servers &&
+    currentEnabledKinds.users;
+  const peersTableColumns = useMemo(
+    () => getPeersTableColumns(showPeerKindIcons),
+    [showPeerKindIcons],
+  );
+  const hasPeerKindFilterResult =
+    showKindFilters &&
+    !kind &&
+    !!peers &&
+    peers.length > 0 &&
+    (kindFilteredPeers?.length ?? 0) === 0;
+
   const { isUser } = useLoggedInUser();
 
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
@@ -338,6 +396,17 @@ export default function PeersTable({
     if (Object.keys(selectedRows).length > 0) {
       setSelectedRows({});
     }
+  };
+
+  const toggleKind = (peerKind: PeersTableKind) => {
+    setEnabledKinds((current) => {
+      const normalized = { ...DEFAULT_ENABLED_KINDS, ...current };
+      return {
+        ...normalized,
+        [peerKind]: !normalized[peerKind],
+      };
+    });
+    resetSelectedRows();
   };
 
   const [showBrowserPeers, setShowBrowserPeers] = useState(false);
@@ -432,7 +501,11 @@ export default function PeersTable({
         formatChip: (v) => formatGroupsChip(v as string[] | undefined),
       });
     }
-    if (kind === "users" && !isUser && tableUsers.length > 0) {
+    if (
+      (kind === "users" || showKindFilters) &&
+      !isUser &&
+      tableUsers.length > 0
+    ) {
       defs.push({
         id: "user_email",
         label: "Users",
@@ -448,7 +521,7 @@ export default function PeersTable({
       });
     }
     return defs;
-  }, [isUser, kind, osOptions, tableGroups, tableUsers]);
+  }, [isUser, kind, osOptions, showKindFilters, tableGroups, tableUsers]);
 
   return (
     <>
@@ -458,6 +531,7 @@ export default function PeersTable({
       />
       <DataTable
         headingTarget={headingTarget}
+        headingCountLabel={headingCountLabel}
         rowSelection={selectedRows}
         setRowSelection={setSelectedRows}
         useRowId={true}
@@ -466,7 +540,7 @@ export default function PeersTable({
         setSorting={setSorting}
         initialPageSize={25}
         showResetFilterButton={false}
-        columns={PeersTableColumns}
+        columns={peersTableColumns}
         data={showBrowserPeers ? browserPeers : regularPeers}
         searchPlaceholder={"Search by name, IP, owner or group..."}
         columnVisibility={{
@@ -487,15 +561,34 @@ export default function PeersTable({
         }}
         isLoading={isLoading}
         getStartedCard={
-          <NoPeersGettingStarted
-            showBackground={true}
-            isUserDevice={kind ? kind === "users" : undefined}
-          />
+          hasPeerKindFilterResult ? (
+            <NoResults
+              className={"py-4"}
+              title={
+                selectedKindCount === 0
+                  ? "No peer types selected"
+                  : "No peers match this view"
+              }
+              description={
+                selectedKindCount === 0
+                  ? "Turn on Devices or Servers to show peers."
+                  : "Try another peer type."
+              }
+              icon={<PeerIcon size={20} className={"fill-nb-gray-300"} />}
+            />
+          ) : (
+            <NoPeersGettingStarted
+              showBackground={true}
+              isUserDevice={kind ? kind === "users" : undefined}
+            />
+          )
         }
         rightSide={() => (
           <>
             {peers && peers.length > 0 && (
-              <AddPeerButton isUserDevice={kind === "users"} />
+              <AddPeerButton
+                isUserDevice={kind ? kind === "users" : undefined}
+              />
             )}
           </>
         )}
@@ -505,6 +598,45 @@ export default function PeersTable({
       >
         {(table) => (
           <>
+            {showKindFilters && !kind && (
+              <ButtonGroup disabled={peers?.length == 0}>
+                {(["servers", "users"] as PeersTableKind[]).map((peerKind) => (
+                  <ButtonGroup.Button
+                    key={peerKind}
+                    aria-pressed={currentEnabledKinds[peerKind]}
+                    className={cn(
+                      currentEnabledKinds[peerKind]
+                        ? "!bg-gray-100 !text-gray-900 dark:!bg-nb-gray-900/70 dark:!text-nb-gray-100 dark:!border-nb-gray-800 dark:hover:!bg-nb-gray-900"
+                        : "dark:!bg-nb-gray-920 dark:!text-nb-gray-500 dark:hover:!text-nb-gray-200",
+                    )}
+                    disabled={peers?.length == 0}
+                    onClick={() => {
+                      table.setPageIndex(0);
+                      toggleKind(peerKind);
+                    }}
+                    variant={"secondary"}
+                  >
+                    {peerKind === "servers" ? (
+                      <ServerIcon
+                        size={15}
+                        strokeWidth={1.8}
+                        className={"shrink-0"}
+                        aria-hidden={true}
+                      />
+                    ) : (
+                      <MonitorSmartphoneIcon
+                        size={15}
+                        strokeWidth={1.8}
+                        className={"shrink-0"}
+                        aria-hidden={true}
+                      />
+                    )}
+                    {PEERS_TABLE_KIND_LABELS[peerKind]}
+                  </ButtonGroup.Button>
+                ))}
+              </ButtonGroup>
+            )}
+
             <TableFiltersButton
               table={table}
               filters={filterDefs}
@@ -517,6 +649,7 @@ export default function PeersTable({
                 table.setPageIndex(0);
                 table.resetColumnFilters();
                 table.resetGlobalFilter();
+                setEnabledKinds(DEFAULT_ENABLED_KINDS);
                 resetSelectedRows();
               }}
             />

--- a/src/modules/peers/peerKind.ts
+++ b/src/modules/peers/peerKind.ts
@@ -1,0 +1,50 @@
+import type { Peer } from "@/interfaces/Peer";
+
+export type PeerKind = "auto" | "device" | "server";
+export type ResolvedPeerKind = Exclude<PeerKind, "auto">;
+export type PeersTableKind = "users" | "servers";
+
+export const PEER_KIND_LABELS: Record<PeerKind, string> = {
+  auto: "Automatic",
+  device: "Device",
+  server: "Server",
+};
+
+export const PEERS_TABLE_KIND_LABELS: Record<PeersTableKind, string> = {
+  users: "Devices",
+  servers: "Servers",
+};
+
+export const supportsPeerKind = (peer: Peer) =>
+  Object.prototype.hasOwnProperty.call(peer, "kind");
+
+export const normalizePeerKind = (kind: unknown): PeerKind => {
+  if (kind === "device" || kind === "server" || kind === "auto") {
+    return kind;
+  }
+
+  return "auto";
+};
+
+export const inferPeerKind = (peer: Peer): ResolvedPeerKind => {
+  const hasRealUser = !!peer.user && !peer.user.is_service_user;
+  return hasRealUser ? "device" : "server";
+};
+
+export const getEffectivePeerKind = (peer: Peer): ResolvedPeerKind => {
+  const kind = normalizePeerKind(peer.kind);
+  if (kind === "device" || kind === "server") {
+    return kind;
+  }
+
+  return inferPeerKind(peer);
+};
+
+export const matchesPeerTableKind = (peer: Peer, kind?: PeersTableKind) => {
+  if (!kind) return true;
+
+  const effectiveKind = getEffectivePeerKind(peer);
+  return kind === "users"
+    ? effectiveKind === "device"
+    : effectiveKind === "server";
+};


### PR DESCRIPTION
## Issue ticket number and link

Closes https://github.com/netbirdio/dashboard/issues/663

Issue #663 reports that Dashboard v2.39.0 reduced peer-list usability by splitting the previous unified Peers view into two separate navigation destinations: **User Devices** and **Servers**. That split made it impossible to see all peers in one sortable/searchable/filterable table, forcing users to move back and forth between two pages when they needed a complete view of their network.

This PR restores `/peers` as the canonical combined Peers page while preserving the ability to focus the list by peer type. Instead of separate sidebar destinations, the Peers page now shows both Servers and Devices in one table by default and provides inline **Servers** / **Devices** toggles for quick visibility filtering. This directly addresses the issue request: “go back to a full list with ‘User Devices’ and ‘Servers’ toggles to filter visibility instead.”

The previous classification logic is still useful as a default because peers enrolled with setup keys are likely servers most of the time, and peers enrolled through SSO are likely user devices most of the time. However, that assumption is not always correct. Some setup-key peers are regular devices, and some SSO-enrolled peers may function as servers or shared infrastructure. Treating enrollment method as the only source of truth makes the experience clunky, especially once users need to organize or audit mixed environments from the Peers page. This PR keeps that inference as the automatic fallback, but prepares the dashboard to respect an explicit backend-provided peer type when available.

The change also keeps the combined view practical:

- The sidebar `Peers` item now links directly to `/peers` instead of opening only the old split page dropdown.
- The `/peers` page shows one combined list of all peers by default.
- Servers and Devices can be toggled independently without leaving the page.
- The toggle state is persisted locally, so users do not lose their preferred view when navigating away and returning.
- The heading count updates based on the active view, for example `X Peers`, `X Server Peers`, or `X Device Peers`.
- A small info tooltip next to the Peers heading preserves the explanatory text from the previous split sections, with Servers and Devices described in the same order as the toggles.
- When both peer types are visible, each peer row can show a subtle server/device icon so users can still distinguish peer type in the combined table.
- Peer detail breadcrumbs and Cancel navigation now return to `/peers`, matching the restored combined page instead of sending users back into the old split routes.

This PR also includes dashboard support for an optional backend-provided peer classification field. When the management API exposes `peer.kind`, the peer detail page can show/edit the peer type. When connected to an older backend that does not return that field, the editor is hidden and the dashboard falls back to the existing inference logic. That keeps the dashboard backward-compatible while allowing newer backends to support explicit peer classification.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This change restores and improves the dashboard Peers list behavior requested in issue #663. The relevant guidance is already presented in the UI through the Peers heading tooltip, which preserves the explanatory Servers and Devices wording from the previously split sections. No external documentation page currently describes the split Peers navigation or the new table toggles, and this PR does not require users to follow a new setup procedure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer type support (device vs. server) to peer information and dashboard views
  * Introduced optional device/server filtering in the peers list
  * Added visual indicators for peer types in the peers table

* **UI/UX Improvements**
  * Simplified navigation by removing nested peer categories
  * Enhanced peer dashboard with type selection and management
  * Improved peers list organization with better conditional rendering and tooltips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->