### PR TITLE
fix: allow single-label domains as network resources

### DIFF
--- a/src/modules/networks/resources/ResourceSingleAddressInput.tsx
+++ b/src/modules/networks/resources/ResourceSingleAddressInput.tsx
@@ -46,12 +46,8 @@ export const ResourceSingleAddressInput = ({
 
     // Case 1: If it has characters (potential domain) but is not a CIDR block
     if (hasChars && !isCIDRBlock) {
-      if (
-        !validator.isValidDomain(value) ||
-        !value.includes(".") ||
-        value.endsWith(".")
-      ) {
-        return "Please enter a valid domain, e.g. service.internal, example.com or *.example.com";
+      if (!validator.isValidDomain(value) || value.endsWith(".")) {
+        return "Please enter a valid domain, e.g. service.internal, example.com, *.example.com or service";
       }
       return ""; // Valid domain
     }


### PR DESCRIPTION
Remove the explicit dot requirement in ResourceSingleAddressInput. 
The backend accepts single-label domains (e.g. 'service') since v0.71.0 via netbirdio/netbird#5211, but the UI was blocking them with a hardcoded !value.includes('.') check.

If you want to verify that the backend already accepted them:
```
curl -X POST https://<YOUR_MANAGEMENT_HOST>/api/networks/<NETWORK_ID>/resources \
   -H "Authorization: Token <YOUR_PAT_TOKEN>" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "yeet-test",
     "address": "yeet",
     "groups": ["<YOUR_GROUP_ID>"],
     "enabled": true
   }'
```

use case(if needed): container setups where netbird & applications are in one network, allowing single-label domains allows one to talk to the application containers via their container name (internal DNS)

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

not needed as the functionality was already there beforehand

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain validation logic to more accurately detect valid domains during network resource input.
  * Updated domain validation error message to provide clearer guidance on accepted domain formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->