### PR TITLE
Restrict cloud/licensed-only API calls in open-source mode

### DIFF
--- a/src/app/(dashboard)/team/users/page.tsx
+++ b/src/app/(dashboard)/team/users/page.tsx
@@ -7,6 +7,7 @@ import SkeletonTable from "@components/skeletons/SkeletonTable";
 import { RestrictedAccess } from "@components/ui/RestrictedAccess";
 import { usePortalElement } from "@hooks/usePortalElement";
 import useFetchApi from "@utils/api";
+import { isNetBirdCloud } from "@utils/netbird";
 import { ExternalLinkIcon, User2 } from "lucide-react";
 import React, { lazy, Suspense } from "react";
 import TeamIcon from "@/assets/icons/TeamIcon";
@@ -62,7 +63,9 @@ export default function TeamUsers() {
         <Suspense fallback={<SkeletonTable />}>
           {permission.settings.read && (
             <div className={"flex flex-wrap gap-4 p-default pb-6"}>
-              {permission?.idp?.read && <IdentityProviderCard />}
+              {(permission?.idp?.read || !isNetBirdCloud()) && (
+                <IdentityProviderCard />
+              )}
               <AccountMfaCard />
             </div>
           )}

--- a/src/cloud/distributor/contexts/DistributorProvider.tsx
+++ b/src/cloud/distributor/contexts/DistributorProvider.tsx
@@ -1,4 +1,5 @@
 import useFetchApi from "@utils/api";
+import { isNetBirdCloud } from "@utils/netbird";
 import React, { useEffect, useMemo } from "react";
 import { Distributor } from "@/cloud/distributor/interfaces/Distributor";
 
@@ -41,11 +42,18 @@ const DistributorContext = React.createContext(
 );
 
 export default function DistributorProvider({ children }: Readonly<Props>) {
+  // Distributor (reseller) data lives behind an MSP endpoint that only NetBird
+  // Cloud serves. Skip the call on self-hosted deployments.
   const {
     data: distributorInfo,
     isLoading: isDistributorInfoLoading,
     error,
-  } = useFetchApi<Distributor>("/integrations/msp/reseller", true);
+  } = useFetchApi<Distributor>(
+    "/integrations/msp/reseller",
+    true,
+    true,
+    isNetBirdCloud(),
+  );
 
   const isActive = useMemo(() => {
     try {

--- a/src/cloud/edr/useBypass.tsx
+++ b/src/cloud/edr/useBypass.tsx
@@ -1,6 +1,7 @@
 import useFetchApi, { useApiCall } from "@utils/api";
 import { useSWRConfig } from "swr";
 import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useIsLicensed } from "@/hooks/useIsLicensed";
 
 export interface BypassResponse {
   peer_id: string;
@@ -9,9 +10,14 @@ export interface BypassResponse {
 const BYPASSED_PATH = "/peers/edr/bypassed";
 
 export const useBypassedPeers = () => {
+  // EDR bypass is a licensed feature; the endpoint is not served on
+  // open-source deployments, so skip the call there entirely.
+  const { isLicensed } = useIsLicensed();
   const { data, isLoading, mutate } = useFetchApi<BypassResponse[]>(
     BYPASSED_PATH,
     true,
+    true,
+    isLicensed,
   );
 
   // The endpoint can resolve to a non-array (e.g. an error body) on

--- a/src/cloud/msp/contexts/MSPProvider.tsx
+++ b/src/cloud/msp/contexts/MSPProvider.tsx
@@ -1,5 +1,6 @@
 import FullScreenLoading from "@components/ui/FullScreenLoading";
 import useFetchApi from "@utils/api";
+import { isNetBirdCloud } from "@utils/netbird";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { MSP } from "@/cloud/msp/interfaces/MSP";
 import { TenantListItem, TenantStatus } from "@/cloud/msp/interfaces/Tenant";
@@ -35,15 +36,23 @@ const MSPContext = React.createContext(
 );
 
 export default function MSPProvider({ children }: Readonly<Props>) {
+  // MSP is a NetBird Cloud-only feature. Skip the calls on self-hosted
+  // deployments where the endpoints are not served.
+  const isCloud = isNetBirdCloud();
   const {
     data: mspInfo,
     isLoading: isMspInfoLoading,
     error,
-  } = useFetchApi<MSP>("/integrations/msp", true);
+  } = useFetchApi<MSP>("/integrations/msp", true, true, isCloud);
   const { isOwner } = useLoggedInUser();
 
   const { data: tenantListItems, isLoading: isTenantListItemsLoading } =
-    useFetchApi<TenantListItem[]>("/integrations/msp/switcher", true);
+    useFetchApi<TenantListItem[]>(
+      "/integrations/msp/switcher",
+      true,
+      true,
+      isCloud,
+    );
 
   const { globalApiParams, setGlobalApiParams } = useApplicationContext();
   const currentAccountId = globalApiParams?.account;

--- a/src/hooks/useIsLicensed.tsx
+++ b/src/hooks/useIsLicensed.tsx
@@ -1,5 +1,7 @@
 import useFetchApi from "@utils/api";
+import loadConfig from "@utils/config";
 import { hasLicensedFlag, testEditionOverride } from "@utils/netbird";
+import { useEffect, useState } from "react";
 
 /**
  * Endpoint that is only served by licensed management servers.
@@ -14,10 +16,45 @@ const LICENSE_PROBE_ENDPOINT = "/integrations/event-streaming";
 const ENDPOINT_EXISTS_ERROR_CODES = [401, 403, 405];
 
 /**
+ * Probe result is cached so open-source deployments do not re-request the
+ * licensed-only endpoint on every page load. The TTL lets a later license
+ * activation be picked up without forcing the user to clear storage.
+ */
+const LICENSE_CACHE_PREFIX = "netbird-licensed:";
+const LICENSE_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const licenseCacheKey = () => `${LICENSE_CACHE_PREFIX}${loadConfig().apiOrigin}`;
+
+const readLicenseCache = (): boolean | undefined => {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.localStorage.getItem(licenseCacheKey());
+    if (!raw) return undefined;
+    const { value, ts } = JSON.parse(raw) as { value: boolean; ts: number };
+    if (typeof value !== "boolean" || typeof ts !== "number") return undefined;
+    if (Date.now() - ts > LICENSE_CACHE_TTL_MS) return undefined;
+    return value;
+  } catch (e) {
+    return undefined;
+  }
+};
+
+const writeLicenseCache = (value: boolean) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      licenseCacheKey(),
+      JSON.stringify({ value, ts: Date.now() }),
+    );
+  } catch (e) {}
+};
+
+/**
  * useIsLicensed determines whether premium features are available on this
  * deployment. NetBird Cloud and deployments with NETBIRD_LICENSED=true are
  * licensed by definition. For backwards compatibility, deployments without
- * the flag are probed once against a licensed-only management endpoint.
+ * the flag are probed once against a licensed-only management endpoint and the
+ * result is cached so the probe does not repeat on every page load.
  */
 export const useIsLicensed = (): {
   isLicensed: boolean;
@@ -25,22 +62,40 @@ export const useIsLicensed = (): {
 } => {
   const declared = hasLicensedFlag();
   const override = testEditionOverride();
+
+  const [cached] = useState<boolean | undefined>(() =>
+    declared || override ? undefined : readLicenseCache(),
+  );
+
+  const shouldProbe = !declared && !override && cached === undefined;
   const { data, error, isLoading } = useFetchApi<unknown>(
     LICENSE_PROBE_ENDPOINT,
     true,
     false,
-    !declared && !override,
+    shouldProbe,
     { shouldRetryOnError: false },
   );
 
-  if (override) return { isLicensed: override !== "oss", isLoading: false };
-  if (declared) return { isLicensed: true, isLoading: false };
-  if (isLoading) return { isLicensed: false, isLoading: true };
-  if (error) {
-    return {
-      isLicensed: ENDPOINT_EXISTS_ERROR_CODES.includes(error.code),
-      isLoading: false,
-    };
+  let isLicensed = false;
+  let resolvedLoading = false;
+  if (override) {
+    isLicensed = override !== "oss";
+  } else if (declared) {
+    isLicensed = true;
+  } else if (cached !== undefined) {
+    isLicensed = cached;
+  } else if (isLoading) {
+    resolvedLoading = true;
+  } else if (error) {
+    isLicensed = ENDPOINT_EXISTS_ERROR_CODES.includes(error.code);
+  } else {
+    isLicensed = data !== undefined;
   }
-  return { isLicensed: data !== undefined, isLoading: false };
+
+  useEffect(() => {
+    if (!shouldProbe || isLoading) return;
+    writeLicenseCache(isLicensed);
+  }, [shouldProbe, isLoading, isLicensed]);
+
+  return { isLicensed, isLoading: resolvedLoading };
 };

--- a/src/modules/integrations/event-streaming/EventStreamingCard.tsx
+++ b/src/modules/integrations/event-streaming/EventStreamingCard.tsx
@@ -10,6 +10,7 @@ import firehoseLogo from "@/assets/integrations/firehose.png";
 import genericHttpLogo from "@/assets/integrations/generic-http.png";
 import s3Logo from "@/assets/integrations/s3.svg";
 import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useIsLicensed } from "@/hooks/useIsLicensed";
 import { EventStream } from "@/interfaces/EventStream";
 
 type Platform = "datadog" | "s3" | "firehose" | "generic_http";
@@ -22,12 +23,15 @@ const platformImages: { [key in Platform]?: StaticImageData } = {
 
 export const EventStreamingCard = () => {
   const { permission } = usePermissions();
+  // Event Streaming is a licensed feature; the endpoint is not served on
+  // open-source deployments, so skip the call there entirely.
+  const { isLicensed } = useIsLicensed();
 
   const { data: eventStreamIntegrations } = useFetchApi<EventStream[]>(
     "/integrations/event-streaming",
     false,
     false,
-    permission?.event_streaming?.read,
+    !!permission?.event_streaming?.read && isLicensed,
   );
   const activeSettings = eventStreamIntegrations?.find(
     (integration) => integration.enabled,

--- a/src/modules/integrations/event-streaming/amazon/firehose/Firehose.tsx
+++ b/src/modules/integrations/event-streaming/amazon/firehose/Firehose.tsx
@@ -7,12 +7,15 @@ import { useSWRConfig } from "swr";
 import integrationImage from "@/assets/integrations/firehose.png";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useIsLicensed } from "@/hooks/useIsLicensed";
 import { EventStream } from "@/interfaces/EventStream";
 import FirehoseSetup from "@/modules/integrations/event-streaming/amazon/firehose/FirehoseSetup";
 import { IntegrationCard } from "@/modules/integrations/IntegrationCard";
 
 export default function Firehose() {
   const { permission } = usePermissions();
+  // Event Streaming is a licensed feature; skip the call on open-source.
+  const { isLicensed } = useIsLicensed();
 
   const { mutate } = useSWRConfig();
   const { data: eventStreamIntegrations, isLoading } = useFetchApi<
@@ -21,7 +24,7 @@ export default function Firehose() {
     "/integrations/event-streaming",
     false,
     false,
-    permission.event_streaming.read,
+    permission.event_streaming.read && isLicensed,
   );
 
   const firehoseSettings = eventStreamIntegrations?.find(

--- a/src/modules/integrations/event-streaming/amazon/s3/S3.tsx
+++ b/src/modules/integrations/event-streaming/amazon/s3/S3.tsx
@@ -7,12 +7,15 @@ import { useSWRConfig } from "swr";
 import integrationImage from "@/assets/integrations/s3.svg";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useIsLicensed } from "@/hooks/useIsLicensed";
 import { EventStream } from "@/interfaces/EventStream";
 import S3Setup from "@/modules/integrations/event-streaming/amazon/s3/S3Setup";
 import { IntegrationCard } from "@/modules/integrations/IntegrationCard";
 
 export default function S3() {
   const { permission } = usePermissions();
+  // Event Streaming is a licensed feature; skip the call on open-source.
+  const { isLicensed } = useIsLicensed();
 
   const { mutate } = useSWRConfig();
   const { data: eventStreamIntegrations, isLoading } = useFetchApi<
@@ -21,7 +24,7 @@ export default function S3() {
     "/integrations/event-streaming",
     false,
     false,
-    permission.event_streaming.read,
+    permission.event_streaming.read && isLicensed,
   );
 
   const s3Settings = eventStreamIntegrations?.find(

--- a/src/modules/integrations/event-streaming/datadog/Datadog.tsx
+++ b/src/modules/integrations/event-streaming/datadog/Datadog.tsx
@@ -7,12 +7,15 @@ import { useSWRConfig } from "swr";
 import integrationImage from "@/assets/integrations/datadog.png";
 import { useDialog } from "@/contexts/DialogProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useIsLicensed } from "@/hooks/useIsLicensed";
 import { EventStream } from "@/interfaces/EventStream";
 import DatadogSetup from "@/modules/integrations/event-streaming/datadog/DatadogSetup";
 import { IntegrationCard } from "@/modules/integrations/IntegrationCard";
 
 export default function Datadog() {
   const { permission } = usePermissions();
+  // Event Streaming is a licensed feature; skip the call on open-source.
+  const { isLicensed } = useIsLicensed();
 
   const { mutate } = useSWRConfig();
   const { data: eventStreamIntegrations, isLoading } = useFetchApi<
@@ -21,7 +24,7 @@ export default function Datadog() {
     "/integrations/event-streaming",
     false,
     false,
-    permission.event_streaming.read,
+    permission.event_streaming.read && isLicensed,
   );
 
   const dataDogSettings = eventStreamIntegrations?.find(

--- a/src/modules/integrations/event-streaming/generic-http/GenericHTTP.tsx
+++ b/src/modules/integrations/event-streaming/generic-http/GenericHTTP.tsx
@@ -8,12 +8,15 @@ import { useState } from "react";
 import { useSWRConfig } from "swr";
 import integrationImage from "@/assets/integrations/generic-http.png";
 import { usePermissions } from "@/contexts/PermissionsProvider";
+import { useIsLicensed } from "@/hooks/useIsLicensed";
 import { EventStream } from "@/interfaces/EventStream";
 import GenericHTTPModal from "@/modules/integrations/event-streaming/generic-http/GenericHTTPModal";
 import { IntegrationCard } from "@/modules/integrations/IntegrationCard";
 
 export default function GenericHTTP() {
   const { permission } = usePermissions();
+  // Event Streaming is a licensed feature; skip the call on open-source.
+  const { isLicensed } = useIsLicensed();
 
   const { mutate } = useSWRConfig();
   const { data: eventStreamIntegrations, isLoading } = useFetchApi<
@@ -22,7 +25,7 @@ export default function GenericHTTP() {
     "/integrations/event-streaming",
     false,
     false,
-    permission.event_streaming.read,
+    permission.event_streaming.read && isLicensed,
   );
 
   const genericHTTPIntegration = eventStreamIntegrations?.find(


### PR DESCRIPTION
Gate premium endpoints so the open-source dashboard stops calling endpoints the open-source management server does not serve:

- MSP/Distributor: only fetch /integrations/msp, /integrations/msp/switcher and /integrations/msp/reseller on NetBird Cloud
- EDR bypass: only fetch /peers/edr/bypassed when licensed
- Event Streaming: gate /integrations/event-streaming GETs on the license in addition to the existing permission check
- useIsLicensed: cache the licensed-only probe result (per API origin, 1h TTL) so it no longer re-fires on every page load
- Team > Users: show the Identity Provider Sync tile in open-source mode so IdP sync remains discoverable

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * License status caching with local storage to reduce repeated network checks.

* **Changes**
  * Event Streaming integrations now require appropriate licensing.
  * EDR bypass feature now gated behind licensing requirements.
  * MSP features restricted to NetBird Cloud deployments.
  * Identity provider card visibility adjusted based on self-hosted vs. cloud deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->