### PR TITLE
Preserve inactivity expiration on partial peer updates

### DIFF
--- a/src/contexts/PeerProvider.tsx
+++ b/src/contexts/PeerProvider.tsx
@@ -96,7 +96,7 @@ export default function PeerProvider({
             : peer.login_expiration_enabled,
         inactivity_expiration_enabled:
           props?.inactivityExpiration == undefined
-            ? undefined
+            ? peer.inactivity_expiration_enabled
             : props.inactivityExpiration,
         approval_required:
           props?.approval_required == undefined


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inactivity expiration settings to persist correctly when not explicitly modified during peer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->