### PR TITLE
Fix CSP blocking OIDC token endpoint

### DIFF
--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -91,6 +91,8 @@ fi
 # Add AUTH_AUTHORITY to CSP
 if [[ -n "${AUTH_AUTHORITY}" ]]; then
     CSP_DOMAINS="$CSP_DOMAINS $AUTH_AUTHORITY"
+    AUTH_AUTHORITY_ORIGIN=$(echo "$AUTH_AUTHORITY" | sed -E 's|^(https?://[^/]+).*|\1|')
+    CSP_DOMAINS="$CSP_DOMAINS $AUTH_AUTHORITY_ORIGIN"
 fi
 
 # Add AUTH_AUDIENCE to CSP


### PR DESCRIPTION
Calculate the origin URL for AUTH_AUTHORITY and add it to CSP_DOMAINS.
Fixes #679 

## Documentation
- [x] Documentation is **not needed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app compatibility with authentication endpoints by correctly allowing the auth service’s origin in the content security policy.
  * Reduced issues caused by using full auth URLs, helping sign-in and related flows work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->