### PR TITLE
fix: Name, Metric and Domain column headers do nothing when clicked

### DIFF
--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { TableContentSkeleton } from "@components/skeletons/SkeletonTable";
+import { DataTableInstanceProvider } from "@components/table/DataTableContext";
 import DataTableGlobalSearch from "@components/table/DataTableGlobalSearch";
 import { DataTableHeadingPortal } from "@components/table/DataTableHeadingPortal";
 import { DataTablePagination } from "@components/table/DataTablePagination";
@@ -440,6 +441,7 @@ export function DataTable<TData, TValue>({
   }, [manualColumnFiltering, externalColumnFilters, table]);
 
   return (
+    <DataTableInstanceProvider table={table}>
     <div className={cn("relative table-fixed-scroll", className)}>
       {showSearchAndFilters && (
         <div className={cn("flex gap-x-4 gap-y-6", !minimal && "p-default")}>
@@ -648,5 +650,6 @@ export function DataTable<TData, TValue>({
         hasActiveFilters={hasServerSideFilters}
       />
     </div>
+    </DataTableInstanceProvider>
   );
 }

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { TableContentSkeleton } from "@components/skeletons/SkeletonTable";
+import { DataTableInstanceProvider } from "@components/table/DataTableContext";
 import DataTableGlobalSearch from "@components/table/DataTableGlobalSearch";
 import { DataTableHeadingPortal } from "@components/table/DataTableHeadingPortal";
 import { DataTablePagination } from "@components/table/DataTablePagination";
@@ -468,7 +469,7 @@ export function DataTable<TData, TValue>({
     }
   }, [manualColumnFiltering, externalColumnFilters, table]);
 
-  return (
+  const content = (
     <div className={cn("relative table-fixed-scroll", className)}>
       {showSearchAndFilters && (
         <div className={cn("flex gap-x-4 gap-y-6", !minimal && "p-default")}>
@@ -677,5 +678,11 @@ export function DataTable<TData, TValue>({
         hasActiveFilters={hasServerSideFilters}
       />
     </div>
+  );
+
+  return (
+    <DataTableInstanceProvider table={table}>
+      {content}
+    </DataTableInstanceProvider>
   );
 }

--- a/src/components/table/DataTableContext.tsx
+++ b/src/components/table/DataTableContext.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { Table as TanStackTable } from "@tanstack/table-core";
+import React, { createContext, useContext } from "react";
+
+const DataTableInstanceContext = createContext<TanStackTable<any> | null>(null);
+
+type ProviderProps = {
+  table: TanStackTable<any>;
+  children: React.ReactNode;
+};
+
+export function DataTableInstanceProvider({ table, children }: ProviderProps) {
+  return (
+    <DataTableInstanceContext.Provider value={table}>
+      {children}
+    </DataTableInstanceContext.Provider>
+  );
+}
+
+/**
+ * Returns the tanstack table instance for the surrounding DataTable, or null
+ * when used outside of one.
+ */
+export function useOptionalDataTable() {
+  return useContext(DataTableInstanceContext);
+}

--- a/src/components/table/DataTableHeader.test.tsx
+++ b/src/components/table/DataTableHeader.test.tsx
@@ -1,0 +1,156 @@
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React, { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DataTableInstanceProvider } from "./DataTableContext";
+import DataTableHeader from "./DataTableHeader";
+
+// A header click must always replace the sort with the clicked column alone.
+// The peers tables default to a multi-sort ([connected, last_seen, name]), and
+// column.toggleSorting() only toggles in place when the clicked column is that
+// sort's last entry — so the click used to leave the visible order untouched.
+
+const { setSort } = vi.hoisted(() => ({ setSort: vi.fn() }));
+
+vi.mock("@/contexts/ServerPaginationProvider", () => ({
+  useOptionalServerPagination: () => ({ setSort }),
+}));
+
+afterEach(() => {
+  cleanup();
+  setSort.mockClear();
+});
+
+type Peer = { name: string; connected: boolean; last_seen: string };
+
+const peers: Peer[] = [
+  { name: "alpha", connected: false, last_seen: "2026-01-01" },
+  { name: "zulu", connected: true, last_seen: "2026-03-01" },
+  { name: "mike", connected: true, last_seen: "2026-02-01" },
+];
+
+const columns: ColumnDef<Peer>[] = [
+  { id: "name", accessorKey: "name", sortingFn: "text" },
+  { id: "connected", accessorKey: "connected" },
+  { id: "last_seen", accessorKey: "last_seen", sortingFn: "text" },
+];
+
+// DataTable augments TanStack's FilterFns and SortingFns interfaces, which makes
+// both options required on every table in the app. Nothing here uses them.
+const filterFns = {
+  fuzzy: () => true,
+  dateRange: () => true,
+  exactMatch: () => true,
+  arrIncludesSomeExact: () => true,
+};
+const sortingFns = { checkbox: () => 0, datetime: () => 0 };
+
+// Mirrors DataTable: sorting state lives in the parent and is fed back through
+// state.sorting / onSortingChange.
+function Harness({
+  initialSorting,
+  columnId,
+  name,
+}: {
+  initialSorting: SortingState;
+  columnId: string;
+  name?: string;
+}) {
+  const [sorting, setSorting] = useState<SortingState>(initialSorting);
+  const table = useReactTable({
+    data: peers,
+    columns,
+    filterFns,
+    sortingFns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <DataTableInstanceProvider table={table}>
+      <DataTableHeader column={table.getColumn(columnId)!} name={name}>
+        Header
+      </DataTableHeader>
+      <output data-testid={"sorting"}>{JSON.stringify(sorting)}</output>
+      <ul>
+        {table.getRowModel().rows.map((row) => (
+          <li key={row.id}>{row.original.name}</li>
+        ))}
+      </ul>
+    </DataTableInstanceProvider>
+  );
+}
+
+const defaultSorting: SortingState = [
+  { id: "connected", desc: true },
+  { id: "last_seen", desc: true },
+  { id: "name", desc: false },
+];
+
+const rowOrder = () =>
+  screen.getAllByRole("listitem").map((row) => row.textContent);
+
+const sortingState = () =>
+  JSON.parse(screen.getByTestId("sorting").textContent ?? "");
+
+const clickHeader = () => fireEvent.click(screen.getByText("Header"));
+
+describe("DataTableHeader sorting", () => {
+  it("replaces a default multi-sort when its lowest-priority column is clicked", () => {
+    render(<Harness initialSorting={defaultSorting} columnId={"name"} />);
+    expect(rowOrder()).toEqual(["zulu", "mike", "alpha"]);
+
+    clickHeader();
+
+    expect(rowOrder()).toEqual(["alpha", "mike", "zulu"]);
+    expect(sortingState()).toEqual([{ id: "name", desc: false }]);
+  });
+
+  it("sorts ascending on the first click of a column that does not lead the sort", () => {
+    render(<Harness initialSorting={[]} columnId={"name"} />);
+
+    clickHeader();
+
+    expect(sortingState()).toEqual([{ id: "name", desc: false }]);
+    expect(rowOrder()).toEqual(["alpha", "mike", "zulu"]);
+  });
+
+  it("toggles the direction while the column leads the sort", () => {
+    render(
+      <Harness
+        initialSorting={[{ id: "name", desc: false }]}
+        columnId={"name"}
+      />,
+    );
+
+    clickHeader();
+    expect(sortingState()).toEqual([{ id: "name", desc: true }]);
+    expect(rowOrder()).toEqual(["zulu", "mike", "alpha"]);
+
+    clickHeader();
+    expect(sortingState()).toEqual([{ id: "name", desc: false }]);
+    expect(rowOrder()).toEqual(["alpha", "mike", "zulu"]);
+  });
+
+  it("reports the direction it applied to server-side pagination", () => {
+    render(
+      <Harness
+        initialSorting={defaultSorting}
+        columnId={"name"}
+        name={"name"}
+      />,
+    );
+
+    clickHeader();
+
+    expect(sortingState()).toEqual([{ id: "name", desc: false }]);
+    expect(setSort).toHaveBeenCalledWith("name", "asc");
+  });
+});

--- a/src/components/table/DataTableHeader.tsx
+++ b/src/components/table/DataTableHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import FullTooltip from "@components/FullTooltip";
+import { useOptionalDataTable } from "@components/table/DataTableContext";
 import { IconSortAscending, IconSortDescending } from "@tabler/icons-react";
 import type { Column } from "@tanstack/table-core";
 import { cn } from "@utils/helpers";
@@ -28,13 +29,21 @@ export default function DataTableHeader({
   name,
 }: Props) {
   const serverPagination = useOptionalServerPagination();
+  const table = useOptionalDataTable();
 
   const handleSort = () => {
     if (onSort) {
       onSort();
     } else {
       const direction = column.getIsSorted() === "asc" ? "desc" : "asc";
-      column.toggleSorting(direction === "desc");
+      // Force a single-column sort. column.toggleSorting() only toggles in
+      // place when the column is the lowest-priority entry of an existing
+      // multi-sort, which makes the first click appear to do nothing.
+      if (table) {
+        table.setSorting([{ id: column.id, desc: direction === "desc" }]);
+      } else {
+        column.toggleSorting(direction === "desc");
+      }
     }
     if (name && serverPagination?.setSort) {
       const direction = column.getIsSorted() === "asc" ? "desc" : "asc";

--- a/src/components/table/DataTableHeader.tsx
+++ b/src/components/table/DataTableHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import FullTooltip from "@components/FullTooltip";
+import { useOptionalDataTable } from "@components/table/DataTableContext";
 import { IconSortAscending, IconSortDescending } from "@tabler/icons-react";
 import type { Column } from "@tanstack/table-core";
 import { cn } from "@utils/helpers";
@@ -28,17 +29,27 @@ export default function DataTableHeader({
   name,
 }: Props) {
   const serverPagination = useOptionalServerPagination();
+  const table = useOptionalDataTable();
 
   const handleSort = () => {
+    // A click replaces the sort with this column alone. The direction only
+    // flips while the column already leads the sort; clicking any other column
+    // starts ascending. column.toggleSorting() cannot express this: when the
+    // column is the lowest-priority entry of an existing multi-sort it toggles
+    // in place, which leaves the visible order unchanged.
+    const leadsSort = table?.getState().sorting[0]?.id === column.id;
+    const desc = leadsSort ? column.getIsSorted() !== "desc" : false;
+
     if (onSort) {
       onSort();
+    } else if (table) {
+      table.setSorting([{ id: column.id, desc }]);
     } else {
-      const direction = column.getIsSorted() === "asc" ? "desc" : "asc";
-      column.toggleSorting(direction === "desc");
+      column.toggleSorting(desc);
     }
+
     if (name && serverPagination?.setSort) {
-      const direction = column.getIsSorted() === "asc" ? "desc" : "asc";
-      serverPagination.setSort(name, direction);
+      serverPagination.setSort(name, desc ? "desc" : "asc");
     }
   };
 


### PR DESCRIPTION
## Describe your changes

Three column headers in the dashboard do nothing when you click them. Not on the first click, and not on any click after it — they stay dead until some *other* column in the same table is sorted, which is the only thing that brings them back to life.

| Where | Dead header |
|---|---|
| Group → **Peers**, and Accessible Peers | **Name** |
| **Routes** | **Metric** |
| Okta SSO → domain verification | **Domain** |

To reproduce: open a Group → **Peers** and click the **Name** header. The list does not reorder, however many times you click it. Now click **Address**, then **Name** — and Name sorting works from then on.

### Root cause

Those three tables are the only ones in the app whose default sort has more than one column:

- `MinimalPeersTable.tsx:105-118` — `[connected desc, last_seen desc, `**`name asc`**`]`
- `RouteTable.tsx:103-111` — `[network_id desc, `**`metric desc`**`]`
- `DomainVerificationTable.tsx:45-54` — `[is_current desc, `**`name desc`**`]`

In each case the dead header is the **last** entry. A header click calls `column.toggleSorting()`, whose non-multi branch in `@tanstack/table-core` 8.21.3 (`RowSorting.ts`) only *replaces* the sort when the clicked column is **not** the last entry of the current sort:

```js
if (old?.length && existingIndex !== old.length - 1) sortAction = 'replace'
else if (existingSorting)                            sortAction = 'toggle'
else                                                 sortAction = 'replace'
```

`name` is the last entry, so every click `toggle`s it in place — flipping only its `desc` behind the dominant `connected`/`last_seen` sorts — and the visible order never changes. Clicking a different column *does* hit the `replace` branch, which collapses the sort to a single entry; from that point `name` is no longer last and starts behaving. That is why the bug looks intermittent, and why it is easy to miss when testing.

Only the last entry of a default sort is affected — columns earlier in it, and every table with a single-column default sort, work fine. That is why the list is three headers rather than the whole app, and it is also why clicking around casually makes the bug disappear.

This is already a known sharp edge in this codebase: `PeersTable.tsx:180-195` works around it for one column by reaching for the `onSort` escape hatch and calling `table.setSorting([{ id: "last_seen", desc: !desc }])` by hand. This PR generalises that workaround to every header; the bespoke override can be retired separately.

### Changes

- **`DataTableContext`** — exposes the tanstack table instance to anything rendered inside `DataTable`, mirroring the existing `ServerPaginationProvider` pattern. `DataTableHeader` is rendered from ~200 column definitions across 46 files, so threading `table` through as a prop is not realistic; only one of those call sites currently pulls it out of the header render props. `useOptionalDataTable()` returns `null` rather than throwing, and the header keeps a `column.toggleSorting()` fallback, so a header rendered outside a `DataTable` degrades instead of crashing.
- **`DataTableHeader`** — a click now replaces the sort with the clicked column alone, regardless of its position.
- Direction is taken from whether the column already **leads** the sort, rather than from `column.getIsSorted()`. `name` reports `"asc"` while it sits at the bottom of the default sort, so deriving direction from it would open with a *descending* sort on a list the user reads as unsorted. This also collapses a second, duplicate direction computation that previously ran *after* the sort had been applied, so the local sort and the server-side `setSort` can no longer disagree.

Header clicks never passed tanstack's `multi` flag and there is no shift-click multi-sort UI anywhere in the app (no `enableMultiSort`, `isMultiSortEvent` or `maxMultiSortColCount` in the tree), so forcing a single-column sort does not remove behaviour anyone can currently reach.

### Verification

`src/components/table/DataTableHeader.test.tsx` covers four cases, including the reported bug asserted on the **rendered row order**, not just on sorting state. Reverting `DataTableHeader.tsx` to `main` turns two of them red, with sorting stuck at `[connected desc, last_seen desc, name desc]` and the row order unchanged — the bug exactly as reported.

Run locally on node 20, matching `unit-tests.yml`:

```
npm run test:unit
 Test Files  47 passed (47)
      Tests  641 passed (641)
```

`eslint` and `prettier` are clean on all four touched files, and `tsc --noEmit` reports nothing in them.

Note that CI has never actually run on this PR — every workflow sits at `action_required`, since runs from a fork need a maintainer to approve them.

## Issue ticket number and link

N/A — reported internally, no public issue.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Internal table sort-behaviour bug fix with no user-facing API or configuration surface to document.

## E2E tests

management-cloud-tag: main
reverse-proxy-tag: main
