### PR TITLE
Feat/search peers by mac

### DIFF
--- a/src/app/(dashboard)/peer/page.tsx
+++ b/src/app/(dashboard)/peer/page.tsx
@@ -64,7 +64,7 @@ import { usePermissions } from "@/contexts/PermissionsProvider";
 import RoutesProvider from "@/contexts/RoutesProvider";
 import { useHasChanges } from "@/hooks/useHasChanges";
 import type { Group } from "@/interfaces/Group";
-import type { Peer } from "@/interfaces/Peer";
+import { type Peer, peerMacAddresses } from "@/interfaces/Peer";
 import type { User } from "@/interfaces/User";
 import PageContainer from "@/layouts/PageContainer";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
@@ -675,6 +675,24 @@ function PeerInformationCard({ peer }: Readonly<{ peer: Peer }>) {
                 </>
               }
               value={peer.serial_number}
+            />
+          )}
+
+          {peerMacAddresses(peer).length > 0 && (
+            <Card.ListItem
+              copy
+              copyText={"MAC Address"}
+              label={
+                <>
+                  <NetworkIcon size={16} className={"shrink-0"} />
+                  MAC Address
+                </>
+              }
+              className={
+                peerMacAddresses(peer).length > 1 ? "items-start" : ""
+              }
+              value={peerMacAddresses(peer)[0]}
+              extraText={peerMacAddresses(peer).slice(1)}
             />
           )}
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -100,7 +100,7 @@ const CardTextItem = ({
   return (
     <div
       className={cn(
-        "text-right text-nb-gray-400 text-[0.84rem] flex items-center gap-2",
+        "text-right text-nb-gray-400 text-[0.84rem] flex items-center justify-end gap-2",
         copy && "cursor-pointer hover:text-nb-gray-300 transition-all",
       )}
       onClick={() =>

--- a/src/interfaces/Peer.ts
+++ b/src/interfaces/Peer.ts
@@ -33,6 +33,26 @@ export interface Peer {
   serial_number: string;
   ephemeral: boolean;
   local_flags?: PeerLocalFlags;
+  network_addresses?: NetworkAddress[];
+}
+
+export interface NetworkAddress {
+  net_ip: string;
+  mac: string;
+}
+
+// peerMacAddresses returns the unique, non-empty MAC addresses reported by a
+// peer's network interfaces. A peer reports the same MAC for several IPs
+// (e.g. IPv4 + IPv6 of one NIC), so we de-duplicate.
+export function peerMacAddresses(peer: Peer): string[] {
+  if (!peer.network_addresses) return [];
+  return Array.from(
+    new Set(
+      peer.network_addresses
+        .map((address) => address.mac)
+        .filter((mac) => !!mac),
+    ),
+  );
 }
 
 export interface PeerLocalFlags {

--- a/src/modules/peers/PeersTable.tsx
+++ b/src/modules/peers/PeersTable.tsx
@@ -51,7 +51,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { getOperatingSystem } from "@/hooks/useOperatingSystem";
 import { Group } from "@/interfaces/Group";
 import { OperatingSystem } from "@/interfaces/OperatingSystem";
-import { Peer } from "@/interfaces/Peer";
+import { Peer, peerMacAddresses } from "@/interfaces/Peer";
 import PeerActionCell from "@/modules/peers/PeerActionCell";
 import PeerAddressCell from "@/modules/peers/PeerAddressCell";
 import PeerGroupCell from "@/modules/peers/PeerGroupCell";
@@ -262,6 +262,10 @@ const PeersTableColumns: ColumnDef<Peer>[] = [
   {
     id: "ipv6",
     accessorFn: (row) => row.ipv6,
+  },
+  {
+    id: "mac",
+    accessorFn: (peer) => peerMacAddresses(peer).join(", "),
   },
 ];
 
@@ -492,7 +496,7 @@ export default function PeersTable({
         showResetFilterButton={false}
         columns={PeersTableColumns}
         data={showBrowserPeers ? browserPeers : regularPeers}
-        searchPlaceholder={"Search by name, IP, owner or group..."}
+        searchPlaceholder={"Search by name, IP, MAC, owner or group..."}
         columnVisibility={{
           select: permission.groups.read,
           connected: false,
@@ -509,6 +513,7 @@ export default function PeersTable({
           os: false,
           os_kind: false,
           ipv6: false,
+          mac: false,
         }}
         isLoading={isLoading}
         // Treat a selected kind as an active filter: when peers exist but the


### PR DESCRIPTION
The management API now returns each peer's per-interface MAC addresses (in a new `network_addresses` field). This PR uses that data in the dashboard so you can search the peer list by MAC address and see a peer's MAC on its detail page.

## Describe your changes

- **Search:** peers are now matched by MAC in the User Devices / Servers list.
  Added a hidden `mac` column feeding the existing client-side global filter,   and updated the search placeholder to
  "Search by name, IP, MAC, owner or group…".
- **Display:** the peer detail page shows a copyable **MAC Address** row. A  device that reports several interfaces lists each MAC, de-duplicated (the same  NIC is otherwise repeated across its IPv4/IPv6 addresses).
- **Type:** added `NetworkAddress` + `network_addresses` to the `Peer` interface  and a small `peerMacAddresses()` helper.
- **Minor fix:** right-justified value rows in `Card.ListItem` so copy icons line  up in multi-line lists (the MAC list, and the existing Domain field).

Depends on the management API change that adds the `network_addresses` field to the peers response: netbirdio/netbird#6553 (https://github.com/netbirdio/netbird/pull/6553). Without it the field is absent and the search/detail simply show nothing (no regression to existing behavior).

## Issue ticket number and link

Discussion thread: https://netbirdio.slack.com/archives/C02KHAE8VLZ/p1782489164474579

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is a self-explanatory UI affordance (an extra searchable value and a field on the peer detail page); it doesn't introduce new concepts or workflows that require documentation.

### Docs PR URL (required if "docs added" is checked)

N/A

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MAC address visibility to peer details, showing a primary address and additional addresses when available.
  * Added a MAC address column to the peers table, displaying addresses as a comma-separated list when enabled.

* **Enhancements**
  * Updated peer table search to include MAC addresses.
  * Improved card row alignment for clearer label and value presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->