### PR TITLE
The empty-state peer card now renders AddPeerDropdown

### DIFF
--- a/src/components/NoPeersGettingStarted.tsx
+++ b/src/components/NoPeersGettingStarted.tsx
@@ -1,6 +1,6 @@
 import InlineLink from "@components/InlineLink";
 import SquareIcon from "@components/SquareIcon";
-import AddPeerButton from "@components/ui/AddPeerButton";
+import AddPeerDropdown from "@components/ui/AddPeerDropdown";
 import GetStartedTest from "@components/ui/GetStartedTest";
 import { ExternalLinkIcon } from "lucide-react";
 import * as React from "react";
@@ -8,17 +8,10 @@ import PeerIcon from "@/assets/icons/PeerIcon";
 
 type Props = {
   showBackground?: boolean;
-  // When set, tailors the empty-state copy and threads isUserDevice
-  // through AddPeerButton so the right Install NetBird flow opens:
-  //   true  → User Devices empty state (browser/SSO flow, mobile tabs).
-  //   false → Servers empty state (setup-key flow, no mobile tabs).
-  //   undefined → legacy/global empty state (no kind preference).
-  isUserDevice?: boolean;
 };
 
 export const NoPeersGettingStarted = ({
   showBackground = true,
-  isUserDevice,
 }: Readonly<Props>) => {
   return (
     <GetStartedTest
@@ -35,7 +28,7 @@ export const NoPeersGettingStarted = ({
         "It looks like you don't have any connected machines.\n" +
         "Get started by adding one to your network."
       }
-      button={<AddPeerButton isUserDevice={isUserDevice} />}
+      button={<AddPeerDropdown />}
       learnMore={
         <>
           Learn more in our{" "}

--- a/src/modules/peers/PeersTable.tsx
+++ b/src/modules/peers/PeersTable.tsx
@@ -518,10 +518,7 @@ export default function PeersTable({
         // still shows.
         hasServerSideFilters={kind !== undefined && (peers?.length ?? 0) > 0}
         getStartedCard={
-          <NoPeersGettingStarted
-            showBackground={true}
-            isUserDevice={kind ? kind === "users" : undefined}
-          />
+          <NoPeersGettingStarted showBackground={true} />
         }
         rightSide={() => (
           <>


### PR DESCRIPTION

<img width="576" height="339" alt="Screenshot 2026-06-28 at 12 09 37" src="https://github.com/user-attachments/assets/cc61332a-63de-4798-8b99-b2b91dfb555c" />


## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the empty-state “get started” experience so the primary action now opens a dropdown consistently.
  * Removed device-specific branching from the empty-state flow, creating a more streamlined and predictable setup screen.
  * Improved the empty-state display so it now uses a cleaner default configuration with the background shown by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->