### PR TITLE
Reload nginx after patching CSP header

### DIFF
--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -162,3 +162,16 @@ for f in $(grep -R -l AUTH_SUPPORTED_SCOPES /usr/share/nginx/html); do
     envsubst "$ENV_STR" < "$f".copy > "$f"
     rm "$f".copy
 done
+
+# Reload nginx so the patched CSP header takes effect.
+# supervisord starts nginx (priority 100) before this script (priority 201) and
+# never reloads it, so without this nginx keeps serving the static default.conf
+# CSP that has no connect-src, breaking OIDC discovery over plain HTTP.
+for i in $(seq 1 10); do
+    if nginx -s reload 2>/dev/null; then
+        echo "Reloaded nginx to apply updated CSP configuration"
+        break
+    fi
+    echo "Waiting for nginx to be ready before reload (attempt $i)..."
+    sleep 1
+done

--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -180,5 +180,6 @@ done
 
 if [[ "$reloaded" != true ]]; then
     echo "Failed to reload nginx after patching CSP header" >&2
+    nginx -t || true
     exit 1
 fi

--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -167,11 +167,18 @@ done
 # supervisord starts nginx (priority 100) before this script (priority 201) and
 # never reloads it, so without this nginx keeps serving the static default.conf
 # CSP that has no connect-src, breaking OIDC discovery over plain HTTP.
+reloaded=false
 for i in $(seq 1 10); do
     if nginx -s reload 2>/dev/null; then
         echo "Reloaded nginx to apply updated CSP configuration"
+        reloaded=true
         break
     fi
     echo "Waiting for nginx to be ready before reload (attempt $i)..."
     sleep 1
 done
+
+if [[ "$reloaded" != true ]]; then
+    echo "Failed to reload nginx after patching CSP header" >&2
+    exit 1
+fi

--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -141,8 +141,18 @@ CSP_CONNECT_SRC=$(echo $CSP_CONNECT_SRC | tr ' ' '\n' | sort -u | tr '\n' ' ' | 
 CSP_FRAME_SRC=$(echo $CSP_FRAME_SRC | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
 CSP_SCRIPT_SRC=$(echo $CSP_SCRIPT_SRC | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
 
+# upgrade-insecure-requests tells the browser to rewrite every http subresource,
+# fetch and WebSocket to https/wss. That is correct for https deployments but breaks
+# plain-http ones (e.g. local or self-hosted over http), where it would rewrite the
+# working http/ws endpoints to unreachable https/wss. Emit it only when the backend
+# is served over https, matching the ws:// vs wss:// scheme logic above.
+CSP_UPGRADE_INSECURE=" upgrade-insecure-requests;"
+if [[ "$NETBIRD_MGMT_API_ENDPOINT" == http://* || "$AUTH_AUTHORITY" == http://* ]]; then
+    CSP_UPGRADE_INSECURE=""
+fi
+
 # Update CSP in nginx config
-CSP_POLICY="default-src 'none'; connect-src 'self' $CSP_CONNECT_SRC; frame-src 'self' $CSP_FRAME_SRC; script-src 'self' 'wasm-unsafe-eval' $CSP_SCRIPT_SRC; font-src 'self'; img-src * data:; manifest-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+CSP_POLICY="default-src 'none'; connect-src 'self' $CSP_CONNECT_SRC; frame-src 'self' $CSP_FRAME_SRC; script-src 'self' 'wasm-unsafe-eval' $CSP_SCRIPT_SRC; font-src 'self'; img-src * data:; manifest-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';$CSP_UPGRADE_INSECURE"
 CSP_HEADER="add_header Content-Security-Policy \"$CSP_POLICY\" always;"
 
 echo "CSP header: $CSP_HEADER"


### PR DESCRIPTION
nginx is started by supervisord (priority 100) before init_react_envs.sh (priority 201) and is never reloaded afterwards, so it keeps serving the static default.conf CSP that has no connect-src. Over plain HTTP this blocks OIDC discovery and the management API, breaking browser SSH/RDP auth.

Reload nginx at the end of the init script so the dynamically built CSP header takes effect.

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended HTTP→HTTPS rewriting by applying the CSP `upgrade-insecure-requests` directive only when the management API endpoint and auth authority are not served over plain HTTP.
  * Improved the nginx reload workflow after updating environment-driven OIDC static templates and CSP settings, ensuring the latest configuration is applied.
  * Added bounded nginx reload retries (up to 10 attempts with brief delays) with clear success/“waiting” logging, and now fails if reload never succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->