### PR TITLE
Prefill Vertex endpoint

### DIFF
--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -557,7 +557,7 @@ export default function AIProviderModal({
                       // placeholder hint them what to type instead.
                       setUpstreamUrl(
                         next === "vertex_ai_api"
-                          ? ""
+                          ? "https://aiplatform.googleapis.com"
                           : c.default_host
                           ? `https://${c.default_host}`
                           : "",


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When selecting Vertex AI, the upstream URL is now prefilled with the correct Google API endpoint instead of starting blank.
  * Other provider selections continue to use their existing default host values, with no change in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->