### PR TITLE
Prevent gated useFetchApi hooks from overwriting shared cache entries

### DIFF
--- a/src/utils/api.tsx
+++ b/src/utils/api.tsx
@@ -129,17 +129,19 @@ export default function useFetchApi<T>(
   const handleErrors = useApiErrorHandling(ignoreError);
   const { globalApiParams } = useApplicationContext();
 
-  const cacheKey = options?.key ? [url, options?.key] : url;
+  const cacheKey = !allowFetch
+    ? null
+    : options?.key
+    ? [url, options?.key]
+    : url;
   const fetchFn = options?.key
     ? async ([url]: [url: string]) => {
-        if (!allowFetch) return;
         return apiRequest<T>(fetch, "GET", url, undefined, {
           ...options,
           globalParams: globalApiParams,
         }).catch((err) => handleErrors(err as ErrorResponse));
       }
     : async (url: string) => {
-        if (!allowFetch) return;
         return apiRequest<T>(fetch, "GET", url, undefined, {
           ...options,
           globalParams: globalApiParams,


### PR DESCRIPTION
## Issue ticket number and link

Fixes `useFetchApi` so disabled fetches don't register an SWR cache key. This prevents gated hooks that share the same endpoint from blocking active requests and leaving shared data empty.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request handling so network calls are no longer triggered when fetching is disabled.
  * Improved consistency in how requests are keyed, while keeping normal fetching behavior unchanged when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->