### PR TITLE
Show reason for peer login expiration events

### DIFF
--- a/src/modules/activity/ActivityDescription.tsx
+++ b/src/modules/activity/ActivityDescription.tsx
@@ -223,8 +223,7 @@ export default function ActivityDescription({ event }: Props) {
     return (
       <div className={"inline"}>
         User <Value>{event.meta.username}</Value>{" "}
-        <Value>{event.meta.email}</Value>
-        was blocked
+        <Value>{event.meta.email}</Value> was blocked
       </div>
     );
 
@@ -232,8 +231,7 @@ export default function ActivityDescription({ event }: Props) {
     return (
       <div className={"inline"}>
         User <Value>{event.meta.username}</Value>{" "}
-        <Value>{event.meta.email}</Value>
-        was unblocked
+        <Value>{event.meta.email}</Value> was unblocked
       </div>
     );
 

--- a/src/modules/activity/ActivityDescription.tsx
+++ b/src/modules/activity/ActivityDescription.tsx
@@ -359,12 +359,21 @@ export default function ActivityDescription({ event }: Props) {
       </div>
     );
 
-  if (event.activity_code == "peer.login.expire")
+  if (event.activity_code == "peer.login.expire") {
+    const reason = m.reason?.toLowerCase();
+
     return (
       <div className={"inline"}>
-        Login of the peer <Value>{m.name}</Value> is expired
+        Login of the peer <Value>{m.name}</Value> expired
+        {reason && (
+          <>
+            {" "}
+            due to <Value>{reason}</Value>
+          </>
+        )}
       </div>
     );
+  }
 
   if (event.activity_code == "peer.ssh.disable")
     return (

--- a/src/modules/activity/ActivityDescription.tsx
+++ b/src/modules/activity/ActivityDescription.tsx
@@ -360,15 +360,13 @@ export default function ActivityDescription({ event }: Props) {
     );
 
   if (event.activity_code == "peer.login.expire") {
-    const reason = m.reason?.toLowerCase();
-
     return (
       <div className={"inline"}>
         Login of the peer <Value>{m.name}</Value> expired
-        {reason && (
+        {m.reason && (
           <>
             {" "}
-            due to <Value>{reason}</Value>
+            due to <Value>{m.reason}</Value>
           </>
         )}
       </div>


### PR DESCRIPTION
## Issue ticket number and link

<img width="815" height="514" alt="image" src="https://github.com/user-attachments/assets/f9a7fc7e-9f2e-4052-ac4a-38971169284a" />


## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the wording of peer login expiration messages for clearer activity logs.
  * Added an optional reason to expiration notices when available.
  * Kept user block/unblock activity messages consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->