### PR TITLE
Fix peer table page reset when switching kind

### DIFF
--- a/src/modules/peers/PeersTable.tsx
+++ b/src/modules/peers/PeersTable.tsx
@@ -541,9 +541,13 @@ export default function PeersTable({
               <ButtonGroup.Button
                 className={"h-[42px]"}
                 variant={kind === "users" ? "tertiary" : "secondary"}
-                onClick={() =>
-                  onKindChange?.(kind === "users" ? undefined : "users")
-                }
+                onClick={() => {
+                  // Reset to the first page: the new subset may have fewer
+                  // pages than the current index, which would show an empty
+                  // table (page index doesn't auto-reset on data change).
+                  table.setPageIndex(0);
+                  onKindChange?.(kind === "users" ? undefined : "users");
+                }}
               >
                 User Devices
               </ButtonGroup.Button>
@@ -552,9 +556,10 @@ export default function PeersTable({
                 // button's right border into a doubled divider.
                 className={"h-[42px] !border-l-0"}
                 variant={kind === "servers" ? "tertiary" : "secondary"}
-                onClick={() =>
-                  onKindChange?.(kind === "servers" ? undefined : "servers")
-                }
+                onClick={() => {
+                  table.setPageIndex(0);
+                  onKindChange?.(kind === "servers" ? undefined : "servers");
+                }}
               >
                 Servers
               </ButtonGroup.Button>


### PR DESCRIPTION
## Issue ticket number and link

The peers table uses client-side pagination with autoResetPageIndex: false in DataTable, so the page index never resets when the data changes. Switching kind swaps the
  data (kindFilteredPeers) but left the page index untouched — so being on page 10 of Servers and switching to Users (only 5 pages) left tanstack on an out-of-range page, rendering
  an empty table.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the device and server toggle behavior so the table now returns to the first page when switching views.
  * Prevents empty or out-of-range pages from appearing after changing the table’s content subset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->