### PR TITLE
Feature/add skip tls verification

### DIFF
--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -111,6 +111,8 @@ function upstreamUrlPlaceholder(providerId: AIProviderId): string {
       return "https://your-litellm-host";
     case "portkey":
       return "https://api.portkey.ai";
+    case "vllm":
+      return "https://your-vllm-host:8000";
     case "custom":
       return "https://your-llm-host";
     default:
@@ -132,6 +134,8 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
       return "Vercel AI Gateway uses a fixed endpoint; only the API key varies by operator. Apps choose the upstream provider with the model prefix, e.g. openai/gpt-5.4 or anthropic/claude-opus-4.6.";
     case "openrouter":
       return "OpenRouter uses a fixed endpoint, openrouter.ai/api/v1; apps choose the upstream provider via the model prefix, e.g. anthropic/claude-* or openai/gpt-*.";
+    case "vllm":
+      return "Your local vLLM server's OpenAI-compatible base URL.";
     default:
       return "Where NetBird forwards the traffic.";
   }
@@ -215,6 +219,9 @@ export default function AIProviderModal({
   );
 
   const catalog = getById(providerId);
+  // Custom-kind providers (the generic "Custom" entry and named self-hosted
+  // ones like vLLM) share the self-hosted extras, e.g. Skip TLS verification.
+  const isCustomKind = catalog?.kind === "custom";
   const customizableHeaderPair =
     catalog?.identity_injection?.header_pair?.customizable === true;
   const customizableJsonMetadata =
@@ -397,7 +404,7 @@ export default function AIProviderModal({
         models,
         extraValues: sanitizedExtraValues,
         ...identityOverrides,
-        skipTlsVerification: providerId === "custom" ? skipTlsVerification : false,
+        skipTlsVerification: isCustomKind ? skipTlsVerification : false,
         // Only forward the API key when the user actually rotated it
         ...(apiKey && apiKey !== "••••••••" ? { apiKey } : {}),
       });
@@ -412,22 +419,21 @@ export default function AIProviderModal({
       apiKey,
       extraValues: sanitizedExtraValues,
       ...identityOverrides,
-      skipTlsVerification: providerId === "custom" ? skipTlsVerification : false,
+      skipTlsVerification: isCustomKind ? skipTlsVerification : false,
       models,
       enabled: true,
     });
     handleClose();
   };
 
-  // providerOptions are sorted into three groups, gateways first, so
-  // the catalog Select makes the routing-layer entries (LiteLLM,
-  // Portkey) prominent. SelectDropdown renders section headers
-  // automatically when options carry a `group` value; the section
-  // order tracks first-occurrence in the array.
+  // providerOptions are sorted into three groups, first-party AI Providers
+  // first, then AI Gateways, then the self-hosted / custom catch-all.
+  // SelectDropdown renders section headers automatically when options carry a
+  // `group` value; the section order tracks first-occurrence in the array.
   const providerOptions = useMemo(() => {
     const groupRank: Record<string, number> = {
-      gateway: 0,
-      provider: 1,
+      provider: 0,
+      gateway: 1,
       custom: 2,
     };
     const groupLabel: Record<string, string> = {
@@ -613,7 +619,7 @@ export default function AIProviderModal({
                 />
               </FormRow>
 
-              {providerId === "custom" && (
+              {isCustomKind && (
                 <FancyToggleSwitch
                   value={skipTlsVerification}
                   onChange={setSkipTlsVerification}

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -2,6 +2,7 @@
 
 import Button from "@components/Button";
 import { Callout } from "@components/Callout";
+import FancyToggleSwitch from "@components/FancyToggleSwitch";
 import HelpText from "@components/HelpText";
 import { HelpTooltip } from "@components/HelpTooltip";
 import InlineLink from "@components/InlineLink";
@@ -27,6 +28,7 @@ import {
   MinusCircleIcon,
   PlusCircle,
   PlusIcon,
+  ShieldOffIcon,
   Sparkles,
   UploadIcon,
 } from "lucide-react";
@@ -208,6 +210,9 @@ export default function AIProviderModal({
   const [identityHeaderGroups, setIdentityHeaderGroups] = useState<string>(
     provider?.identityHeaderGroups ?? "",
   );
+  const [skipTlsVerification, setSkipTlsVerification] = useState<boolean>(
+    provider?.skipTlsVerification ?? false,
+  );
 
   const catalog = getById(providerId);
   const customizableHeaderPair =
@@ -327,6 +332,7 @@ export default function AIProviderModal({
       setExtraValues(provider.extraValues ?? {});
       setIdentityHeaderUserId(provider.identityHeaderUserId ?? "");
       setIdentityHeaderGroups(provider.identityHeaderGroups ?? "");
+      setSkipTlsVerification(provider.skipTlsVerification ?? false);
     } else {
       const fallback = getById("openai_api");
       setProviderId("openai_api");
@@ -340,6 +346,7 @@ export default function AIProviderModal({
       setExtraValues({});
       setIdentityHeaderUserId("");
       setIdentityHeaderGroups("");
+      setSkipTlsVerification(false);
     }
   };
 
@@ -390,6 +397,7 @@ export default function AIProviderModal({
         models,
         extraValues: sanitizedExtraValues,
         ...identityOverrides,
+        skipTlsVerification: providerId === "custom" ? skipTlsVerification : false,
         // Only forward the API key when the user actually rotated it
         ...(apiKey && apiKey !== "••••••••" ? { apiKey } : {}),
       });
@@ -404,6 +412,7 @@ export default function AIProviderModal({
       apiKey,
       extraValues: sanitizedExtraValues,
       ...identityOverrides,
+      skipTlsVerification: providerId === "custom" ? skipTlsVerification : false,
       models,
       enabled: true,
     });
@@ -603,6 +612,43 @@ export default function AIProviderModal({
                   placeholder={upstreamUrlPlaceholder(providerId)}
                 />
               </FormRow>
+
+              {providerId === "custom" && (
+                <FancyToggleSwitch
+                  value={skipTlsVerification}
+                  onChange={setSkipTlsVerification}
+                  label={
+                    <>
+                      <ShieldOffIcon size={15} />
+                      Skip TLS Verification
+                      <span onClick={(e) => e.stopPropagation()}>
+                        <HelpTooltip
+                          interactive
+                          content={
+                            <>
+                              Skips certificate validation on requests to this
+                              provider. Useful for quick testing against
+                              endpoints with self-signed certificates. For
+                              production we recommend mounting trusted
+                              certificates on your proxy instances instead.{" "}
+                              <InlineLink
+                                href={
+                                  "https://docs.netbird.io/agent-network/providers/self-signed-certificates"
+                                }
+                                target={"_blank"}
+                              >
+                                Learn more
+                                <ExternalLinkIcon size={12} />
+                              </InlineLink>
+                            </>
+                          }
+                        />
+                      </span>
+                    </>
+                  }
+                  helpText={"Disable upstream TLS certificate validation."}
+                />
+              )}
 
               {providerId === "vertex_ai_api" ? (
                 <FormRow

--- a/src/modules/agent-network/AIProvidersProvider.tsx
+++ b/src/modules/agent-network/AIProvidersProvider.tsx
@@ -47,6 +47,9 @@ export type APIProvider = {
   // stored here land on the wire.
   identity_header_user_id?: string;
   identity_header_groups?: string;
+  // Skip TLS certificate verification on upstream requests (custom providers
+  // with self-signed certs). Off by default.
+  skip_tls_verification?: boolean;
   enabled: boolean;
   created_at: string;
   updated_at: string;
@@ -63,6 +66,7 @@ export type APIProviderRequest = {
   extra_values?: Record<string, string>;
   identity_header_user_id?: string;
   identity_header_groups?: string;
+  skip_tls_verification?: boolean;
   models: APIProviderModel[];
   enabled?: boolean;
 };
@@ -78,6 +82,8 @@ export type ProviderConnectInput = {
   extraValues?: Record<string, string>;
   identityHeaderUserId?: string;
   identityHeaderGroups?: string;
+  // Skip upstream TLS verification (custom providers with self-signed certs).
+  skipTlsVerification?: boolean;
   models: ProviderModel[];
   enabled?: boolean;
 };
@@ -90,6 +96,7 @@ export type ProviderUpdateInput = {
   extraValues?: Record<string, string>;
   identityHeaderUserId?: string;
   identityHeaderGroups?: string;
+  skipTlsVerification?: boolean;
   models?: ProviderModel[];
   enabled?: boolean;
 };
@@ -151,6 +158,7 @@ function fromAPI(p: APIProvider): AIProvider {
     extraValues: p.extra_values ?? {},
     identityHeaderUserId: p.identity_header_user_id,
     identityHeaderGroups: p.identity_header_groups,
+    skipTlsVerification: p.skip_tls_verification ?? false,
     status: p.enabled ? "active" : "disabled",
     models,
     allowedGroups: [],
@@ -192,6 +200,7 @@ function toCreateRequest(input: ProviderConnectInput): APIProviderRequest {
     extra_values: input.extraValues,
     identity_header_user_id: input.identityHeaderUserId,
     identity_header_groups: input.identityHeaderGroups,
+    skip_tls_verification: input.skipTlsVerification,
     models: toAPIModels(input.models),
     enabled: input.enabled,
   };
@@ -635,6 +644,8 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
           updates.identityHeaderUserId ?? existing.identity_header_user_id,
         identity_header_groups:
           updates.identityHeaderGroups ?? existing.identity_header_groups,
+        skip_tls_verification:
+          updates.skipTlsVerification ?? existing.skip_tls_verification,
         models: updates.models
           ? toAPIModels(updates.models)
           : existing.models ?? [],

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -18,6 +18,7 @@ export type AIProviderId =
   | "cloudflare_ai_gateway"
   | "vercel_ai_gateway"
   | "openrouter"
+  | "vllm"
   | "custom";
 
 export type AIProviderStatus = "active" | "warning" | "disabled";

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -60,6 +60,9 @@ export type AIProvider = {
   // the value stored here lands on the wire.
   identityHeaderUserId?: string;
   identityHeaderGroups?: string;
+  // Skip TLS certificate verification on upstream requests — for custom
+  // providers using self-signed certs. Off by default.
+  skipTlsVerification?: boolean;
   status: AIProviderStatus;
   models: ProviderModel[];
   allowedGroups: string[];


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/823

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option for custom/self-hosted AI providers to skip TLS certificate verification.
  * Expanded provider support to include vLLM and improved the provider selection order in the modal.

* **Bug Fixes**
  * Provider settings now persist the TLS verification choice when creating or updating providers.
  * The TLS verification setting resets correctly when the provider dialog is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->