### PR TITLE
Improve RDP connection error handling and retry flow

### DIFF
--- a/src/app/(remote-access)/peer/rdp/page.tsx
+++ b/src/app/(remote-access)/peer/rdp/page.tsx
@@ -67,24 +67,55 @@ function RDPSession({ peer }: Props) {
     });
   };
 
+  /**
+   * Reset the RDP session state but keep the NetBird client connected,
+   * so a retry does not pay the full engine reconnect.
+   */
   const reset = useCallback(async () => {
     setCredentials(null);
     connected.current = false;
     setCredentialsModal(true);
     rdp.session?.disconnect();
-    await client.disconnect();
-  }, [client, rdp]);
+  }, [rdp]);
+
+  // Port the temporary access peer was created for; access is scoped to it.
+  const connectedPort = useRef<number | null>(null);
 
   /**
    * Establishes a connection to the peer
    */
   const connect = async (rdpCredentials: RDPCredentials) => {
     if (!peer?.id) return;
-    if (client.status === NetBirdStatus.DISCONNECTED) {
+
+    let status = client.status;
+
+    // The temporary access is scoped to a single port, so a port change
+    // requires a fresh temporary peer.
+    if (
+      status === NetBirdStatus.CONNECTED &&
+      connectedPort.current !== null &&
+      connectedPort.current !== rdpCredentials.port
+    ) {
       try {
-        setCredentials(rdpCredentials);
+        await client.disconnect();
+        connectedPort.current = null;
+        status = NetBirdStatus.DISCONNECTED;
+      } catch (error) {
+        sendErrorNotification(
+          "NetBird Connection Error",
+          (error as Error).message,
+        );
+        return;
+      }
+    }
+
+    setCredentials(rdpCredentials);
+
+    if (status === NetBirdStatus.DISCONNECTED) {
+      try {
         setIsNetBirdConnecting(true);
         await client.connectTemporary(peer.id, [`tcp/${rdpCredentials.port}`]);
+        connectedPort.current = rdpCredentials.port;
         setIsNetBirdConnecting(false);
       } catch (error) {
         sendErrorNotification(

--- a/src/modules/remote-access/rdp/ironrdp-wasm-bridge.ts
+++ b/src/modules/remote-access/rdp/ironrdp-wasm-bridge.ts
@@ -177,7 +177,7 @@ export class IronRDPWASMBridge {
     } catch (error) {
       console.error(`IronRDP connection failed:`, error);
       this.logIronError(error);
-      throw error;
+      throw new Error(this.getReadableError(error));
     }
   }
   private setupClipboard(builder: SessionBuilder): void {
@@ -278,6 +278,24 @@ export class IronRDPWASMBridge {
     }
 
     return backtraceMsg;
+  }
+
+  private getReadableError(error: unknown): string {
+    const ironError = error as any;
+    if (typeof ironError?.backtrace === "function") {
+      try {
+        const formatted = this.formatRDCleanPathError(ironError.backtrace());
+        if (formatted.startsWith("Connection failed:")) {
+          return formatted;
+        }
+      } catch {
+        // Fall through to generic handling below.
+      }
+    }
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+    return "RDP connection failed";
   }
 
   private logIronError(error: unknown): void {

--- a/src/modules/remote-access/rdp/useRemoteDesktop.ts
+++ b/src/modules/remote-access/rdp/useRemoteDesktop.ts
@@ -5,11 +5,6 @@ import {
   useRDPCertificateHandler,
 } from "./useRDPCertificateHandler";
 
-interface IronError {
-  message: string;
-  backtrace?: () => string;
-}
-
 interface RDPConfig {
   hostname: string;
   port: number;
@@ -216,10 +211,10 @@ export const useRemoteDesktop = (client: any) => {
           canvasRef?.current?.focus();
           return RDPStatus.CONNECTED;
         } catch (err) {
-          const ironError = err as IronError;
-          const errorMessage = ironError.backtrace
-            ? ironError.backtrace()
-            : "RDP connection failed";
+          const errorMessage =
+            err instanceof Error && err.message
+              ? err.message
+              : "RDP connection failed";
           setError(errorMessage);
           resetState();
           throw Error(errorMessage);

--- a/src/modules/remote-access/useNetBirdClient.ts
+++ b/src/modules/remote-access/useNetBirdClient.ts
@@ -176,7 +176,7 @@ export const useNetBirdClient = () => {
       try {
         netBirdClient.current = await (window as any).NetBirdClient({
           privateKey,
-          logLevel: "warn",
+          logLevel: "info",
           managementURL: config.apiOrigin,
         });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -82,7 +82,7 @@ const loadConfig = (): Config => {
     googleTagManagerID: configJson?.googleTagManagerID || undefined,
     authServiceUrl: configJson?.authServiceUrl ?? undefined,
     wasmPath:
-      configJson?.wasmPath || "https://pkgs.netbird.io/wasm/client/v0.63.0",
+      configJson?.wasmPath || "https://pkgs.netbird.io/wasm/client/v0.74.2",
     licensed: configJson?.licensed === "true",
     cloud: configJson?.cloud === "true",
     agentNetworkOnly: configJson?.agentNetworkOnly === "true",


### PR DESCRIPTION
Improves RDP connection error handling in the browser client and updates the bundled wasm client version.

- Show the formatted connection error (e.g. connection timed out) in the error notification instead of a raw backtrace or a generic message
- Keep the temporary NetBird client connected when an RDP attempt fails, so retries skip the full engine reconnect; reconnect only when the target port changes
- Default the browser client log level to info
- Bump the default wasm client to v0.74.2

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal error-handling and dependency bump, no user-facing docs impact)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RDP reconnect behavior so retries can reuse an existing connection when possible, while still handling port changes correctly.
  * Resetting an RDP session now clears only the active session state, helping avoid unnecessary client disconnects.
  * RDP connection failures now show clearer, more readable error messages.
* **Chores**
  * Updated the default remote desktop web client source to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->