### PR TITLE
Default billing to EUR, preserve USD for active subscribers

### DIFF
--- a/e2e/tests/setup-keys.spec.ts
+++ b/e2e/tests/setup-keys.spec.ts
@@ -137,6 +137,7 @@ async function revokeSetupKey(
   );
   await page.getByTestId("confirmation.confirm").click();
   await responsePromise;
+  await expect(page.getByRole("dialog")).not.toBeVisible();
   await expect(
     page
       .locator("tr")
@@ -158,4 +159,5 @@ async function deleteSetupKey(
   await page.getByTestId("delete-setup-key").click({ force: true });
   await page.getByTestId("confirmation.confirm").click();
   await expect(page.locator("tr").filter({ hasText: name })).not.toBeVisible();
+  await expect(page.getByRole("dialog")).not.toBeVisible();
 }

--- a/src/cloud/aws/AWSChoosePlan.tsx
+++ b/src/cloud/aws/AWSChoosePlan.tsx
@@ -13,7 +13,7 @@ import Skeleton from "react-loading-skeleton";
 import AWSMarketplaceLogo from "@/assets/integrations/aws-marketplace.svg";
 import { useBilling } from "@/contexts/BillingProvider";
 import { useLoggedInUser } from "@/contexts/UsersProvider";
-import { Plan } from "@/interfaces/Plan";
+import { Currency, Plan } from "@/interfaces/Plan";
 import { PlanTier } from "@/interfaces/Subscription";
 import { PlanCard, PlanLoadingSkeleton } from "@/modules/billing/PlanCard";
 
@@ -27,7 +27,6 @@ export const AWSChoosePlan = ({ onSuccess }: Props) => {
     plans,
     isLoading,
     subscription,
-    currency,
     changeSubscription,
     isTrial,
     subscribe,
@@ -178,7 +177,7 @@ export const AWSChoosePlan = ({ onSuccess }: Props) => {
                                 upgrade: "Subscribe to",
                                 downgrade: "Downgrade to",
                               }}
-                              currency={currency}
+                              currency={Currency.USD}
                               isSubscribing={isSubscribing}
                               onClick={() => subscribeToPlan(plan)}
                               key={plan.name}

--- a/src/cloud/distributor/hooks/useCustomerPlan.ts
+++ b/src/cloud/distributor/hooks/useCustomerPlan.ts
@@ -1,4 +1,5 @@
 import useFetchApi, { useApiCall } from "@utils/api";
+import { resolveActiveCurrency } from "@utils/billing";
 import { notify } from "@components/Notification";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -20,7 +21,6 @@ export const useCustomerPlan = ({ accountId, withUsage = false }: Props) => {
     true,
   );
   const {
-    currency,
     plans,
     isLoading: isBillingLoading,
     getCurrentPlanByPlanTier,
@@ -44,6 +44,12 @@ export const useCustomerPlan = ({ accountId, withUsage = false }: Props) => {
     isTrialExpired,
     isSubscriptionLoading,
   } = useTenantSubscription({ tenantId: accountId });
+
+  // This customer's own billing currency, not the distributor's account currency
+  const currency = useMemo(
+    () => resolveActiveCurrency(subscription),
+    [subscription],
+  );
 
   const teamAndBusinessPlans = plans?.filter(
     (plan) =>

--- a/src/cloud/distributor/hooks/useCustomerPlan.ts
+++ b/src/cloud/distributor/hooks/useCustomerPlan.ts
@@ -1,10 +1,12 @@
 import useFetchApi, { useApiCall } from "@utils/api";
-import { resolveActiveCurrency } from "@utils/billing";
 import { notify } from "@components/Notification";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useTenantSubscription } from "@/cloud/msp/hooks/useTenantSubscription";
-import { useBilling } from "@/contexts/BillingProvider";
+import {
+  resolveActiveCurrency,
+  useBilling,
+} from "@/contexts/BillingProvider";
 import { AccountUsageStats } from "@/interfaces/AccountUsageStats";
 import { Plan } from "@/interfaces/Plan";
 import { PlanTier } from "@/interfaces/Subscription";

--- a/src/cloud/msp/MSPTenantsTable.tsx
+++ b/src/cloud/msp/MSPTenantsTable.tsx
@@ -7,12 +7,7 @@ import DataTableRefreshButton from "@components/table/DataTableRefreshButton";
 import { DataTableRowsPerPage } from "@components/table/DataTableRowsPerPage";
 import GetStartedTest from "@components/ui/GetStartedTest";
 import { ColumnDef, SortingState, Table } from "@tanstack/react-table";
-import {
-  CreditCardIcon,
-  HelpCircle,
-  PlusCircle,
-  ReceiptTextIcon,
-} from "lucide-react";
+import { HelpCircle, PlusCircle, ReceiptTextIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import React, { Fragment } from "react";
 import { useSWRConfig } from "swr";
@@ -268,24 +263,3 @@ const AddTenantButton = () => {
   );
 };
 
-const TotalCost = () => {
-  return (
-    <div className={"flex items-center gap-3"}>
-      <div
-        className={
-          "h-10 w-10 rounded-full bg-nb-gray-910 flex items-center justify-center"
-        }
-      >
-        <CreditCardIcon size={16} className={"text-nb-gray-200"} />
-      </div>
-      <div className={"flex items-start justify-center text-left flex-col"}>
-        <span className={"text-xs text-nb-gray-300 font-medium block"}>
-          Total Cost / Month
-        </span>
-        <span className={"font-semibold text-base relative text-nb-gray-200"}>
-          $5,260
-        </span>
-      </div>
-    </div>
-  );
-};

--- a/src/cloud/msp/hooks/useTenantPlan.ts
+++ b/src/cloud/msp/hooks/useTenantPlan.ts
@@ -1,11 +1,13 @@
 import useFetchApi from "@utils/api";
-import { resolveActiveCurrency } from "@utils/billing";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useTenants } from "@/cloud/msp/contexts/TenantsProvider";
 import { useTenantSubscription } from "@/cloud/msp/hooks/useTenantSubscription";
 import { Tenant } from "@/cloud/msp/interfaces/Tenant";
-import { useBilling } from "@/contexts/BillingProvider";
+import {
+  resolveActiveCurrency,
+  useBilling,
+} from "@/contexts/BillingProvider";
 import { AccountUsageStats } from "@/interfaces/AccountUsageStats";
 import { Plan } from "@/interfaces/Plan";
 import { PlanTier } from "@/interfaces/Subscription";

--- a/src/cloud/msp/hooks/useTenantPlan.ts
+++ b/src/cloud/msp/hooks/useTenantPlan.ts
@@ -1,4 +1,5 @@
 import useFetchApi from "@utils/api";
+import { resolveActiveCurrency } from "@utils/billing";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useTenants } from "@/cloud/msp/contexts/TenantsProvider";
@@ -18,7 +19,6 @@ export const useTenantPlan = ({ tenant, withUsage = true }: Props) => {
   const { mutate } = useSWRConfig();
   const { updateSubscription } = useTenants();
   const {
-    currency,
     plans,
     isLoading: isBillingLoading,
     getCurrentPlanByPlanTier,
@@ -42,6 +42,12 @@ export const useTenantPlan = ({ tenant, withUsage = true }: Props) => {
     isTrialExpired,
     isSubscriptionLoading,
   } = useTenantSubscription({ tenantId: tenant.id });
+
+  // This tenant's own billing currency, not the MSP admin's account currency
+  const currency = useMemo(
+    () => resolveActiveCurrency(subscription),
+    [subscription],
+  );
 
   const teamAndBusinessPlans = plans?.filter(
     (plan) =>

--- a/src/cloud/msp/table/TenantPlanCostCell.tsx
+++ b/src/cloud/msp/table/TenantPlanCostCell.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
-import { useMemo } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useTenantPlan } from "@/cloud/msp/hooks/useTenantPlan";
 import { Tenant, TenantStatus } from "@/cloud/msp/interfaces/Tenant";
-import { useBilling } from "@/contexts/BillingProvider";
 import { Currency } from "@/interfaces/Plan";
 import EmptyRow from "@/modules/common-table-rows/EmptyRow";
 
@@ -12,19 +10,13 @@ type Props = {
 };
 
 export const TenantPlanCostCell = ({ tenant }: Props) => {
-  const { calculateEstimatedPrice, currency } = useBilling();
-  const { isLoading, currentPlan, stats } = useTenantPlan({
+  const { isLoading, currency, estimatedPrice } = useTenantPlan({
     tenant,
   });
 
   const isActive = tenant.status === TenantStatus.Active;
   const isInvited = tenant.status === TenantStatus.Invited;
   const isExisting = tenant.status === TenantStatus.Existing;
-
-  const estimatedPrice = useMemo(() => {
-    if (!currentPlan || !stats || !currency || !isActive) return 0;
-    return calculateEstimatedPrice(currentPlan, currency, stats);
-  }, [currentPlan, stats, currency, isActive, calculateEstimatedPrice]);
 
   if (isLoading) return <Skeleton width={70} height={20} />;
   if (isInvited || isExisting) return <EmptyRow />;
@@ -37,7 +29,7 @@ export const TenantPlanCostCell = ({ tenant }: Props) => {
         }
       >
         {currency == Currency.USD && "$ "}
-        {estimatedPrice.toFixed(2)}
+        {(isActive ? estimatedPrice : 0).toFixed(2)}
         {currency == Currency.EUR && " €"}
       </span>
     </div>

--- a/src/contexts/BillingProvider.tsx
+++ b/src/contexts/BillingProvider.tsx
@@ -1,16 +1,11 @@
 import { notify } from "@components/Notification";
 import useFetchApi, { useApiCall } from "@utils/api";
+import { resolveActiveCurrency } from "@utils/billing";
 import { isNetBirdCloud } from "@utils/netbird";
 import md5 from "crypto-js/md5";
 import dayjs from "dayjs";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { PlanFeatures } from "@/cloud/cloud-hooks/useIsFeatureLocked";
 import { MSPTrialExpiredModal } from "@/cloud/msp/MSPTrialExpiredModal";
@@ -81,7 +76,6 @@ export const BillingContext = React.createContext(
     ) => Promise<boolean>;
     trialDaysRemaining: number;
     currency: Currency;
-    setCurrency: (currency: Currency) => void;
     getCurrentPlanByPlanTier: (planTier: PlanTier) => Plan | undefined;
     calculateEstimatedPrice: (
       plan: Plan,
@@ -171,22 +165,11 @@ function BillingContextProvider({ children }: Readonly<Props>) {
     );
   }, [currentPlan, subscription]);
 
-  const initialCurrency = useRef<Currency | undefined>(undefined);
-
-  const [currency, setCurrency] = useState<Currency>(
-    subscription?.currency || Currency.USD,
-  );
+  const [currency, setCurrency] = useState<Currency>(Currency.EUR);
 
   useEffect(() => {
     if (isSubscriptionLoading) return;
-
-    if (subscription?.active && subscription?.currency) {
-      setCurrency(subscription.currency);
-      initialCurrency.current = subscription.currency;
-    } else if (!initialCurrency.current) {
-      initialCurrency.current = subscription?.currency || Currency.USD;
-      setCurrency(initialCurrency.current);
-    }
+    setCurrency(resolveActiveCurrency(subscription));
   }, [isSubscriptionLoading, subscription?.active, subscription?.currency]);
 
   const maxPeersOfPlan = useMemo(() => {
@@ -483,7 +466,6 @@ function BillingContextProvider({ children }: Readonly<Props>) {
         startTrial,
         trialDaysRemaining,
         currency,
-        setCurrency,
         getCurrentPlanByPlanTier,
         calculateEstimatedPrice,
         isAWS,

--- a/src/contexts/BillingProvider.tsx
+++ b/src/contexts/BillingProvider.tsx
@@ -170,12 +170,10 @@ function BillingContextProvider({ children }: Readonly<Props>) {
     );
   }, [currentPlan, subscription]);
 
-  const [currency, setCurrency] = useState<Currency>(Currency.EUR);
-
-  useEffect(() => {
-    if (isSubscriptionLoading) return;
-    setCurrency(resolveActiveCurrency(subscription));
-  }, [isSubscriptionLoading, subscription?.active, subscription?.currency]);
+  const currency = useMemo(
+    () => resolveActiveCurrency(subscription),
+    [subscription],
+  );
 
   const maxPeersOfPlan = useMemo(() => {
     return (
@@ -237,8 +235,10 @@ function BillingContextProvider({ children }: Readonly<Props>) {
   ]);
 
   const subscribe = async (plan: Plan, aws?: boolean) => {
-    const priceID = plan.prices.find((price) => price.currency === currency)
-      ?.price_id;
+    const effectiveCurrency = aws ? Currency.USD : currency;
+    const priceID = plan.prices.find(
+      (price) => price.currency === effectiveCurrency,
+    )?.price_id;
     if (!priceID) return Promise.reject();
 
     let promise;
@@ -273,8 +273,10 @@ function BillingContextProvider({ children }: Readonly<Props>) {
   };
 
   const changeSubscription = async (plan: Plan, aws = false) => {
-    const priceID = plan.prices.find((price) => price.currency === currency)
-      ?.price_id;
+    const effectiveCurrency = aws ? Currency.USD : currency;
+    const priceID = plan.prices.find(
+      (price) => price.currency === effectiveCurrency,
+    )?.price_id;
     if (!priceID) return Promise.reject();
     const downgrade = isDowngrade(plan);
     const choice = await confirm({

--- a/src/contexts/BillingProvider.tsx
+++ b/src/contexts/BillingProvider.tsx
@@ -1,6 +1,5 @@
 import { notify } from "@components/Notification";
 import useFetchApi, { useApiCall } from "@utils/api";
-import { resolveActiveCurrency } from "@utils/billing";
 import { isNetBirdCloud } from "@utils/netbird";
 import md5 from "crypto-js/md5";
 import dayjs from "dayjs";
@@ -50,6 +49,12 @@ export const trialExpiresInfo: Announcement = {
   closeable: false,
   isCloudOnly: true,
 };
+
+export function resolveActiveCurrency(subscription?: Subscription): Currency {
+  return subscription?.active && subscription?.currency
+    ? subscription.currency
+    : Currency.EUR;
+}
 
 export const BillingContext = React.createContext(
   {} as {

--- a/src/modules/billing/PlansAndBillingTab.tsx
+++ b/src/modules/billing/PlansAndBillingTab.tsx
@@ -1,23 +1,11 @@
 import Breadcrumbs from "@components/Breadcrumbs";
 import InlineLink from "@components/InlineLink";
 import Paragraph from "@components/Paragraph";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@components/Select";
 import Separator from "@components/Separator";
 import { VerticalTabs } from "@components/VerticalTabs";
 import * as Tabs from "@radix-ui/react-tabs";
 import { isNetBirdCloud } from "@utils/netbird";
-import {
-  CreditCardIcon,
-  DollarSignIcon,
-  EuroIcon,
-  ExternalLinkIcon,
-} from "lucide-react";
+import { CreditCardIcon, ExternalLinkIcon } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
 import Skeleton from "react-loading-skeleton";
@@ -25,7 +13,7 @@ import SettingsIcon from "@/assets/icons/SettingsIcon";
 import { useMSP } from "@/cloud/msp/contexts/MSPProvider";
 import { useBilling } from "@/contexts/BillingProvider";
 import { usePermissions } from "@/contexts/PermissionsProvider";
-import { Currency, Plan } from "@/interfaces/Plan";
+import { Plan } from "@/interfaces/Plan";
 import { PlanTier } from "@/interfaces/Subscription";
 import { PlanCard, PlanLoadingSkeleton } from "@/modules/billing/PlanCard";
 import { PlanCurrentPlan } from "@/modules/billing/PlanCurrentPlan";
@@ -75,7 +63,6 @@ const PlansAndBillingTabContent = () => {
     isTrialAvailable,
     isTrial,
     currency,
-    setCurrency,
     currentPlanPrice,
     trialDaysRemaining,
     estimatedPrice,
@@ -216,34 +203,11 @@ const PlansAndBillingTabContent = () => {
       <Separator />
       <div className={"px-8 py-6"}>
         <div className={"max-w-3xl"}>
-          <div className={"flex justify-between"}>
-            <h2>
-              {subscription?.active
-                ? "Update your NetBird Plan"
-                : "Upgrade your NetBird Plan"}
-            </h2>
-            <Select
-              value={currency}
-              onValueChange={setCurrency}
-              disabled={subscription?.active}
-            >
-              <SelectTrigger className="w-[140px]">
-                <div className={"flex items-center gap-3"}>
-                  {currency == Currency.EUR ? (
-                    <EuroIcon size={15} className={"text-nb-gray-300"} />
-                  ) : (
-                    <DollarSignIcon size={15} className={"text-nb-gray-300"} />
-                  )}
-
-                  <SelectValue placeholder="Select currency..." />
-                </div>
-              </SelectTrigger>
-              <SelectContent data-testid={"protocol-selection"}>
-                <SelectItem value="usd">USD</SelectItem>
-                <SelectItem value="eur">EUR</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          <h2>
+            {subscription?.active
+              ? "Update your NetBird Plan"
+              : "Upgrade your NetBird Plan"}
+          </h2>
 
           <Paragraph>
             Increase your user and peer limit by upgrading your plan.

--- a/src/utils/billing.ts
+++ b/src/utils/billing.ts
@@ -1,0 +1,8 @@
+import { Currency } from "@/interfaces/Plan";
+import { Subscription } from "@/interfaces/Subscription";
+
+export function resolveActiveCurrency(subscription?: Subscription): Currency {
+  return subscription?.active && subscription?.currency
+    ? subscription.currency
+    : Currency.EUR;
+}

--- a/src/utils/billing.ts
+++ b/src/utils/billing.ts
@@ -1,8 +1,0 @@
-import { Currency } from "@/interfaces/Plan";
-import { Subscription } from "@/interfaces/Subscription";
-
-export function resolveActiveCurrency(subscription?: Subscription): Currency {
-  return subscription?.active && subscription?.currency
-    ? subscription.currency
-    : Currency.EUR;
-}


### PR DESCRIPTION
## Summary

Removes the USD/EUR currency selector from Settings → Plans & Billing and makes EUR the default currency across the dashboard, while keeping pricing accurate for customers already billed in USD.

- **No active subscription** (new signup, free tier, expired trial): currency resolves to EUR everywhere. No currency choice is offered.
- **Active subscription**: the subscription's real currency is used, so existing USD subscribers keep seeing correct `$` pricing until they change plans.
- New shared helper `resolveActiveCurrency()` (`src/utils/billing.ts`) encodes this rule once and is used by all three resolution sites.

### Bug fixes included

- **MSP / Distributor per-tenant currency**: `useTenantPlan` and `useCustomerPlan` previously derived currency from the *logged-in admin's* account. They now resolve it from each tenant/customer's own subscription, so the MSP Tenants cost column and the assign-a-plan modals show what that tenant is actually billed in.
- **`TenantPlanCostCell`** now reuses the hook's `estimatedPrice` instead of duplicating the calculation with the wrong currency source.
- **AWS Marketplace** plan selection (`AWSChoosePlan.tsx`) is pinned to USD — AWS bills in USD regardless of the dashboard default, so showing EUR list prices there would be misleading.
- Removed the dead `TotalCost` component in `MSPTenantsTable.tsx` (hardcoded `$5,260`, never rendered).

`setCurrency` is dropped from `BillingContext` (nothing calls it once the selector is gone), along with the `initialCurrency` ref that only existed to protect manual selections. The `Currency` enum keeps both values — it's the backend contract and legacy subscriptions still carry `currency: "usd"`.

## Issue ticket number and link

N/A — internal request to move dashboard billing display to EUR.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

UI-only change to currency display/defaults; no user-facing docs describe the currency selector.

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS plan selection now shows pricing in USD.
  * Billing currency is now determined automatically from the active subscription.

* **Bug Fixes**
  * Tenant and plan pricing now stays consistent with the customer’s active subscription currency.
  * Tenant plan cost display is simplified and only shows the estimated price when the tenant is Active.

* **UI Changes**
  * Removed the currency selector from the billing plans screen.
  * Simplified tenant cost and billing header displays.

* **Tests**
  * Updated setup-keys end-to-end assertions around confirmation dialog visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->