### PR TITLE
Revert using tenants own currency and instead use MSP currency

### DIFF
--- a/src/cloud/distributor/hooks/useCustomerPlan.ts
+++ b/src/cloud/distributor/hooks/useCustomerPlan.ts
@@ -3,10 +3,7 @@ import { notify } from "@components/Notification";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useTenantSubscription } from "@/cloud/msp/hooks/useTenantSubscription";
-import {
-  resolveActiveCurrency,
-  useBilling,
-} from "@/contexts/BillingProvider";
+import { useBilling } from "@/contexts/BillingProvider";
 import { AccountUsageStats } from "@/interfaces/AccountUsageStats";
 import { Plan } from "@/interfaces/Plan";
 import { PlanTier } from "@/interfaces/Subscription";
@@ -23,6 +20,7 @@ export const useCustomerPlan = ({ accountId, withUsage = false }: Props) => {
     true,
   );
   const {
+    currency,
     plans,
     isLoading: isBillingLoading,
     getCurrentPlanByPlanTier,
@@ -46,12 +44,6 @@ export const useCustomerPlan = ({ accountId, withUsage = false }: Props) => {
     isTrialExpired,
     isSubscriptionLoading,
   } = useTenantSubscription({ tenantId: accountId });
-
-  // This customer's own billing currency, not the distributor's account currency
-  const currency = useMemo(
-    () => resolveActiveCurrency(subscription),
-    [subscription],
-  );
 
   const teamAndBusinessPlans = plans?.filter(
     (plan) =>

--- a/src/cloud/msp/hooks/useTenantPlan.ts
+++ b/src/cloud/msp/hooks/useTenantPlan.ts
@@ -4,10 +4,7 @@ import { useSWRConfig } from "swr";
 import { useTenants } from "@/cloud/msp/contexts/TenantsProvider";
 import { useTenantSubscription } from "@/cloud/msp/hooks/useTenantSubscription";
 import { Tenant } from "@/cloud/msp/interfaces/Tenant";
-import {
-  resolveActiveCurrency,
-  useBilling,
-} from "@/contexts/BillingProvider";
+import { useBilling } from "@/contexts/BillingProvider";
 import { AccountUsageStats } from "@/interfaces/AccountUsageStats";
 import { Plan } from "@/interfaces/Plan";
 import { PlanTier } from "@/interfaces/Subscription";
@@ -21,6 +18,7 @@ export const useTenantPlan = ({ tenant, withUsage = true }: Props) => {
   const { mutate } = useSWRConfig();
   const { updateSubscription } = useTenants();
   const {
+    currency,
     plans,
     isLoading: isBillingLoading,
     getCurrentPlanByPlanTier,
@@ -44,12 +42,6 @@ export const useTenantPlan = ({ tenant, withUsage = true }: Props) => {
     isTrialExpired,
     isSubscriptionLoading,
   } = useTenantSubscription({ tenantId: tenant.id });
-
-  // This tenant's own billing currency, not the MSP admin's account currency
-  const currency = useMemo(
-    () => resolveActiveCurrency(subscription),
-    [subscription],
-  );
 
   const teamAndBusinessPlans = plans?.filter(
     (plan) =>


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing currency handling so plan and subscription flows now use the active currency directly from billing settings.
  * Reduced mismatches in subscription updates by keeping currency selection consistent across customer and tenant plan screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->