### PR TITLE
Remove experimental flag from lazy connections

### DIFF
--- a/src/modules/settings/ClientSettingsTab.tsx
+++ b/src/modules/settings/ClientSettingsTab.tsx
@@ -20,7 +20,6 @@ import {
   AlertTriangle,
   ClockFadingIcon,
   ExternalLinkIcon,
-  FlaskConicalIcon,
   MonitorSmartphoneIcon,
   RefreshCcw,
 } from "lucide-react";
@@ -372,14 +371,14 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
 
           <div>
             <Label>
-              <FlaskConicalIcon size={15} />
-              Experimental
+              <ClockFadingIcon size={15} />
+              Lazy Connections
             </Label>
 
             <HelpText>
-              Lazy connections are an experimental feature. Functionality and
-              behavior may evolve. Instead of maintaining always-on connections,
-              NetBird activates them on-demand based on activity or signaling.{" "}
+              Instead of maintaining always-on connections, NetBird activates
+              them on-demand based on activity or signaling. This requires
+              NetBird client v0.50.1 or higher.{" "}
               <InlineLink
                 href={"https://docs.netbird.io/how-to/lazy-connection"}
                 target={"_blank"}
@@ -393,17 +392,12 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
               value={lazyConnection}
               onChange={toggleLazyConnection}
               data-testid="lazy-connections"
-              label={
-                <>
-                  <ClockFadingIcon size={15} />
-                  Enable Lazy Connections
-                </>
-              }
+              label={<>Enable Lazy Connections</>}
               helpText={
                 <>
                   Allow to establish connections between peers only when
-                  required. This requires NetBird client v0.45 or higher.
-                  Changes will only take effect after restarting the clients.
+                  required. Changes will take effect after restarting the
+                  clients.
                 </>
               }
               disabled={!permission.settings.update}


### PR DESCRIPTION
## Issue ticket number and link
<img width="732" height="221" alt="CleanShot 2026-07-09 at 17 29 17" src="https://github.com/user-attachments/assets/17073085-f15f-49f8-869c-5a1f40e2da44" />

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/842

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Lazy Connections settings section with a clearer label and refreshed icon.
  * Revised the help text to remove “experimental” wording and reflect the current minimum client version requirement.
  * Simplified the toggle presentation so the icon no longer appears inside the switch label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->