### PR TITLE
[reverse proxy] Feature/cluster one click deploy

### DIFF
--- a/.github/workflows/sync-deploy-templates.yml
+++ b/.github/workflows/sync-deploy-templates.yml
@@ -2,7 +2,8 @@ name: Sync deploy templates to S3
 
 on:
   push:
-    branches: [main]
+    # TODO: remove feature/cluster-one-click-deploy before merging - dev only.
+    branches: [main, feature/cluster-one-click-deploy]
     paths:
       - "templates/reverse-proxy/**"
 

--- a/.github/workflows/sync-deploy-templates.yml
+++ b/.github/workflows/sync-deploy-templates.yml
@@ -1,0 +1,32 @@
+name: Sync deploy templates to S3
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "templates/reverse-proxy/**"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DEPLOY_TEMPLATES_ROLE_ARN }}
+          aws-region: eu-central-1
+
+      - name: Validate CloudFormation template
+        run: |
+          aws cloudformation validate-template \
+            --template-body file://templates/reverse-proxy/netbird-proxy-cfn.yaml
+
+      - name: Upload CloudFormation template
+        run: |
+          aws s3 cp templates/reverse-proxy/netbird-proxy-cfn.yaml \
+            s3://netbird-deploy-templates/templates/netbird-proxy-cfn.yaml

--- a/.github/workflows/sync-deploy-templates.yml
+++ b/.github/workflows/sync-deploy-templates.yml
@@ -2,8 +2,7 @@ name: Sync deploy templates to S3
 
 on:
   push:
-    # TODO: remove feature/cluster-one-click-deploy before merging - dev only.
-    branches: [main, feature/cluster-one-click-deploy]
+    branches: [main]
     paths:
       - "templates/reverse-proxy/**"
 

--- a/.github/workflows/sync-deploy-templates.yml
+++ b/.github/workflows/sync-deploy-templates.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/test-cloud-deploy.yml
+++ b/.github/workflows/test-cloud-deploy.yml
@@ -76,4 +76,11 @@ jobs:
           URL=$(grep -o 'https://[^"]*netbird-proxy-cfn\.yaml' src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx)
           echo "CFN_TEMPLATE_URL: $URL"
           test -n "$URL"
-          curl -sfI "$URL"
+          # Non-blocking: the template is published by sync-deploy-templates on
+          # the default branch, so it may not exist yet for a PR that only edits
+          # the URL. Warn instead of failing the check.
+          if curl -sfI "$URL" >/dev/null; then
+            echo "OK: template URL is live"
+          else
+            echo "::warning::CloudFormation template URL is not reachable yet: $URL"
+          fi

--- a/.github/workflows/test-cloud-deploy.yml
+++ b/.github/workflows/test-cloud-deploy.yml
@@ -7,14 +7,6 @@ on:
       - "templates/reverse-proxy/**"
       - "src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx"
       - ".github/workflows/test-cloud-deploy.yml"
-  push:
-    # TODO: remove feature/cluster-one-click-deploy before merging - dev only.
-    branches: [feature/cluster-one-click-deploy]
-    paths:
-      - "docker/init_react_envs.sh"
-      - "templates/reverse-proxy/**"
-      - "src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx"
-      - ".github/workflows/test-cloud-deploy.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test-cloud-deploy.yml
+++ b/.github/workflows/test-cloud-deploy.yml
@@ -1,0 +1,79 @@
+name: Test cloud deploy config
+
+on:
+  pull_request:
+    paths:
+      - "docker/init_react_envs.sh"
+      - "templates/reverse-proxy/**"
+      - "src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx"
+      - ".github/workflows/test-cloud-deploy.yml"
+  push:
+    # TODO: remove feature/cluster-one-click-deploy before merging - dev only.
+    branches: [feature/cluster-one-click-deploy]
+    paths:
+      - "docker/init_react_envs.sh"
+      - "templates/reverse-proxy/**"
+      - "src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx"
+      - ".github/workflows/test-cloud-deploy.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  csp-connect-src:
+    name: CSP allows cloud provider APIs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nginx
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nginx gettext-base
+
+      - name: Prepare nginx layout expected by the init script
+        run: |
+          sudo mkdir -p /etc/nginx/http.d /usr/share/nginx/html
+          echo 'add_header Content-Security-Policy "placeholder" always;' | sudo tee /etc/nginx/http.d/default.conf
+          sudo touch /usr/share/nginx/html/OidcTrustedDomains.js.tmpl
+          sudo systemctl start nginx
+
+      - name: Run init script with production-like env
+        env:
+          AUTH_AUTHORITY: https://auth.example.com
+          AUTH_CLIENT_ID: test-client
+          AUTH_AUDIENCE: test-audience
+          AUTH_SUPPORTED_SCOPES: openid profile email
+          USE_AUTH0: "false"
+          NETBIRD_MGMT_API_ENDPOINT: https://api.example.com
+        run: sudo -E bash docker/init_react_envs.sh
+
+      - name: Assert provider APIs are in connect-src
+        run: |
+          CSP=$(grep -o 'Content-Security-Policy "[^"]*"' /etc/nginx/http.d/default.conf)
+          echo "Generated CSP: $CSP"
+          CONNECT_SRC=$(echo "$CSP" | sed 's/.*connect-src \([^;]*\);.*/\1/')
+          echo "connect-src: $CONNECT_SRC"
+          status=0
+          for origin in https://api.hetzner.cloud https://api.digitalocean.com; do
+            if echo "$CONNECT_SRC" | grep -qF "$origin"; then
+              echo "OK: $origin"
+            else
+              echo "MISSING in connect-src: $origin"
+              status=1
+            fi
+          done
+          exit $status
+
+  cfn-template-url:
+    name: CloudFormation template URL is live
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract template URL from component and check it
+        run: |
+          URL=$(grep -o 'https://[^"]*netbird-proxy-cfn\.yaml' src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx)
+          echo "CFN_TEMPLATE_URL: $URL"
+          test -n "$URL"
+          curl -sfI "$URL"

--- a/docker/init_react_envs.sh
+++ b/docker/init_react_envs.sh
@@ -80,7 +80,7 @@ echo "NetBird latest version: ${NETBIRD_LATEST_VERSION}"
 FIRST_PARTY_CSP="pkgs.netbird.io"
 FIRST_PARTY_CSP_CONNECT_SRC="wss://*.netbird.io"
 THIRD_PARTY_CSP="*.licdn.com *.linkedin.com *.vector.co *.sibforms.com *.hotjar.com *.hotjar.io *.redditstatic.com pixel-config.reddit.com *.clarity.ms c.bing.com *.microsoft.com googleads.g.doubleclick.net pagead2.googlesyndication.com www.google.com www.googleadservices.com *.google-analytics.com *.googletagmanager.com analytics.google.com *.hubapi.com *.hs-banner.com *.hubspot.com *.hubspot.net js.hs-analytics.com *.hsforms.net *.hscollectedforms.net *.hs-analytics.net *.hsforms.com track.hubspot.com *.hsadspixel.net static.hsappstatic.net"
-THIRD_PARTY_CSP_CONNECT_SRC="https://api.github.com/repos/netbirdio/netbird/releases/latest https://raw.githubusercontent.com/netbirdio/dashboard/ wss://ws.hotjar.com"
+THIRD_PARTY_CSP_CONNECT_SRC="https://api.github.com/repos/netbirdio/netbird/releases/latest https://raw.githubusercontent.com/netbirdio/dashboard/ wss://ws.hotjar.com https://api.hetzner.cloud https://api.digitalocean.com"
 THIRD_PARTY_CSP_SCRIPT_SRC="'sha256-7knV6EIjKUvCpYWE2rCYx8dYV2WCNb2bpTuitFXzBcA=' *.hs-scripts.com"
 
 CSP_DOMAINS=""

--- a/src/app/(dashboard)/reverse-proxy/clusters/page.tsx
+++ b/src/app/(dashboard)/reverse-proxy/clusters/page.tsx
@@ -40,9 +40,9 @@ export default function ReverseProxyClustersPage() {
         </Breadcrumbs>
         <h1 ref={headingRef}>Clusters</h1>
         <Paragraph>
-          Proxy clusters that route inbound traffic to your services. Shared
-          clusters are deployed at the server level; account clusters are
-          self-hosted on your own infrastructure.{" "}
+          Proxy clusters route inbound traffic to your services. Shared clusters
+          are run by the platform; account clusters (self-hosted) run on your
+          own infrastructure.{" "}
           <InlineLink href={REVERSE_PROXY_CLUSTERS_DOCS_LINK} target={"_blank"}>
             Learn more
             <ExternalLinkIcon size={12} />

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -459,10 +459,11 @@ const HetznerDeploy = ({
 
   const deploy = async () => {
     setIsDeploying(true);
+    const apiToken = hetznerToken.trim();
     const promise = fetch("https://api.hetzner.cloud/v1/servers", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${hetznerToken}`,
+        Authorization: `Bearer ${apiToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -489,7 +490,7 @@ const HetznerDeploy = ({
             {
               method: "PUT",
               headers: {
-                Authorization: `Bearer ${hetznerToken.trim()}`,
+                Authorization: `Bearer ${apiToken}`,
                 "Content-Type": "application/json",
               },
               body: JSON.stringify({ auto_delete: false }),

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -142,6 +142,7 @@ type HetznerCatalog = {
   locations: { name: string; label: string }[];
   availableTypeIds: Record<string, number[]>;
   serverTypes: HetznerServerType[];
+  sshKeys: { id: number; name: string }[];
 };
 
 // fetchHetznerCatalog loads the current locations, server types, and
@@ -149,9 +150,10 @@ type HetznerCatalog = {
 // server types, so the dropdowns always offer valid combinations.
 const fetchHetznerCatalog = async (token: string): Promise<HetznerCatalog> => {
   const headers = { Authorization: `Bearer ${token}` };
-  const [typesRes, dcsRes] = await Promise.all([
+  const [typesRes, dcsRes, keysRes] = await Promise.all([
     fetch("https://api.hetzner.cloud/v1/server_types?per_page=50", { headers }),
     fetch("https://api.hetzner.cloud/v1/datacenters?per_page=50", { headers }),
+    fetch("https://api.hetzner.cloud/v1/ssh_keys?per_page=50", { headers }),
   ]);
   const typesBody = await typesRes.json().catch(() => null);
   if (!typesRes.ok) {
@@ -164,6 +166,12 @@ const fetchHetznerCatalog = async (token: string): Promise<HetznerCatalog> => {
   if (!dcsRes.ok) {
     throw new Error(
       dcsBody?.error?.message ?? `Hetzner API error (HTTP ${dcsRes.status})`,
+    );
+  }
+  const keysBody = await keysRes.json().catch(() => null);
+  if (!keysRes.ok) {
+    throw new Error(
+      keysBody?.error?.message ?? `Hetzner API error (HTTP ${keysRes.status})`,
     );
   }
 
@@ -195,7 +203,11 @@ const fetchHetznerCatalog = async (token: string): Promise<HetznerCatalog> => {
     .map(([name, label]) => ({ name, label }))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  return { locations, availableTypeIds, serverTypes };
+  const sshKeys = (
+    (keysBody?.ssh_keys ?? []) as { id: number; name: string }[]
+  ).map((k) => ({ id: k.id, name: k.name }));
+
+  return { locations, availableTypeIds, serverTypes, sshKeys };
 };
 
 type DeploySuccessProps = {
@@ -208,18 +220,9 @@ type DeploySuccessProps = {
   children?: React.ReactNode;
 };
 
-// DeploySuccess shows the deployment result: the DNS records to create for
-// the new instance IP and a live check that the proxy registered with the
-// NetBird management service.
-const DeploySuccess = ({
-  resourceLabel,
-  name,
-  ip,
-  isStaticIP,
-  domain,
-  ipPendingNote,
-  children,
-}: DeploySuccessProps) => {
+// RegistrationCheck polls the management API until the cluster for the given
+// domain reports a connected proxy.
+const RegistrationCheck = ({ domain }: { domain: string }) => {
   const clustersRequest = useApiCall<ReverseProxyCluster[]>(
     "/reverse-proxies/clusters",
     true,
@@ -251,6 +254,41 @@ const DeploySuccess = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [registered, domain]);
 
+  return (
+    <div className={"flex items-center gap-2 text-sm"}>
+      {registered ? (
+        <>
+          <CheckCircle2 size={16} className={"text-green-500 shrink-0"} />
+          <span className={"text-nb-gray-100"}>
+            Proxy registered with NetBird and connected.
+          </span>
+        </>
+      ) : (
+        <>
+          <Loader2 size={16} className={"animate-spin shrink-0"} />
+          <span className={"text-nb-gray-300"}>
+            Waiting for the proxy to register with NetBird. The instance still
+            installs Docker and starts the proxy after its IP appears - this
+            usually takes another minute or two...
+          </span>
+        </>
+      )}
+    </div>
+  );
+};
+
+// DeploySuccess shows the deployment result: the DNS records to create for
+// the new instance IP and a live check that the proxy registered with the
+// NetBird management service.
+const DeploySuccess = ({
+  resourceLabel,
+  name,
+  ip,
+  isStaticIP,
+  domain,
+  ipPendingNote,
+  children,
+}: DeploySuccessProps) => {
   return (
     <div className={"flex flex-col gap-4"}>
       <Callout variant={"info"}>
@@ -304,25 +342,7 @@ const DeploySuccess = ({
           </CardTable>
         </div>
       )}
-      <div className={"flex items-center gap-2 text-sm"}>
-        {registered ? (
-          <>
-            <CheckCircle2 size={16} className={"text-green-500 shrink-0"} />
-            <span className={"text-nb-gray-100"}>
-              Proxy registered with NetBird and connected.
-            </span>
-          </>
-        ) : (
-          <>
-            <Loader2 size={16} className={"animate-spin shrink-0"} />
-            <span className={"text-nb-gray-300"}>
-              Waiting for the proxy to register with NetBird. The instance still
-              installs Docker and starts the proxy after its IP appears - this
-              usually takes another minute or two...
-            </span>
-          </>
-        )}
-      </div>
+      <RegistrationCheck domain={domain} />
       {children}
     </div>
   );
@@ -334,13 +354,13 @@ const HetznerDeploy = ({
   managementUrl,
   isGeneratingToken,
 }: ProviderProps) => {
-  const [rootPassword] = useState(generateRootPassword);
   const [hetznerToken, setHetznerToken] = useState("");
   const [catalog, setCatalog] = useState<HetznerCatalog | null>(null);
   const [catalogError, setCatalogError] = useState("");
   const [isLoadingCatalog, setIsLoadingCatalog] = useState(false);
   const [location, setLocation] = useState("");
   const [serverType, setServerType] = useState("");
+  const [sshKeyId, setSshKeyId] = useState("");
   const [staticIP, setStaticIP] = useState(true);
   const [isDeploying, setIsDeploying] = useState(false);
   const [serverIP, setServerIP] = useState("");
@@ -411,6 +431,13 @@ const HetznerDeploy = ({
     }
   }, [catalog, location, serverTypeOptions, serverType]);
 
+  useEffect(() => {
+    if (!catalog) return;
+    if (!catalog.sshKeys.some((k) => String(k.id) === sshKeyId)) {
+      setSshKeyId(catalog.sshKeys[0] ? String(catalog.sshKeys[0].id) : "");
+    }
+  }, [catalog, sshKeyId]);
+
   const deploy = async () => {
     setIsDeploying(true);
     const promise = fetch("https://api.hetzner.cloud/v1/servers", {
@@ -424,7 +451,8 @@ const HetznerDeploy = ({
         server_type: serverType,
         image: "ubuntu-24.04",
         location,
-        user_data: buildCloudInit(domain, token, managementUrl, rootPassword),
+        ssh_keys: sshKeyId ? [Number(sshKeyId)] : [],
+        user_data: buildCloudInit(domain, token, managementUrl),
       }),
     })
       .then(async (res) => {
@@ -478,19 +506,7 @@ const HetznerDeploy = ({
         ip={serverIP}
         isStaticIP={staticIP}
         domain={domain}
-      >
-        <div>
-          <Label>Server Root Password</Label>
-          <HelpText>
-            Use it with the server console in the Hetzner Cloud Console (SSH
-            password login stays disabled). Copy it now - it is not stored
-            anywhere.
-          </HelpText>
-          <Code codeToCopy={rootPassword}>
-            <Code.Line>{rootPassword}</Code.Line>
-          </Code>
-        </div>
-      </DeploySuccess>
+      />
     );
   }
 
@@ -536,6 +552,24 @@ const HetznerDeploy = ({
                 options={serverTypeOptions}
               />
             </div>
+          </div>
+          <div>
+            <Label>SSH Key</Label>
+            {catalog.sshKeys.length > 0 ? (
+              <SelectDropdown
+                value={sshKeyId}
+                onChange={(v) => setSshKeyId(v as string)}
+                options={catalog.sshKeys.map((k) => ({
+                  value: String(k.id),
+                  label: k.name,
+                }))}
+              />
+            ) : (
+              <HelpText className={"mb-0"}>
+                No SSH keys found in this Hetzner project. Add one in the
+                Hetzner Console first if you need SSH access to the server.
+              </HelpText>
+            )}
           </div>
           <FancyToggleSwitch
             value={staticIP}
@@ -782,6 +816,7 @@ const AWSDeploy = ({
   isGeneratingToken,
 }: ProviderProps) => {
   const [region, setRegion] = useState("eu-central-1");
+  const [launched, setLaunched] = useState(false);
 
   const launchUrl = useMemo(() => {
     const params = new URLSearchParams({
@@ -818,7 +853,10 @@ const AWSDeploy = ({
       <Button
         variant={"primary"}
         disabled={isGeneratingToken || !token}
-        onClick={() => window.open(launchUrl, "_blank", "noopener,noreferrer")}
+        onClick={() => {
+          window.open(launchUrl, "_blank", "noopener,noreferrer");
+          setLaunched(true);
+        }}
       >
         <RocketIcon size={16} />
         Launch Stack in AWS Console
@@ -829,6 +867,7 @@ const AWSDeploy = ({
         token, review, and create the stack. Point the DNS records from the
         previous step to the PublicIP stack output afterwards.
       </HelpText>
+      {launched && <RegistrationCheck domain={domain} />}
     </div>
   );
 };

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -107,6 +107,11 @@ chpasswd:
         reverse-proxy:
           image: netbirdio/reverse-proxy:latest
           restart: unless-stopped
+          logging:
+            driver: json-file
+            options:
+              max-size: "500m"
+              max-file: "2"
           ports:
             - "80:80"
             - "443:443"

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -9,10 +9,10 @@ import { SelectDropdown } from "@components/select/SelectDropdown";
 import { ExternalLinkIcon, Loader2, RocketIcon } from "lucide-react";
 import React, { useMemo, useState } from "react";
 
-// TODO(PoC): replace with the final public S3 location of
-// templates/reverse-proxy/netbird-proxy-cfn.yaml from this repository.
+// Synced from templates/reverse-proxy/netbird-proxy-cfn.yaml by the
+// sync-deploy-templates workflow.
 const CFN_TEMPLATE_URL =
-  "https://netbird-deploy-templates.s3.amazonaws.com/netbird-proxy-cfn.yaml";
+  "https://netbird-deploy-templates.s3.eu-central-1.amazonaws.com/templates/netbird-proxy-cfn.yaml";
 
 const DEFAULT_WIREGUARD_PORT = 51820;
 

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -1,5 +1,6 @@
 import Button from "@components/Button";
 import { Callout } from "@components/Callout";
+import CardTable from "@components/CardTable";
 import Code from "@components/Code";
 import FancyToggleSwitch from "@components/FancyToggleSwitch";
 import HelpText from "@components/HelpText";
@@ -7,8 +8,15 @@ import { Input } from "@components/Input";
 import { Label } from "@components/Label";
 import { notify } from "@components/Notification";
 import { SelectDropdown } from "@components/select/SelectDropdown";
-import { ExternalLinkIcon, Loader2, RocketIcon } from "lucide-react";
+import {
+  CheckCircle2,
+  ExternalLinkIcon,
+  Loader2,
+  RocketIcon,
+} from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
+import { useApiCall } from "@/utils/api";
+import { ReverseProxyCluster } from "@/interfaces/ReverseProxy";
 
 // Synced from templates/reverse-proxy/netbird-proxy-cfn.yaml by the
 // sync-deploy-templates workflow.
@@ -79,7 +87,7 @@ chpasswd:
 `
     : ""
 }write_files:
-  - path: /etc/netbird-proxy/env
+  - path: /opt/netbird-proxy/env
     permissions: "0600"
     content: |
       NB_PROXY_TOKEN=${token}
@@ -92,15 +100,26 @@ chpasswd:
       NB_PROXY_LOG_LEVEL=info
       NB_PROXY_ADDRESS=:443
       NB_PROXY_WG_PORT=${DEFAULT_WIREGUARD_PORT}
+  - path: /opt/netbird-proxy/docker-compose.yml
+    permissions: "0644"
+    content: |
+      services:
+        reverse-proxy:
+          image: netbirdio/reverse-proxy:latest
+          restart: unless-stopped
+          ports:
+            - "80:80"
+            - "443:443"
+            - "${DEFAULT_WIREGUARD_PORT}:${DEFAULT_WIREGUARD_PORT}/udp"
+          env_file:
+            - /opt/netbird-proxy/env
+          volumes:
+            - proxy_certs:/certs
+      volumes:
+        proxy_certs:
 runcmd:
   - curl -fsSL https://get.docker.com | sh
-  - >-
-    docker run -d --name netbird-proxy --restart unless-stopped
-    -p 443:443 -p 80:80
-    -p ${DEFAULT_WIREGUARD_PORT}:${DEFAULT_WIREGUARD_PORT}/udp
-    --env-file /etc/netbird-proxy/env
-    -v proxy_certs:/certs
-    netbirdio/reverse-proxy:latest
+  - docker compose -f /opt/netbird-proxy/docker-compose.yml up -d
 `;
 
 export const ClusterCloudDeploy = ({ provider, ...props }: Props) => {
@@ -177,6 +196,133 @@ const fetchHetznerCatalog = async (token: string): Promise<HetznerCatalog> => {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return { locations, availableTypeIds, serverTypes };
+};
+
+type DeploySuccessProps = {
+  resourceLabel: string;
+  name: string;
+  ip: string;
+  isStaticIP: boolean;
+  domain: string;
+  ipPendingNote?: string;
+  children?: React.ReactNode;
+};
+
+// DeploySuccess shows the deployment result: the DNS records to create for
+// the new instance IP and a live check that the proxy registered with the
+// NetBird management service.
+const DeploySuccess = ({
+  resourceLabel,
+  name,
+  ip,
+  isStaticIP,
+  domain,
+  ipPendingNote,
+  children,
+}: DeploySuccessProps) => {
+  const clustersRequest = useApiCall<ReverseProxyCluster[]>(
+    "/reverse-proxies/clusters",
+    true,
+  );
+  const [registered, setRegistered] = useState(false);
+
+  useEffect(() => {
+    if (registered) return;
+    let attempts = 0;
+    const timer = setInterval(() => {
+      attempts += 1;
+      if (attempts > 120) {
+        clearInterval(timer);
+        return;
+      }
+      clustersRequest
+        .get()
+        .then((clusters) => {
+          const cluster = clusters?.find((c) => c.address === domain);
+          if (cluster?.online && cluster.connected_proxies > 0) {
+            setRegistered(true);
+          }
+        })
+        .catch(() => {
+          // Polling failures are retried on the next tick.
+        });
+    }, 5000);
+    return () => clearInterval(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [registered, domain]);
+
+  return (
+    <div className={"flex flex-col gap-4"}>
+      <Callout variant={"info"}>
+        {resourceLabel} <span className={"text-white font-medium"}>{name}</span>{" "}
+        was created
+        {ip ? (
+          <>
+            {" "}
+            with {isStaticIP ? "static IP" : "IP"}{" "}
+            <span className={"text-netbird font-medium"}>{ip}</span>.
+          </>
+        ) : (
+          <> {ipPendingNote}</>
+        )}
+      </Callout>
+      {ip && (
+        <div>
+          <Label>Update your DNS records</Label>
+          <HelpText>
+            Point these records at the new {resourceLabel.toLowerCase()}. The
+            proxy requests its certificate once they resolve.
+          </HelpText>
+          <CardTable>
+            <CardTable.Header>
+              <CardTable.HeaderCell width={100}>Type</CardTable.HeaderCell>
+              <CardTable.HeaderCell>Name</CardTable.HeaderCell>
+              <CardTable.HeaderCell>Content</CardTable.HeaderCell>
+            </CardTable.Header>
+            <CardTable.Body>
+              <CardTable.Row>
+                <CardTable.Cell>A</CardTable.Cell>
+                <CardTable.Cell copy copyText={domain}>
+                  {domain}
+                </CardTable.Cell>
+                <CardTable.Cell copy copyText={ip}>
+                  {ip}
+                </CardTable.Cell>
+              </CardTable.Row>
+              <CardTable.Row>
+                <CardTable.Cell>CNAME</CardTable.Cell>
+                <CardTable.Cell copy copyText={`*.${domain}`}>
+                  {`*.${domain}`}
+                </CardTable.Cell>
+                <CardTable.Cell copy copyText={domain}>
+                  {domain}
+                </CardTable.Cell>
+              </CardTable.Row>
+            </CardTable.Body>
+          </CardTable>
+        </div>
+      )}
+      <div className={"flex items-center gap-2 text-sm"}>
+        {registered ? (
+          <>
+            <CheckCircle2 size={16} className={"text-green-500 shrink-0"} />
+            <span className={"text-nb-gray-100"}>
+              Proxy registered with NetBird and connected.
+            </span>
+          </>
+        ) : (
+          <>
+            <Loader2 size={16} className={"animate-spin shrink-0"} />
+            <span className={"text-nb-gray-300"}>
+              Waiting for the proxy to register with NetBird - this takes a few
+              minutes while the instance installs Docker and starts the proxy...
+            </span>
+          </>
+        )}
+      </div>
+      {children}
+    </div>
+  );
 };
 
 const HetznerDeploy = ({
@@ -322,13 +468,13 @@ const HetznerDeploy = ({
 
   if (serverIP) {
     return (
-      <Callout variant={"info"}>
-        Server <span className={"text-white font-medium"}>{serverName}</span>{" "}
-        was created with IP{" "}
-        <span className={"text-netbird font-medium"}>{serverIP}</span>. Update
-        the DNS records from the previous step to point to this IP. The proxy
-        will request its certificate and connect within a minute or two.
-      </Callout>
+      <DeploySuccess
+        resourceLabel={"Server"}
+        name={serverName}
+        ip={serverIP}
+        isStaticIP={staticIP}
+        domain={domain}
+      />
     );
   }
 
@@ -526,32 +672,18 @@ const DigitalOceanDeploy = ({
 
   if (isCreated) {
     return (
-      <div className={"flex flex-col gap-4"}>
-        <Callout variant={"info"}>
-          Droplet{" "}
-          <span className={"text-white font-medium"}>{dropletName}</span> was
-          created
-          {reservedIP || dropletIP ? (
-            <>
-              {" "}
-              with {reservedIP ? "static IP" : "IP"}{" "}
-              <span className={"text-netbird font-medium"}>
-                {reservedIP || dropletIP}
-              </span>
-              . Update the DNS records from the previous step to point to this
-              IP. The proxy will request its certificate and connect within a
-              minute or two.
-            </>
-          ) : (
-            <>
-              {" "}
-              and is provisioning. Waiting for its public IP
-              {isDeploying
-                ? "..."
-                : " timed out - find the IP in the DigitalOcean control panel and update the DNS records from the previous step."}
-            </>
-          )}
-        </Callout>
+      <DeploySuccess
+        resourceLabel={"Droplet"}
+        name={dropletName}
+        ip={reservedIP || dropletIP}
+        isStaticIP={!!reservedIP}
+        domain={domain}
+        ipPendingNote={
+          isDeploying
+            ? "and is provisioning. Waiting for its public IP..."
+            : "but waiting for its public IP timed out - find the IP in the DigitalOcean control panel."
+        }
+      >
         <div>
           <Label>Droplet Root Password</Label>
           <HelpText>
@@ -563,7 +695,7 @@ const DigitalOceanDeploy = ({
             <Code.Line>{rootPassword}</Code.Line>
           </Code>
         </div>
-      </div>
+      </DeploySuccess>
     );
   }
 

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -5,6 +5,7 @@ import Code from "@components/Code";
 import FancyToggleSwitch from "@components/FancyToggleSwitch";
 import HelpText from "@components/HelpText";
 import { HelpTooltip } from "@components/HelpTooltip";
+import InlineLink from "@components/InlineLink";
 import { Input } from "@components/Input";
 import { Label } from "@components/Label";
 import { notify } from "@components/Notification";
@@ -273,9 +274,7 @@ const RegistrationCheck = ({ domain }: { domain: string }) => {
         <>
           <Loader2 size={16} className={"animate-spin shrink-0"} />
           <span className={"text-nb-gray-300"}>
-            Waiting for the proxy to register with NetBird. The instance still
-            installs Docker and starts the proxy after its IP appears - this
-            usually takes another minute or two...
+            Waiting for the proxy to register with NetBird...
           </span>
         </>
       )}
@@ -304,9 +303,8 @@ const DeploySuccess = ({
           <>
             {" "}
             with {isStaticIP ? "static IP" : "IP"}{" "}
-            <span className={"text-netbird font-medium"}>{ip}</span>. It keeps
-            bootstrapping in the background - create the DNS records below in
-            the meantime.
+            <span className={"text-netbird font-medium"}>{ip}</span> and is still
+            bootstrapping. Meanwhile, add the DNS records below.
           </>
         ) : (
           <> {ipPendingNote}</>
@@ -314,10 +312,10 @@ const DeploySuccess = ({
       </Callout>
       {ip && (
         <div>
-          <Label>Update your DNS records</Label>
+          <Label>Create DNS Records</Label>
           <HelpText>
             Point these records at the new {resourceLabel.toLowerCase()}. The
-            proxy requests its certificate once they resolve.
+            proxy gets its certificate once they resolve.
           </HelpText>
           <CardTable>
             <CardTable.Header>
@@ -348,8 +346,8 @@ const DeploySuccess = ({
           </CardTable>
         </div>
       )}
-      <RegistrationCheck domain={domain} />
       {children}
+      <RegistrationCheck domain={domain} />
     </div>
   );
 };
@@ -519,14 +517,16 @@ const HetznerDeploy = ({
   return (
     <div className={"flex flex-col gap-4"}>
       <div>
-        <Label>Hetzner API Token</Label>
-        <HelpText>
-          Create a read &amp; write API token. It is never stored by NetBird{" "}
+        <Label>
+          Hetzner API Token
           <HelpTooltip
             content={
-              "The token is sent directly from your browser to the Hetzner API. It never reaches NetBird's servers."
+              "The token is sent directly from your browser to the Hetzner API and never reaches NetBird's servers."
             }
           />
+        </Label>
+        <HelpText>
+          Create a read &amp; write API token. It is never stored by NetBird.
         </HelpText>
         <Input
           type={"password"}
@@ -746,8 +746,7 @@ const DigitalOceanDeploy = ({
         <div>
           <Label>Droplet Root Password</Label>
           <HelpText>
-            Use it with the Droplet Console in the DigitalOcean control panel
-            (SSH password login stays disabled). Copy it now - it is not stored
+            Use it with the Droplet Web Console. Copy it now - it is not stored
             anywhere.
           </HelpText>
           <Code codeToCopy={rootPassword}>
@@ -761,14 +760,33 @@ const DigitalOceanDeploy = ({
   return (
     <div className={"flex flex-col gap-4"}>
       <div>
-        <Label>DigitalOcean API Token</Label>
-        <HelpText>
-          Create a token with write access. It is never stored by NetBird{" "}
+        <Label>
+          DigitalOcean API Token
           <HelpTooltip
+            interactive={true}
             content={
-              "The token is sent directly from your browser to the DigitalOcean API. It never reaches NetBird's servers."
+              <>
+                For the tightest scope, grant full access to{" "}
+                <span className={"font-mono text-netbird"}>tag</span>,{" "}
+                <span className={"font-mono text-netbird"}>droplet</span>, and{" "}
+                <span className={"font-mono text-netbird"}>reserved_ip</span>{" "}
+                only. The token goes straight from your browser to DigitalOcean
+                and never touches NetBird&apos;s servers, and you can delete it
+                once setup succeeds.{" "}
+                <InlineLink
+                  href={
+                    "https://docs.digitalocean.com/reference/api/create-personal-access-token/"
+                  }
+                  target={"_blank"}
+                >
+                  How to create a token
+                </InlineLink>
+              </>
             }
           />
+        </Label>
+        <HelpText>
+          Create a token with write access. It is never stored by NetBird.
         </HelpText>
         <Input
           type={"password"}
@@ -802,7 +820,7 @@ const DigitalOceanDeploy = ({
         onChange={setStaticIP}
         label={"Static IP"}
         helpText={
-          "Reserve a static IP so DNS records remain valid after rebuilds. Free while assigned to a Droplet."
+          "Reserve a static IP so DNS records remain valid after rebuilds. Free of charge while assigned to a Droplet."
         }
       />
       <Button

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -1,13 +1,14 @@
 import Button from "@components/Button";
 import { Callout } from "@components/Callout";
 import Code from "@components/Code";
+import FancyToggleSwitch from "@components/FancyToggleSwitch";
 import HelpText from "@components/HelpText";
 import { Input } from "@components/Input";
 import { Label } from "@components/Label";
 import { notify } from "@components/Notification";
 import { SelectDropdown } from "@components/select/SelectDropdown";
 import { ExternalLinkIcon, Loader2, RocketIcon } from "lucide-react";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 // Synced from templates/reverse-proxy/netbird-proxy-cfn.yaml by the
 // sync-deploy-templates workflow.
@@ -15,22 +16,6 @@ const CFN_TEMPLATE_URL =
   "https://netbird-deploy-templates.s3.eu-central-1.amazonaws.com/templates/netbird-proxy-cfn.yaml";
 
 const DEFAULT_WIREGUARD_PORT = 51820;
-
-const HETZNER_LOCATIONS = [
-  { value: "nbg1", label: "Nuremberg, Germany (nbg1)" },
-  { value: "fsn1", label: "Falkenstein, Germany (fsn1)" },
-  { value: "hel1", label: "Helsinki, Finland (hel1)" },
-  { value: "ash", label: "Ashburn, VA, USA (ash)" },
-  { value: "hil", label: "Hillsboro, OR, USA (hil)" },
-  { value: "sin", label: "Singapore (sin)" },
-];
-
-const HETZNER_SERVER_TYPES = [
-  { value: "cx22", label: "CX22 - 2 vCPU / 4 GB (EU locations only)" },
-  { value: "cpx11", label: "CPX11 - 2 vCPU / 2 GB" },
-  { value: "cpx21", label: "CPX21 - 3 vCPU / 4 GB" },
-  { value: "cpx31", label: "CPX31 - 4 vCPU / 8 GB" },
-];
 
 const DIGITALOCEAN_REGIONS = [
   { value: "fra1", label: "Frankfurt, Germany (fra1)" },
@@ -126,6 +111,74 @@ export const ClusterCloudDeploy = ({ provider, ...props }: Props) => {
 
 type ProviderProps = Omit<Props, "provider">;
 
+type HetznerServerType = {
+  id: number;
+  name: string;
+  cores: number;
+  memory: number;
+  deprecated: boolean;
+};
+
+type HetznerCatalog = {
+  locations: { name: string; label: string }[];
+  availableTypeIds: Record<string, number[]>;
+  serverTypes: HetznerServerType[];
+};
+
+// fetchHetznerCatalog loads the current locations, server types, and
+// per-location availability from the Hetzner API, excluding deprecated
+// server types, so the dropdowns always offer valid combinations.
+const fetchHetznerCatalog = async (token: string): Promise<HetznerCatalog> => {
+  const headers = { Authorization: `Bearer ${token}` };
+  const [typesRes, dcsRes] = await Promise.all([
+    fetch("https://api.hetzner.cloud/v1/server_types?per_page=50", { headers }),
+    fetch("https://api.hetzner.cloud/v1/datacenters?per_page=50", { headers }),
+  ]);
+  const typesBody = await typesRes.json().catch(() => null);
+  if (!typesRes.ok) {
+    throw new Error(
+      typesBody?.error?.message ??
+        `Hetzner API error (HTTP ${typesRes.status})`,
+    );
+  }
+  const dcsBody = await dcsRes.json().catch(() => null);
+  if (!dcsRes.ok) {
+    throw new Error(
+      dcsBody?.error?.message ?? `Hetzner API error (HTTP ${dcsRes.status})`,
+    );
+  }
+
+  const serverTypes = ((typesBody?.server_types ?? []) as HetznerServerType[])
+    .filter((t) => !t.deprecated)
+    .sort((a, b) => a.memory - b.memory || a.cores - b.cores);
+
+  type Datacenter = {
+    location?: { name?: string; city?: string; country?: string };
+    server_types?: { available?: number[] };
+  };
+  const locationLabels = new Map<string, string>();
+  const availableTypeIds: Record<string, number[]> = {};
+  for (const dc of (dcsBody?.datacenters ?? []) as Datacenter[]) {
+    const name = dc.location?.name;
+    if (!name) continue;
+    locationLabels.set(
+      name,
+      `${dc.location?.city}, ${dc.location?.country} (${name})`,
+    );
+    const ids = new Set(availableTypeIds[name] ?? []);
+    for (const id of dc.server_types?.available ?? []) {
+      ids.add(id);
+    }
+    availableTypeIds[name] = Array.from(ids);
+  }
+
+  const locations = Array.from(locationLabels.entries())
+    .map(([name, label]) => ({ name, label }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { locations, availableTypeIds, serverTypes };
+};
+
 const HetznerDeploy = ({
   domain,
   token,
@@ -133,8 +186,12 @@ const HetznerDeploy = ({
   isGeneratingToken,
 }: ProviderProps) => {
   const [hetznerToken, setHetznerToken] = useState("");
-  const [location, setLocation] = useState("nbg1");
-  const [serverType, setServerType] = useState("cx22");
+  const [catalog, setCatalog] = useState<HetznerCatalog | null>(null);
+  const [catalogError, setCatalogError] = useState("");
+  const [isLoadingCatalog, setIsLoadingCatalog] = useState(false);
+  const [location, setLocation] = useState("");
+  const [serverType, setServerType] = useState("");
+  const [staticIP, setStaticIP] = useState(true);
   const [isDeploying, setIsDeploying] = useState(false);
   const [serverIP, setServerIP] = useState("");
 
@@ -142,6 +199,67 @@ const HetznerDeploy = ({
     const label = domain.replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase();
     return `netbird-proxy-${label}`.slice(0, 63).replace(/-+$/, "");
   }, [domain]);
+
+  // Load the live catalog once a plausible token is entered, debounced so we
+  // don't call the API on every keystroke.
+  useEffect(() => {
+    const apiToken = hetznerToken.trim();
+    if (apiToken.length < 32) {
+      setCatalog(null);
+      setCatalogError("");
+      return;
+    }
+    const timer = setTimeout(() => {
+      setIsLoadingCatalog(true);
+      setCatalogError("");
+      fetchHetznerCatalog(apiToken)
+        .then(setCatalog)
+        .catch((err) => {
+          setCatalog(null);
+          setCatalogError(
+            err instanceof Error ? err.message : "request failed",
+          );
+        })
+        .finally(() => setIsLoadingCatalog(false));
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [hetznerToken]);
+
+  const locationOptions = useMemo(
+    () =>
+      catalog?.locations.map((l) => ({ value: l.name, label: l.label })) ?? [],
+    [catalog],
+  );
+
+  const serverTypeOptions = useMemo(() => {
+    if (!catalog || !location) return [];
+    const ids = catalog.availableTypeIds[location] ?? [];
+    return catalog.serverTypes
+      .filter((t) => ids.includes(t.id))
+      .map((t) => ({
+        value: t.name,
+        label: `${t.name.toUpperCase()} - ${t.cores} vCPU / ${Math.round(
+          t.memory,
+        )} GB`,
+      }));
+  }, [catalog, location]);
+
+  useEffect(() => {
+    if (!catalog) return;
+    if (!catalog.locations.some((l) => l.name === location)) {
+      const preferred =
+        catalog.locations.find((l) => l.name === "nbg1") ??
+        catalog.locations[0];
+      setLocation(preferred?.name ?? "");
+    }
+  }, [catalog, location]);
+
+  useEffect(() => {
+    if (!catalog || !location) return;
+    if (!serverTypeOptions.some((o) => o.value === serverType)) {
+      setServerType(serverTypeOptions[0]?.value ?? "");
+    }
+  }, [catalog, location, serverTypeOptions, serverType]);
 
   const deploy = async () => {
     setIsDeploying(true);
@@ -167,6 +285,28 @@ const HetznerDeploy = ({
           );
         }
         setServerIP(body?.server?.public_net?.ipv4?.ip ?? "");
+        const primaryIPId = body?.server?.public_net?.ipv4?.id;
+        if (staticIP && primaryIPId) {
+          const ipRes = await fetch(
+            `https://api.hetzner.cloud/v1/primary_ips/${primaryIPId}`,
+            {
+              method: "PUT",
+              headers: {
+                Authorization: `Bearer ${hetznerToken.trim()}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ auto_delete: false }),
+            },
+          );
+          if (!ipRes.ok) {
+            const ipBody = await ipRes.json().catch(() => null);
+            throw new Error(
+              `server created, but keeping its IP static failed: ${
+                ipBody?.error?.message ?? `HTTP ${ipRes.status}`
+              }`,
+            );
+          }
+        }
       })
       .finally(() => setIsDeploying(false));
 
@@ -210,27 +350,57 @@ const HetznerDeploy = ({
           }
         />
       </div>
-      <div className={"flex gap-4"}>
-        <div className={"w-1/2"}>
-          <Label>Location</Label>
-          <SelectDropdown
-            value={location}
-            onChange={(v) => setLocation(v as string)}
-            options={HETZNER_LOCATIONS}
+      {catalogError && (
+        <Callout variant={"warning"}>
+          Could not load Hetzner options: {catalogError}
+        </Callout>
+      )}
+      {catalog ? (
+        <>
+          <div className={"flex gap-4"}>
+            <div className={"w-1/2"}>
+              <Label>Location</Label>
+              <SelectDropdown
+                value={location}
+                onChange={(v) => setLocation(v as string)}
+                options={locationOptions}
+              />
+            </div>
+            <div className={"w-1/2"}>
+              <Label>Server Type</Label>
+              <SelectDropdown
+                value={serverType}
+                onChange={(v) => setServerType(v as string)}
+                options={serverTypeOptions}
+              />
+            </div>
+          </div>
+          <FancyToggleSwitch
+            value={staticIP}
+            onChange={setStaticIP}
+            label={"Static IP"}
+            helpText={
+              "Keep the server's IP when the server is deleted or rebuilt, so the DNS records stay valid. Hetzner bills unassigned IPs."
+            }
           />
-        </div>
-        <div className={"w-1/2"}>
-          <Label>Server Type</Label>
-          <SelectDropdown
-            value={serverType}
-            onChange={(v) => setServerType(v as string)}
-            options={HETZNER_SERVER_TYPES}
-          />
-        </div>
-      </div>
+        </>
+      ) : (
+        <HelpText className={"mb-0"}>
+          {isLoadingCatalog
+            ? "Loading available locations and server types..."
+            : "Enter your API token to load the available locations and server types."}
+        </HelpText>
+      )}
       <Button
         variant={"primary"}
-        disabled={!hetznerToken || isDeploying || isGeneratingToken || !token}
+        disabled={
+          !catalog ||
+          !location ||
+          !serverType ||
+          isDeploying ||
+          isGeneratingToken ||
+          !token
+        }
         onClick={deploy}
       >
         {isDeploying || isGeneratingToken ? (
@@ -280,9 +450,11 @@ const DigitalOceanDeploy = ({
   const [doToken, setDoToken] = useState("");
   const [region, setRegion] = useState("fra1");
   const [size, setSize] = useState("s-1vcpu-2gb");
+  const [staticIP, setStaticIP] = useState(true);
   const [isDeploying, setIsDeploying] = useState(false);
   const [isCreated, setIsCreated] = useState(false);
   const [dropletIP, setDropletIP] = useState("");
+  const [reservedIP, setReservedIP] = useState("");
 
   const dropletName = useMemo(() => {
     const label = domain.replace(/[^a-zA-Z0-9.-]/g, "-").toLowerCase();
@@ -314,8 +486,31 @@ const DigitalOceanDeploy = ({
           );
         }
         setIsCreated(true);
-        const ip = await waitForDropletIP(body?.droplet?.id, doToken);
+        const dropletId = body?.droplet?.id;
+        const ip = await waitForDropletIP(dropletId, doToken);
         setDropletIP(ip);
+        if (staticIP && dropletId) {
+          const ipRes = await fetch(
+            "https://api.digitalocean.com/v2/reserved_ips",
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${doToken}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ droplet_id: dropletId }),
+            },
+          );
+          const ipBody = await ipRes.json().catch(() => null);
+          if (!ipRes.ok) {
+            throw new Error(
+              `droplet created, but reserving a static IP failed: ${
+                ipBody?.message ?? `HTTP ${ipRes.status}`
+              }`,
+            );
+          }
+          setReservedIP(ipBody?.reserved_ip?.ip ?? "");
+        }
       })
       .finally(() => setIsDeploying(false));
 
@@ -336,14 +531,16 @@ const DigitalOceanDeploy = ({
           Droplet{" "}
           <span className={"text-white font-medium"}>{dropletName}</span> was
           created
-          {dropletIP ? (
+          {reservedIP || dropletIP ? (
             <>
               {" "}
-              with IP{" "}
-              <span className={"text-netbird font-medium"}>{dropletIP}</span>.
-              Update the DNS records from the previous step to point to this IP.
-              The proxy will request its certificate and connect within a minute
-              or two.
+              with {reservedIP ? "static IP" : "IP"}{" "}
+              <span className={"text-netbird font-medium"}>
+                {reservedIP || dropletIP}
+              </span>
+              . Update the DNS records from the previous step to point to this
+              IP. The proxy will request its certificate and connect within a
+              minute or two.
             </>
           ) : (
             <>
@@ -406,6 +603,14 @@ const DigitalOceanDeploy = ({
           />
         </div>
       </div>
+      <FancyToggleSwitch
+        value={staticIP}
+        onChange={setStaticIP}
+        label={"Static IP"}
+        helpText={
+          "Reserve a static IP and assign it to the droplet, so the DNS records survive rebuilds. Free while assigned to a droplet."
+        }
+      />
       <Button
         variant={"primary"}
         disabled={!doToken || isDeploying || isGeneratingToken || !token}

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -73,13 +73,27 @@ type Props = {
 };
 
 // buildCloudInit renders the canonical bootstrap with the same environment as
-// the Docker snippet in the cluster modal, for use as VM user data.
+// the Docker snippet in the cluster modal, for use as VM user data. When a
+// root password is given (DigitalOcean), it is set for web-console access
+// while SSH password login stays disabled.
 const buildCloudInit = (
   domain: string,
   token: string,
   managementUrl: string,
+  rootPassword?: string,
 ) => `#cloud-config
-write_files:
+${
+  rootPassword
+    ? `ssh_pwauth: false
+chpasswd:
+  expire: false
+  users:
+    - name: root
+      password: ${rootPassword}
+      type: text
+`
+    : ""
+}write_files:
   - path: /etc/netbird-proxy/env
     permissions: "0600"
     content: |
@@ -247,12 +261,22 @@ const waitForDropletIP = async (dropletId: number, doToken: string) => {
   return "";
 };
 
+// generateRootPassword creates a random droplet password from an alphanumeric
+// set without ambiguous characters.
+const generateRootPassword = () => {
+  const charset = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789";
+  const values = new Uint32Array(20);
+  crypto.getRandomValues(values);
+  return Array.from(values, (v) => charset[v % charset.length]).join("");
+};
+
 const DigitalOceanDeploy = ({
   domain,
   token,
   managementUrl,
   isGeneratingToken,
 }: ProviderProps) => {
+  const [rootPassword] = useState(generateRootPassword);
   const [doToken, setDoToken] = useState("");
   const [region, setRegion] = useState("fra1");
   const [size, setSize] = useState("s-1vcpu-2gb");
@@ -278,7 +302,7 @@ const DigitalOceanDeploy = ({
         region,
         size,
         image: "ubuntu-24-04-x64",
-        user_data: buildCloudInit(domain, token, managementUrl),
+        user_data: buildCloudInit(domain, token, managementUrl, rootPassword),
         tags: ["netbird-proxy"],
       }),
     })
@@ -307,28 +331,42 @@ const DigitalOceanDeploy = ({
 
   if (isCreated) {
     return (
-      <Callout variant={"info"}>
-        Droplet <span className={"text-white font-medium"}>{dropletName}</span>{" "}
-        was created
-        {dropletIP ? (
-          <>
-            {" "}
-            with IP{" "}
-            <span className={"text-netbird font-medium"}>{dropletIP}</span>.
-            Update the DNS records from the previous step to point to this IP.
-            The proxy will request its certificate and connect within a minute
-            or two.
-          </>
-        ) : (
-          <>
-            {" "}
-            and is provisioning. Waiting for its public IP
-            {isDeploying
-              ? "..."
-              : " timed out - find the IP in the DigitalOcean control panel and update the DNS records from the previous step."}
-          </>
-        )}
-      </Callout>
+      <div className={"flex flex-col gap-4"}>
+        <Callout variant={"info"}>
+          Droplet{" "}
+          <span className={"text-white font-medium"}>{dropletName}</span> was
+          created
+          {dropletIP ? (
+            <>
+              {" "}
+              with IP{" "}
+              <span className={"text-netbird font-medium"}>{dropletIP}</span>.
+              Update the DNS records from the previous step to point to this IP.
+              The proxy will request its certificate and connect within a minute
+              or two.
+            </>
+          ) : (
+            <>
+              {" "}
+              and is provisioning. Waiting for its public IP
+              {isDeploying
+                ? "..."
+                : " timed out - find the IP in the DigitalOcean control panel and update the DNS records from the previous step."}
+            </>
+          )}
+        </Callout>
+        <div>
+          <Label>Droplet Root Password</Label>
+          <HelpText>
+            Use it with the Droplet Console in the DigitalOcean control panel
+            (SSH password login stays disabled). Copy it now - it is not stored
+            anywhere.
+          </HelpText>
+          <Code codeToCopy={rootPassword}>
+            <Code.Line>{rootPassword}</Code.Line>
+          </Code>
+        </div>
+      </div>
     );
   }
 

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -1,0 +1,286 @@
+import Button from "@components/Button";
+import { Callout } from "@components/Callout";
+import Code from "@components/Code";
+import HelpText from "@components/HelpText";
+import { Input } from "@components/Input";
+import { Label } from "@components/Label";
+import { notify } from "@components/Notification";
+import { SelectDropdown } from "@components/select/SelectDropdown";
+import { ExternalLinkIcon, Loader2, RocketIcon } from "lucide-react";
+import React, { useMemo, useState } from "react";
+
+// TODO(PoC): replace with the final public S3 location of
+// proxy/deploy/aws/netbird-proxy-cfn.yaml from the netbird repository.
+const CFN_TEMPLATE_URL =
+  "https://netbird-deploy-templates.s3.amazonaws.com/netbird-proxy-cfn.yaml";
+
+const DEFAULT_WIREGUARD_PORT = 51820;
+
+const HETZNER_LOCATIONS = [
+  { value: "nbg1", label: "Nuremberg, Germany (nbg1)" },
+  { value: "fsn1", label: "Falkenstein, Germany (fsn1)" },
+  { value: "hel1", label: "Helsinki, Finland (hel1)" },
+  { value: "ash", label: "Ashburn, VA, USA (ash)" },
+  { value: "hil", label: "Hillsboro, OR, USA (hil)" },
+  { value: "sin", label: "Singapore (sin)" },
+];
+
+const HETZNER_SERVER_TYPES = [
+  { value: "cx22", label: "CX22 - 2 vCPU / 4 GB (EU locations only)" },
+  { value: "cpx11", label: "CPX11 - 2 vCPU / 2 GB" },
+  { value: "cpx21", label: "CPX21 - 3 vCPU / 4 GB" },
+  { value: "cpx31", label: "CPX31 - 4 vCPU / 8 GB" },
+];
+
+const AWS_REGIONS = [
+  { value: "us-east-1", label: "US East (N. Virginia)" },
+  { value: "us-east-2", label: "US East (Ohio)" },
+  { value: "us-west-2", label: "US West (Oregon)" },
+  { value: "eu-central-1", label: "Europe (Frankfurt)" },
+  { value: "eu-west-1", label: "Europe (Ireland)" },
+  { value: "eu-west-2", label: "Europe (London)" },
+  { value: "ap-southeast-1", label: "Asia Pacific (Singapore)" },
+  { value: "ap-northeast-1", label: "Asia Pacific (Tokyo)" },
+];
+
+type Props = {
+  provider: "hetzner" | "aws";
+  domain: string;
+  token: string;
+  managementUrl: string;
+  isGeneratingToken: boolean;
+};
+
+// buildCloudInit renders the canonical bootstrap with the same environment as
+// the Docker snippet in the cluster modal, for use as VM user data.
+const buildCloudInit = (
+  domain: string,
+  token: string,
+  managementUrl: string,
+) => `#cloud-config
+write_files:
+  - path: /etc/netbird-proxy/env
+    permissions: "0600"
+    content: |
+      NB_PROXY_TOKEN=${token}
+      NB_PROXY_DOMAIN=${domain}
+      NB_PROXY_MANAGEMENT_ADDRESS=${managementUrl}
+      NB_PROXY_ACME_CERTIFICATES=true
+      NB_PROXY_CERTIFICATE_DIRECTORY=/certs
+      NB_PROXY_ALLOW_INSECURE=true
+      NB_PROXY_PRIVATE=true
+      NB_PROXY_LOG_LEVEL=info
+      NB_PROXY_ADDRESS=:443
+      NB_PROXY_WG_PORT=${DEFAULT_WIREGUARD_PORT}
+runcmd:
+  - curl -fsSL https://get.docker.com | sh
+  - >-
+    docker run -d --name netbird-proxy --restart unless-stopped
+    -p 443:443 -p 80:80
+    -p ${DEFAULT_WIREGUARD_PORT}:${DEFAULT_WIREGUARD_PORT}/udp
+    --env-file /etc/netbird-proxy/env
+    -v proxy_certs:/certs
+    netbirdio/reverse-proxy:latest
+`;
+
+export const ClusterCloudDeploy = ({
+  provider,
+  domain,
+  token,
+  managementUrl,
+  isGeneratingToken,
+}: Props) => {
+  return provider === "hetzner" ? (
+    <HetznerDeploy
+      domain={domain}
+      token={token}
+      managementUrl={managementUrl}
+      isGeneratingToken={isGeneratingToken}
+    />
+  ) : (
+    <AWSDeploy
+      domain={domain}
+      token={token}
+      managementUrl={managementUrl}
+      isGeneratingToken={isGeneratingToken}
+    />
+  );
+};
+
+type ProviderProps = Omit<Props, "provider">;
+
+const HetznerDeploy = ({
+  domain,
+  token,
+  managementUrl,
+  isGeneratingToken,
+}: ProviderProps) => {
+  const [hetznerToken, setHetznerToken] = useState("");
+  const [location, setLocation] = useState("nbg1");
+  const [serverType, setServerType] = useState("cx22");
+  const [isDeploying, setIsDeploying] = useState(false);
+  const [serverIP, setServerIP] = useState("");
+
+  const serverName = useMemo(() => {
+    const label = domain.replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase();
+    return `netbird-proxy-${label}`.slice(0, 63).replace(/-+$/, "");
+  }, [domain]);
+
+  const deploy = async () => {
+    setIsDeploying(true);
+    const promise = fetch("https://api.hetzner.cloud/v1/servers", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${hetznerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: serverName,
+        server_type: serverType,
+        image: "ubuntu-24.04",
+        location,
+        user_data: buildCloudInit(domain, token, managementUrl),
+      }),
+    })
+      .then(async (res) => {
+        const body = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(
+            body?.error?.message ?? `Hetzner API error (HTTP ${res.status})`,
+          );
+        }
+        setServerIP(body?.server?.public_net?.ipv4?.ip ?? "");
+      })
+      .finally(() => setIsDeploying(false));
+
+    notify({
+      title: "Hetzner Deployment",
+      description: "Failed to create the Hetzner server",
+      promise,
+      loadingMessage: "Creating Hetzner server...",
+      showOnlyError: true,
+      preventSuccessToast: true,
+    });
+  };
+
+  if (serverIP) {
+    return (
+      <Callout variant={"info"}>
+        Server <span className={"text-white font-medium"}>{serverName}</span>{" "}
+        was created with IP{" "}
+        <span className={"text-netbird font-medium"}>{serverIP}</span>. Update
+        the DNS records from the previous step to point to this IP. The proxy
+        will request its certificate and connect within a minute or two.
+      </Callout>
+    );
+  }
+
+  return (
+    <div className={"flex flex-col gap-4"}>
+      <div>
+        <Label>Hetzner API Token</Label>
+        <HelpText>
+          Create a read &amp; write API token in your Hetzner Cloud project. It
+          is sent directly from your browser to the Hetzner API and never stored
+          by NetBird.
+        </HelpText>
+        <Input
+          type={"password"}
+          placeholder={"Paste your Hetzner Cloud API token"}
+          value={hetznerToken}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setHetznerToken(e.target.value)
+          }
+        />
+      </div>
+      <div className={"flex gap-4"}>
+        <div className={"w-1/2"}>
+          <Label>Location</Label>
+          <SelectDropdown
+            value={location}
+            onChange={(v) => setLocation(v as string)}
+            options={HETZNER_LOCATIONS}
+          />
+        </div>
+        <div className={"w-1/2"}>
+          <Label>Server Type</Label>
+          <SelectDropdown
+            value={serverType}
+            onChange={(v) => setServerType(v as string)}
+            options={HETZNER_SERVER_TYPES}
+          />
+        </div>
+      </div>
+      <Button
+        variant={"primary"}
+        disabled={!hetznerToken || isDeploying || isGeneratingToken || !token}
+        onClick={deploy}
+      >
+        {isDeploying || isGeneratingToken ? (
+          <Loader2 size={16} className={"animate-spin"} />
+        ) : (
+          <RocketIcon size={16} />
+        )}
+        {isGeneratingToken ? "Preparing proxy token..." : "Deploy Server"}
+      </Button>
+    </div>
+  );
+};
+
+const AWSDeploy = ({
+  domain,
+  token,
+  managementUrl,
+  isGeneratingToken,
+}: ProviderProps) => {
+  const [region, setRegion] = useState("eu-central-1");
+
+  const launchUrl = useMemo(() => {
+    const params = new URLSearchParams({
+      templateURL: CFN_TEMPLATE_URL,
+      stackName: "netbird-proxy",
+      param_ProxyDomain: domain,
+      param_ManagementURL: managementUrl,
+    });
+    return `https://console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/quickcreate?${params.toString()}`;
+  }, [region, domain, managementUrl]);
+
+  return (
+    <div className={"flex flex-col gap-4"}>
+      <div>
+        <Label>Proxy Access Token</Label>
+        <HelpText>
+          Copy this token first. AWS asks for it in the stack creation form (the
+          field is masked and excluded from stack outputs and logs).
+        </HelpText>
+        <Code codeToCopy={token} showCopyIcon={!isGeneratingToken}>
+          <Code.Line>
+            {isGeneratingToken ? "Generating proxy token..." : token}
+          </Code.Line>
+        </Code>
+      </div>
+      <div>
+        <Label>Region</Label>
+        <SelectDropdown
+          value={region}
+          onChange={(v) => setRegion(v as string)}
+          options={AWS_REGIONS}
+        />
+      </div>
+      <Button
+        variant={"primary"}
+        disabled={isGeneratingToken || !token}
+        onClick={() => window.open(launchUrl, "_blank", "noopener,noreferrer")}
+      >
+        <RocketIcon size={16} />
+        Launch Stack in AWS Console
+        <ExternalLinkIcon size={14} />
+      </Button>
+      <HelpText className={"mb-0"}>
+        The AWS console opens with a pre-filled CloudFormation form: paste the
+        token, review, and create the stack. Point the DNS records from the
+        previous step to the PublicIP stack output afterwards.
+      </HelpText>
+    </div>
+  );
+};

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -10,7 +10,7 @@ import { ExternalLinkIcon, Loader2, RocketIcon } from "lucide-react";
 import React, { useMemo, useState } from "react";
 
 // TODO(PoC): replace with the final public S3 location of
-// proxy/deploy/aws/netbird-proxy-cfn.yaml from the netbird repository.
+// templates/reverse-proxy/netbird-proxy-cfn.yaml from this repository.
 const CFN_TEMPLATE_URL =
   "https://netbird-deploy-templates.s3.amazonaws.com/netbird-proxy-cfn.yaml";
 

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -67,8 +67,8 @@ type Props = {
 
 // buildCloudInit renders the canonical bootstrap with the same environment as
 // the Docker snippet in the cluster modal, for use as VM user data. When a
-// root password is given (DigitalOcean), it is set for web-console access
-// while SSH password login stays disabled.
+// root password is given, it is set for provider web-console access while
+// SSH password login stays disabled.
 const buildCloudInit = (
   domain: string,
   token: string,
@@ -260,7 +260,9 @@ const DeploySuccess = ({
           <>
             {" "}
             with {isStaticIP ? "static IP" : "IP"}{" "}
-            <span className={"text-netbird font-medium"}>{ip}</span>.
+            <span className={"text-netbird font-medium"}>{ip}</span>. It keeps
+            bootstrapping in the background - create the DNS records below in
+            the meantime.
           </>
         ) : (
           <> {ipPendingNote}</>
@@ -314,8 +316,9 @@ const DeploySuccess = ({
           <>
             <Loader2 size={16} className={"animate-spin shrink-0"} />
             <span className={"text-nb-gray-300"}>
-              Waiting for the proxy to register with NetBird - this takes a few
-              minutes while the instance installs Docker and starts the proxy...
+              Waiting for the proxy to register with NetBird. The instance still
+              installs Docker and starts the proxy after its IP appears - this
+              usually takes another minute or two...
             </span>
           </>
         )}
@@ -331,6 +334,7 @@ const HetznerDeploy = ({
   managementUrl,
   isGeneratingToken,
 }: ProviderProps) => {
+  const [rootPassword] = useState(generateRootPassword);
   const [hetznerToken, setHetznerToken] = useState("");
   const [catalog, setCatalog] = useState<HetznerCatalog | null>(null);
   const [catalogError, setCatalogError] = useState("");
@@ -420,7 +424,7 @@ const HetznerDeploy = ({
         server_type: serverType,
         image: "ubuntu-24.04",
         location,
-        user_data: buildCloudInit(domain, token, managementUrl),
+        user_data: buildCloudInit(domain, token, managementUrl, rootPassword),
       }),
     })
       .then(async (res) => {
@@ -474,7 +478,19 @@ const HetznerDeploy = ({
         ip={serverIP}
         isStaticIP={staticIP}
         domain={domain}
-      />
+      >
+        <div>
+          <Label>Server Root Password</Label>
+          <HelpText>
+            Use it with the server console in the Hetzner Cloud Console (SSH
+            password login stays disabled). Copy it now - it is not stored
+            anywhere.
+          </HelpText>
+          <Code codeToCopy={rootPassword}>
+            <Code.Line>{rootPassword}</Code.Line>
+          </Code>
+        </div>
+      </DeploySuccess>
     );
   }
 

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -32,6 +32,25 @@ const HETZNER_SERVER_TYPES = [
   { value: "cpx31", label: "CPX31 - 4 vCPU / 8 GB" },
 ];
 
+const DIGITALOCEAN_REGIONS = [
+  { value: "fra1", label: "Frankfurt, Germany (fra1)" },
+  { value: "ams3", label: "Amsterdam, Netherlands (ams3)" },
+  { value: "lon1", label: "London, UK (lon1)" },
+  { value: "nyc3", label: "New York, USA (nyc3)" },
+  { value: "sfo3", label: "San Francisco, USA (sfo3)" },
+  { value: "tor1", label: "Toronto, Canada (tor1)" },
+  { value: "sgp1", label: "Singapore (sgp1)" },
+  { value: "blr1", label: "Bangalore, India (blr1)" },
+  { value: "syd1", label: "Sydney, Australia (syd1)" },
+];
+
+const DIGITALOCEAN_SIZES = [
+  { value: "s-1vcpu-1gb", label: "Basic - 1 vCPU / 1 GB" },
+  { value: "s-1vcpu-2gb", label: "Basic - 1 vCPU / 2 GB" },
+  { value: "s-2vcpu-2gb", label: "Basic - 2 vCPU / 2 GB" },
+  { value: "s-2vcpu-4gb", label: "Basic - 2 vCPU / 4 GB" },
+];
+
 const AWS_REGIONS = [
   { value: "us-east-1", label: "US East (N. Virginia)" },
   { value: "us-east-2", label: "US East (Ohio)" },
@@ -43,8 +62,10 @@ const AWS_REGIONS = [
   { value: "ap-northeast-1", label: "Asia Pacific (Tokyo)" },
 ];
 
+export type CloudProvider = "hetzner" | "digitalocean" | "aws";
+
 type Props = {
-  provider: "hetzner" | "aws";
+  provider: CloudProvider;
   domain: string;
   token: string;
   managementUrl: string;
@@ -83,28 +104,10 @@ runcmd:
     netbirdio/reverse-proxy:latest
 `;
 
-export const ClusterCloudDeploy = ({
-  provider,
-  domain,
-  token,
-  managementUrl,
-  isGeneratingToken,
-}: Props) => {
-  return provider === "hetzner" ? (
-    <HetznerDeploy
-      domain={domain}
-      token={token}
-      managementUrl={managementUrl}
-      isGeneratingToken={isGeneratingToken}
-    />
-  ) : (
-    <AWSDeploy
-      domain={domain}
-      token={token}
-      managementUrl={managementUrl}
-      isGeneratingToken={isGeneratingToken}
-    />
-  );
+export const ClusterCloudDeploy = ({ provider, ...props }: Props) => {
+  if (provider === "hetzner") return <HetznerDeploy {...props} />;
+  if (provider === "digitalocean") return <DigitalOceanDeploy {...props} />;
+  return <AWSDeploy {...props} />;
 };
 
 type ProviderProps = Omit<Props, "provider">;
@@ -222,6 +225,160 @@ const HetznerDeploy = ({
           <RocketIcon size={16} />
         )}
         {isGeneratingToken ? "Preparing proxy token..." : "Deploy Server"}
+      </Button>
+    </div>
+  );
+};
+
+// waitForDropletIP polls the droplet until its public IPv4 is assigned.
+const waitForDropletIP = async (dropletId: number, doToken: string) => {
+  for (let attempt = 0; attempt < 18; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    const res = await fetch(
+      `https://api.digitalocean.com/v2/droplets/${dropletId}`,
+      { headers: { Authorization: `Bearer ${doToken}` } },
+    );
+    const body = await res.json().catch(() => null);
+    const ip = body?.droplet?.networks?.v4?.find(
+      (net: { type: string }) => net.type === "public",
+    )?.ip_address;
+    if (ip) return ip as string;
+  }
+  return "";
+};
+
+const DigitalOceanDeploy = ({
+  domain,
+  token,
+  managementUrl,
+  isGeneratingToken,
+}: ProviderProps) => {
+  const [doToken, setDoToken] = useState("");
+  const [region, setRegion] = useState("fra1");
+  const [size, setSize] = useState("s-1vcpu-2gb");
+  const [isDeploying, setIsDeploying] = useState(false);
+  const [isCreated, setIsCreated] = useState(false);
+  const [dropletIP, setDropletIP] = useState("");
+
+  const dropletName = useMemo(() => {
+    const label = domain.replace(/[^a-zA-Z0-9.-]/g, "-").toLowerCase();
+    return `netbird-proxy-${label}`.slice(0, 63).replace(/[-.]+$/, "");
+  }, [domain]);
+
+  const deploy = async () => {
+    setIsDeploying(true);
+    const promise = fetch("https://api.digitalocean.com/v2/droplets", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${doToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: dropletName,
+        region,
+        size,
+        image: "ubuntu-24-04-x64",
+        user_data: buildCloudInit(domain, token, managementUrl),
+        tags: ["netbird-proxy"],
+      }),
+    })
+      .then(async (res) => {
+        const body = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(
+            body?.message ?? `DigitalOcean API error (HTTP ${res.status})`,
+          );
+        }
+        setIsCreated(true);
+        const ip = await waitForDropletIP(body?.droplet?.id, doToken);
+        setDropletIP(ip);
+      })
+      .finally(() => setIsDeploying(false));
+
+    notify({
+      title: "DigitalOcean Deployment",
+      description: "Failed to create the DigitalOcean droplet",
+      promise,
+      loadingMessage: "Creating DigitalOcean droplet...",
+      showOnlyError: true,
+      preventSuccessToast: true,
+    });
+  };
+
+  if (isCreated) {
+    return (
+      <Callout variant={"info"}>
+        Droplet <span className={"text-white font-medium"}>{dropletName}</span>{" "}
+        was created
+        {dropletIP ? (
+          <>
+            {" "}
+            with IP{" "}
+            <span className={"text-netbird font-medium"}>{dropletIP}</span>.
+            Update the DNS records from the previous step to point to this IP.
+            The proxy will request its certificate and connect within a minute
+            or two.
+          </>
+        ) : (
+          <>
+            {" "}
+            and is provisioning. Waiting for its public IP
+            {isDeploying
+              ? "..."
+              : " timed out - find the IP in the DigitalOcean control panel and update the DNS records from the previous step."}
+          </>
+        )}
+      </Callout>
+    );
+  }
+
+  return (
+    <div className={"flex flex-col gap-4"}>
+      <div>
+        <Label>DigitalOcean API Token</Label>
+        <HelpText>
+          Create a token with write scope in your DigitalOcean account. It is
+          sent directly from your browser to the DigitalOcean API and never
+          stored by NetBird.
+        </HelpText>
+        <Input
+          type={"password"}
+          placeholder={"Paste your DigitalOcean API token"}
+          value={doToken}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setDoToken(e.target.value)
+          }
+        />
+      </div>
+      <div className={"flex gap-4"}>
+        <div className={"w-1/2"}>
+          <Label>Region</Label>
+          <SelectDropdown
+            value={region}
+            onChange={(v) => setRegion(v as string)}
+            options={DIGITALOCEAN_REGIONS}
+          />
+        </div>
+        <div className={"w-1/2"}>
+          <Label>Droplet Size</Label>
+          <SelectDropdown
+            value={size}
+            onChange={(v) => setSize(v as string)}
+            options={DIGITALOCEAN_SIZES}
+          />
+        </div>
+      </div>
+      <Button
+        variant={"primary"}
+        disabled={!doToken || isDeploying || isGeneratingToken || !token}
+        onClick={deploy}
+      >
+        {isDeploying || isGeneratingToken ? (
+          <Loader2 size={16} className={"animate-spin"} />
+        ) : (
+          <RocketIcon size={16} />
+        )}
+        {isGeneratingToken ? "Preparing proxy token..." : "Deploy Droplet"}
       </Button>
     </div>
   );

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -520,8 +520,21 @@ const HetznerDeploy = ({
         <Label>
           Hetzner API Token
           <HelpTooltip
+            interactive={true}
             content={
-              "The token is sent directly from your browser to the Hetzner API and never reaches NetBird's servers."
+              <>
+                The token goes straight from your browser to Hetzner and never
+                touches NetBird&apos;s servers, and you can delete it once setup
+                succeeds.{" "}
+                <InlineLink
+                  href={
+                    "https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/"
+                  }
+                  target={"_blank"}
+                >
+                  How to create a token
+                </InlineLink>
+              </>
             }
           />
         </Label>

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -4,6 +4,7 @@ import CardTable from "@components/CardTable";
 import Code from "@components/Code";
 import FancyToggleSwitch from "@components/FancyToggleSwitch";
 import HelpText from "@components/HelpText";
+import { HelpTooltip } from "@components/HelpTooltip";
 import { Input } from "@components/Input";
 import { Label } from "@components/Label";
 import { notify } from "@components/Notification";
@@ -520,13 +521,16 @@ const HetznerDeploy = ({
       <div>
         <Label>Hetzner API Token</Label>
         <HelpText>
-          Create a read &amp; write API token in your Hetzner Cloud project. It
-          is sent directly from your browser to the Hetzner API and never stored
-          by NetBird.
+          Create a read &amp; write API token. It is never stored by NetBird{" "}
+          <HelpTooltip
+            content={
+              "The token is sent directly from your browser to the Hetzner API. It never reaches NetBird's servers."
+            }
+          />
         </HelpText>
         <Input
           type={"password"}
-          placeholder={"Paste your Hetzner Cloud API token"}
+          placeholder={"Paste your Hetzner Cloud API token here"}
           value={hetznerToken}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setHetznerToken(e.target.value)
@@ -759,13 +763,16 @@ const DigitalOceanDeploy = ({
       <div>
         <Label>DigitalOcean API Token</Label>
         <HelpText>
-          Create a token with write scope in your DigitalOcean account. It is
-          sent directly from your browser to the DigitalOcean API and never
-          stored by NetBird.
+          Create a token with write access. It is never stored by NetBird{" "}
+          <HelpTooltip
+            content={
+              "The token is sent directly from your browser to the DigitalOcean API. It never reaches NetBird's servers."
+            }
+          />
         </HelpText>
         <Input
           type={"password"}
-          placeholder={"Paste your DigitalOcean API token"}
+          placeholder={"Paste your DigitalOcean API token here"}
           value={doToken}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             setDoToken(e.target.value)
@@ -795,7 +802,7 @@ const DigitalOceanDeploy = ({
         onChange={setStaticIP}
         label={"Static IP"}
         helpText={
-          "Reserve a static IP and assign it to the droplet, so the DNS records survive rebuilds. Free while assigned to a droplet."
+          "Reserve a static IP so DNS records remain valid after rebuilds. Free while assigned to a Droplet."
         }
       />
       <Button
@@ -838,8 +845,8 @@ const AWSDeploy = ({
       <div>
         <Label>Proxy Access Token</Label>
         <HelpText>
-          Copy this token first. AWS asks for it in the stack creation form (the
-          field is masked and excluded from stack outputs and logs).
+          Copy this token for AWS stack creation. It is excluded from outputs and
+          logs.
         </HelpText>
         <Code codeToCopy={token} showCopyIcon={!isGeneratingToken}>
           <Code.Line>
@@ -868,9 +875,8 @@ const AWSDeploy = ({
         <ExternalLinkIcon size={14} />
       </Button>
       <HelpText className={"mb-0"}>
-        The AWS console opens with a pre-filled CloudFormation form: paste the
-        token, review, and create the stack. Point the DNS records from the
-        previous step to the PublicIP stack output afterwards.
+        The AWS Console opens with a prefilled form. Paste the token, create the
+        stack, then point your DNS records to the PublicIP output.
       </HelpText>
       {launched && <RegistrationCheck domain={domain} />}
     </div>

--- a/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
+++ b/src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx
@@ -65,6 +65,9 @@ type Props = {
   token: string;
   managementUrl: string;
   isGeneratingToken: boolean;
+  // Fires once the deployed proxy registers and connects, so the modal can
+  // gate its "Finish Setup" action on real completion.
+  onRegistered?: () => void;
 };
 
 // buildCloudInit renders the canonical bootstrap with the same environment as
@@ -224,12 +227,19 @@ type DeploySuccessProps = {
   isStaticIP: boolean;
   domain: string;
   ipPendingNote?: string;
+  onRegistered?: () => void;
   children?: React.ReactNode;
 };
 
 // RegistrationCheck polls the management API until the cluster for the given
 // domain reports a connected proxy.
-const RegistrationCheck = ({ domain }: { domain: string }) => {
+const RegistrationCheck = ({
+  domain,
+  onRegistered,
+}: {
+  domain: string;
+  onRegistered?: () => void;
+}) => {
   const clustersRequest = useApiCall<ReverseProxyCluster[]>(
     "/reverse-proxies/clusters",
     true,
@@ -237,7 +247,10 @@ const RegistrationCheck = ({ domain }: { domain: string }) => {
   const [registered, setRegistered] = useState(false);
 
   useEffect(() => {
-    if (registered) return;
+    if (registered) {
+      onRegistered?.();
+      return;
+    }
     let attempts = 0;
     const timer = setInterval(() => {
       attempts += 1;
@@ -292,6 +305,7 @@ const DeploySuccess = ({
   isStaticIP,
   domain,
   ipPendingNote,
+  onRegistered,
   children,
 }: DeploySuccessProps) => {
   return (
@@ -347,7 +361,7 @@ const DeploySuccess = ({
         </div>
       )}
       {children}
-      <RegistrationCheck domain={domain} />
+      <RegistrationCheck domain={domain} onRegistered={onRegistered} />
     </div>
   );
 };
@@ -357,6 +371,7 @@ const HetznerDeploy = ({
   token,
   managementUrl,
   isGeneratingToken,
+  onRegistered,
 }: ProviderProps) => {
   const [hetznerToken, setHetznerToken] = useState("");
   const [catalog, setCatalog] = useState<HetznerCatalog | null>(null);
@@ -510,6 +525,7 @@ const HetznerDeploy = ({
         ip={serverIP}
         isStaticIP={staticIP}
         domain={domain}
+        onRegistered={onRegistered}
       />
     );
   }
@@ -663,6 +679,7 @@ const DigitalOceanDeploy = ({
   token,
   managementUrl,
   isGeneratingToken,
+  onRegistered,
 }: ProviderProps) => {
   const [rootPassword] = useState(generateRootPassword);
   const [doToken, setDoToken] = useState("");
@@ -750,6 +767,7 @@ const DigitalOceanDeploy = ({
         ip={reservedIP || dropletIP}
         isStaticIP={!!reservedIP}
         domain={domain}
+        onRegistered={onRegistered}
         ipPendingNote={
           isDeploying
             ? "and is provisioning. Waiting for its public IP..."
@@ -857,6 +875,7 @@ const AWSDeploy = ({
   token,
   managementUrl,
   isGeneratingToken,
+  onRegistered,
 }: ProviderProps) => {
   const [region, setRegion] = useState("eu-central-1");
   const [launched, setLaunched] = useState(false);
@@ -909,7 +928,9 @@ const AWSDeploy = ({
         The AWS Console opens with a prefilled form. Paste the token, create the
         stack, then point your DNS records to the PublicIP output.
       </HelpText>
-      {launched && <RegistrationCheck domain={domain} />}
+      {launched && (
+        <RegistrationCheck domain={domain} onRegistered={onRegistered} />
+      )}
     </div>
   );
 };

--- a/src/modules/reverse-proxy/clusters/ClustersModal.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersModal.tsx
@@ -106,9 +106,10 @@ export const ClustersModal = ({ open, onOpenChange }: Props) => {
     return "";
   }, [domain]);
 
-  const managementUrl = isNetBirdCloud()
-    ? "https://api.netbird.io"
-    : GRPC_API_ORIGIN || "";
+  // Same convention as the add-peer modals: prefer the configured gRPC
+  // endpoint so self-hosted and stage deployments point at their own
+  // management service; fall back to the cloud default.
+  const managementUrl = GRPC_API_ORIGIN || "https://api.netbird.io:443";
 
   const tokenValue = token || "<TOKEN>";
 

--- a/src/modules/reverse-proxy/clusters/ClustersModal.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersModal.tsx
@@ -216,32 +216,32 @@ spec:
   const deployment = {
     docker: {
       label: "Docker",
-      title: "Run the Proxy with Docker",
+      title: "Run with Docker",
       command: dockerCommand,
     },
     compose: {
       label: "Docker Compose",
-      title: "Run the Proxy with Docker Compose",
+      title: "Run with Docker Compose",
       command: composeCommand,
     },
     kubernetes: {
       label: "Kubernetes",
-      title: "Deploy the Proxy on Kubernetes",
+      title: "Deploy on Kubernetes",
       command: kubernetesCommand,
     },
     hetzner: {
       label: "Hetzner Cloud",
-      title: "Deploy the Proxy on Hetzner Cloud",
+      title: "Deploy on Hetzner Cloud",
       command: "",
     },
     digitalocean: {
       label: "DigitalOcean",
-      title: "Deploy the Proxy on DigitalOcean",
+      title: "Deploy on DigitalOcean",
       command: "",
     },
     aws: {
       label: "AWS CloudFormation",
-      title: "Deploy the Proxy on AWS",
+      title: "Deploy on AWS",
       command: "",
     },
   }[deployMethod];
@@ -402,21 +402,26 @@ spec:
 
           <TabsContent value={"install"} className={"pb-8"}>
             <div className={"px-8 flex flex-col gap-4"}>
-              <div className={"flex items-end justify-between gap-4"}>
+              <div className={"flex items-start justify-between gap-4"}>
                 <div>
                   <Label>{deployment.title}</Label>
                   <HelpText className={"mb-0"}>
-                    {isCloudDeploy
-                      ? "Launch a dedicated cloud server running the proxy."
+                    {deployMethod === "digitalocean"
+                      ? "Launch a droplet to run the proxy."
+                      : deployMethod === "aws"
+                      ? "Launch a dedicated AWS server to run the proxy."
+                      : isCloudDeploy
+                      ? "Launch a cloud server to run the proxy."
                       : deployMethod === "kubernetes"
-                      ? "Apply the following manifest to your cluster to start the proxy."
-                      : "Run the following on your machine to start the proxy."}
+                      ? "Apply this manifest to start the proxy."
+                      : "Run on your machine to start the proxy."}
                   </HelpText>
                 </div>
-                <div className={"w-[180px] shrink-0"}>
+                <div className={"w-[200px] shrink-0"}>
                   <SelectDropdown
                     value={deployMethod}
                     onChange={(v) => setDeployMethod(v as DeployMethod)}
+                    truncate={true}
                     options={[
                       { value: "docker", label: "Docker" },
                       { value: "compose", label: "Docker Compose" },

--- a/src/modules/reverse-proxy/clusters/ClustersModal.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersModal.tsx
@@ -36,14 +36,23 @@ import {
   REVERSE_PROXY_SELFHOSTED_ROUTING_DOCS_LINK,
   ReverseProxyClusterToken,
 } from "@/interfaces/ReverseProxy";
-import { ClusterCloudDeploy } from "@/modules/reverse-proxy/clusters/ClusterCloudDeploy";
+import {
+  ClusterCloudDeploy,
+  CloudProvider,
+} from "@/modules/reverse-proxy/clusters/ClusterCloudDeploy";
 
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
 
-type DeployMethod = "docker" | "compose" | "kubernetes" | "hetzner" | "aws";
+type DeployMethod =
+  | "docker"
+  | "compose"
+  | "kubernetes"
+  | "hetzner"
+  | "digitalocean"
+  | "aws";
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -224,6 +233,11 @@ spec:
       title: "Deploy the Proxy on Hetzner Cloud",
       command: "",
     },
+    digitalocean: {
+      label: "DigitalOcean",
+      title: "Deploy the Proxy on DigitalOcean",
+      command: "",
+    },
     aws: {
       label: "AWS CloudFormation",
       title: "Deploy the Proxy on AWS",
@@ -231,7 +245,9 @@ spec:
     },
   }[deployMethod];
 
-  const isCloudDeploy = deployMethod === "hetzner" || deployMethod === "aws";
+  const isCloudDeploy = ["hetzner", "digitalocean", "aws"].includes(
+    deployMethod,
+  );
 
   const generateToken = useCallback(async () => {
     setIsGeneratingToken(true);
@@ -405,6 +421,7 @@ spec:
                       { value: "compose", label: "Docker Compose" },
                       { value: "kubernetes", label: "Kubernetes" },
                       { value: "hetzner", label: "Hetzner Cloud" },
+                      { value: "digitalocean", label: "DigitalOcean" },
                       { value: "aws", label: "AWS CloudFormation" },
                     ]}
                   />
@@ -429,7 +446,7 @@ spec:
 
               {isCloudDeploy ? (
                 <ClusterCloudDeploy
-                  provider={deployMethod as "hetzner" | "aws"}
+                  provider={deployMethod as CloudProvider}
                   domain={domain}
                   token={token}
                   managementUrl={managementUrl}

--- a/src/modules/reverse-proxy/clusters/ClustersModal.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersModal.tsx
@@ -36,13 +36,14 @@ import {
   REVERSE_PROXY_SELFHOSTED_ROUTING_DOCS_LINK,
   ReverseProxyClusterToken,
 } from "@/interfaces/ReverseProxy";
+import { ClusterCloudDeploy } from "@/modules/reverse-proxy/clusters/ClusterCloudDeploy";
 
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
 
-type DeployMethod = "docker" | "compose" | "kubernetes";
+type DeployMethod = "docker" | "compose" | "kubernetes" | "hetzner" | "aws";
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -218,7 +219,19 @@ spec:
       title: "Deploy the Proxy on Kubernetes",
       command: kubernetesCommand,
     },
+    hetzner: {
+      label: "Hetzner Cloud",
+      title: "Deploy the Proxy on Hetzner Cloud",
+      command: "",
+    },
+    aws: {
+      label: "AWS CloudFormation",
+      title: "Deploy the Proxy on AWS",
+      command: "",
+    },
   }[deployMethod];
+
+  const isCloudDeploy = deployMethod === "hetzner" || deployMethod === "aws";
 
   const generateToken = useCallback(async () => {
     setIsGeneratingToken(true);
@@ -376,7 +389,9 @@ spec:
                 <div>
                   <Label>{deployment.title}</Label>
                   <HelpText className={"mb-0"}>
-                    {deployMethod === "kubernetes"
+                    {isCloudDeploy
+                      ? "Launch a dedicated cloud server running the proxy."
+                      : deployMethod === "kubernetes"
                       ? "Apply the following manifest to your cluster to start the proxy."
                       : "Run the following on your machine to start the proxy."}
                   </HelpText>
@@ -389,6 +404,8 @@ spec:
                       { value: "docker", label: "Docker" },
                       { value: "compose", label: "Docker Compose" },
                       { value: "kubernetes", label: "Kubernetes" },
+                      { value: "hetzner", label: "Hetzner Cloud" },
+                      { value: "aws", label: "AWS CloudFormation" },
                     ]}
                   />
                 </div>
@@ -410,39 +427,51 @@ spec:
                 </Callout>
               )}
 
-              <Code
-                key={deployMethod}
-                codeToCopy={deployment.command}
-                className={cn(
-                  "overflow-hidden",
-                  isGeneratingToken && "!border-nb-gray-930",
-                )}
-                showCopyIcon={!isGeneratingToken}
-              >
-                {isGeneratingToken && (
-                  <div className="absolute inset-0 z-10 flex items-center justify-center gap-2 text-nb-gray-100 bg-nb-gray-950/90">
-                    <Loader2 size={16} className="animate-spin" />
-                    Generating proxy token...
-                  </div>
-                )}
+              {isCloudDeploy ? (
+                <ClusterCloudDeploy
+                  provider={deployMethod as "hetzner" | "aws"}
+                  domain={domain}
+                  token={token}
+                  managementUrl={managementUrl}
+                  isGeneratingToken={isGeneratingToken}
+                />
+              ) : (
+                <>
+                  <Code
+                    key={deployMethod}
+                    codeToCopy={deployment.command}
+                    className={cn(
+                      "overflow-hidden",
+                      isGeneratingToken && "!border-nb-gray-930",
+                    )}
+                    showCopyIcon={!isGeneratingToken}
+                  >
+                    {isGeneratingToken && (
+                      <div className="absolute inset-0 z-10 flex items-center justify-center gap-2 text-nb-gray-100 bg-nb-gray-950/90">
+                        <Loader2 size={16} className="animate-spin" />
+                        Generating proxy token...
+                      </div>
+                    )}
 
-                {renderHighlightedCommand(deployment.command, [
-                  managementUrl,
-                  domain,
-                  tokenValue,
-                ])}
-              </Code>
+                    {renderHighlightedCommand(deployment.command, [
+                      managementUrl,
+                      domain,
+                      tokenValue,
+                    ])}
+                  </Code>
 
-              <HelpText className={"mb-0"}>
-                Need to fine-tune the proxy? See all available&nbsp;
-                <InlineLink
-                  href={REVERSE_PROXY_ENV_REFERENCE_DOCS_LINK}
-                  target={"_blank"}
-                >
-                  environment variables
-                  <ExternalLinkIcon size={12} />
-                </InlineLink>
-              </HelpText>
+                  <HelpText className={"mb-0"}>
+                    Need to fine-tune the proxy? See all available&nbsp;
+                    <InlineLink
+                      href={REVERSE_PROXY_ENV_REFERENCE_DOCS_LINK}
+                      target={"_blank"}
+                    >
+                      environment variables
+                      <ExternalLinkIcon size={12} />
+                    </InlineLink>
+                  </HelpText>
+                </>
+              )}
             </div>
           </TabsContent>
         </Tabs>

--- a/src/modules/reverse-proxy/clusters/ClustersModal.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersModal.tsx
@@ -24,7 +24,7 @@ import {
   ServerIcon,
   SquareTerminalIcon,
 } from "lucide-react";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useApiCall } from "@/utils/api";
 import { cn, validator } from "@utils/helpers";
@@ -88,6 +88,7 @@ export const ClustersModal = ({ open, onOpenChange }: Props) => {
   const [token, setToken] = useState("");
   const [isGeneratingToken, setIsGeneratingToken] = useState(true);
   const [deployMethod, setDeployMethod] = useState<DeployMethod>("docker");
+  const [proxyRegistered, setProxyRegistered] = useState(false);
 
   const tokenRequest = useApiCall<ReverseProxyClusterToken>(
     "/reverse-proxies/proxy-tokens",
@@ -250,6 +251,30 @@ spec:
     deployMethod,
   );
 
+  // Cloud one-click deploys provision the server and surface the DNS records
+  // (with the real IP) after deployment, so the standalone DNS step only
+  // applies to the manual paths. Bounce off it if the method flips to cloud.
+  useEffect(() => {
+    if (isCloudDeploy && tab === "dns") setTab("install");
+  }, [isCloudDeploy, tab]);
+
+  // A new deploy target means the proxy has not registered yet, so drop any
+  // prior completion state that would otherwise unlock "Finish Setup".
+  useEffect(() => {
+    setProxyRegistered(false);
+  }, [domain, deployMethod]);
+
+  const deployDescription =
+    deployMethod === "digitalocean"
+      ? "Launch a droplet to run the proxy."
+      : deployMethod === "aws"
+      ? "Launch a dedicated AWS server to run the proxy."
+      : isCloudDeploy
+      ? "Launch a cloud server to run the proxy."
+      : deployMethod === "kubernetes"
+      ? "Apply this manifest to start the proxy."
+      : "Run on your machine to start the proxy.";
+
   const generateToken = useCallback(async () => {
     setIsGeneratingToken(true);
     const promise = tokenRequest
@@ -291,7 +316,7 @@ spec:
         <ModalHeader
           icon={<ServerIcon size={16} />}
           title={"Setup Cluster"}
-          description={"Setup a proxy cluster"}
+          description={"Setup a proxy cluster on infra you own"}
           color={"netbird"}
         />
 
@@ -304,19 +329,21 @@ spec:
               <GlobeIcon size={14} />
               Domain
             </TabsTrigger>
-            <TabsTrigger
-              value={"dns"}
-              disabled={!domain.trim() || !!domainError}
-            >
-              <ListIcon size={14} />
-              DNS Records
-            </TabsTrigger>
+            {!isCloudDeploy && (
+              <TabsTrigger
+                value={"dns"}
+                disabled={!domain.trim() || !!domainError}
+              >
+                <ListIcon size={14} />
+                DNS Records
+              </TabsTrigger>
+            )}
             <TabsTrigger
               value={"install"}
               disabled={!domain.trim() || !!domainError}
             >
               <SquareTerminalIcon size={14} />
-              Run the Proxy
+              {isCloudDeploy ? "Deploy" : "Run the Proxy"}
             </TabsTrigger>
           </TabsList>
 
@@ -337,27 +364,45 @@ spec:
                   }
                 />
               </div>
-              <Callout variant={"info"}>
-                In order to run the proxy, please make sure your machine meets
-                the following requirements:
-                <ul className={"list-disc pl-4 mt-2 flex flex-col gap-1"}>
-                  <li>
-                    <span className={"text-white font-medium"}>
-                      Publicly accessible IP address
-                    </span>
-                  </li>
-                  <li>
-                    <span className={"text-white font-medium"}>Docker</span>{" "}
-                    installed and running
-                  </li>
-                  <li>
-                    <span className={"text-white font-medium"}>
-                      Port 80 and 443
-                    </span>{" "}
-                    open and not in use
-                  </li>
-                </ul>
-              </Callout>
+              <div>
+                <Label>Deployment Method</Label>
+                <HelpText>{deployDescription}</HelpText>
+                <SelectDropdown
+                  value={deployMethod}
+                  onChange={(v) => setDeployMethod(v as DeployMethod)}
+                  options={[
+                    { value: "docker", label: "Docker" },
+                    { value: "compose", label: "Docker Compose" },
+                    { value: "kubernetes", label: "Kubernetes" },
+                    { value: "hetzner", label: "Hetzner Cloud" },
+                    { value: "digitalocean", label: "DigitalOcean" },
+                    { value: "aws", label: "AWS CloudFormation" },
+                  ]}
+                />
+              </div>
+              {!isCloudDeploy && (
+                <Callout variant={"info"}>
+                  In order to run the proxy, please make sure your machine meets
+                  the following requirements:
+                  <ul className={"list-disc pl-4 mt-2 flex flex-col gap-1"}>
+                    <li>
+                      <span className={"text-white font-medium"}>
+                        Publicly accessible IP address
+                      </span>
+                    </li>
+                    <li>
+                      <span className={"text-white font-medium"}>Docker</span>{" "}
+                      installed and running
+                    </li>
+                    <li>
+                      <span className={"text-white font-medium"}>
+                        Port 80 and 443
+                      </span>{" "}
+                      open and not in use
+                    </li>
+                  </ul>
+                </Callout>
+              )}
             </div>
           </TabsContent>
 
@@ -402,36 +447,9 @@ spec:
 
           <TabsContent value={"install"} className={"pb-8"}>
             <div className={"px-8 flex flex-col gap-4"}>
-              <div className={"flex items-start justify-between gap-4"}>
-                <div>
-                  <Label>{deployment.title}</Label>
-                  <HelpText className={"mb-0"}>
-                    {deployMethod === "digitalocean"
-                      ? "Launch a droplet to run the proxy."
-                      : deployMethod === "aws"
-                      ? "Launch a dedicated AWS server to run the proxy."
-                      : isCloudDeploy
-                      ? "Launch a cloud server to run the proxy."
-                      : deployMethod === "kubernetes"
-                      ? "Apply this manifest to start the proxy."
-                      : "Run on your machine to start the proxy."}
-                  </HelpText>
-                </div>
-                <div className={"w-[200px] shrink-0"}>
-                  <SelectDropdown
-                    value={deployMethod}
-                    onChange={(v) => setDeployMethod(v as DeployMethod)}
-                    truncate={true}
-                    options={[
-                      { value: "docker", label: "Docker" },
-                      { value: "compose", label: "Docker Compose" },
-                      { value: "kubernetes", label: "Kubernetes" },
-                      { value: "hetzner", label: "Hetzner Cloud" },
-                      { value: "digitalocean", label: "DigitalOcean" },
-                      { value: "aws", label: "AWS CloudFormation" },
-                    ]}
-                  />
-                </div>
+              <div>
+                <Label>{deployment.title}</Label>
+                <HelpText className={"mb-0"}>{deployDescription}</HelpText>
               </div>
 
               {!isNetBirdCloud() && (
@@ -457,6 +475,7 @@ spec:
                   token={token}
                   managementUrl={managementUrl}
                   isGeneratingToken={isGeneratingToken}
+                  onRegistered={() => setProxyRegistered(true)}
                 />
               ) : (
                 <>
@@ -520,7 +539,7 @@ spec:
                 </ModalClose>
                 <Button
                   variant={"primary"}
-                  onClick={() => setTab("dns")}
+                  onClick={() => (isCloudDeploy ? goToInstall() : setTab("dns"))}
                   disabled={!domain.trim() || !!domainError}
                 >
                   Continue
@@ -539,10 +558,17 @@ spec:
             )}
             {tab === "install" && (
               <>
-                <Button variant={"secondary"} onClick={() => setTab("dns")}>
+                <Button
+                  variant={"secondary"}
+                  onClick={() => setTab(isCloudDeploy ? "domain" : "dns")}
+                >
                   Back
                 </Button>
-                <Button variant={"primary"} onClick={finishSetup}>
+                <Button
+                  variant={"primary"}
+                  onClick={finishSetup}
+                  disabled={isCloudDeploy && !proxyRegistered}
+                >
                   Finish Setup
                 </Button>
               </>

--- a/src/modules/reverse-proxy/clusters/ClustersTable.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersTable.tsx
@@ -201,7 +201,7 @@ export default function ClustersTable({ headingTarget }: Readonly<Props>) {
             }
             title={"No clusters available"}
             description={
-              "Set up a self-hosted cluster to route traffic through your own infrastructure."
+              "Set up a cluster to route traffic through your own infrastructure."
             }
             button={
               <Button

--- a/src/modules/reverse-proxy/clusters/ClustersTable.tsx
+++ b/src/modules/reverse-proxy/clusters/ClustersTable.tsx
@@ -201,7 +201,7 @@ export default function ClustersTable({ headingTarget }: Readonly<Props>) {
             }
             title={"No clusters available"}
             description={
-              "There are no shared clusters connected to your account and no self-hosted clusters configured. Set up a self-hosted cluster to route traffic through your own infrastructure — see the documentation linked above for setup steps."
+              "Set up a self-hosted cluster to route traffic through your own infrastructure."
             }
             button={
               <Button

--- a/templates/reverse-proxy/README.md
+++ b/templates/reverse-proxy/README.md
@@ -1,0 +1,46 @@
+# Reverse Proxy One-Click Deployment Templates
+
+Source templates for the cloud deploy options in the cluster setup modal
+(`src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx`). Everything
+wraps the same contract as the modal's Docker snippet: inject
+`NB_PROXY_TOKEN` + `NB_PROXY_DOMAIN` into the container environment, publish
+443/tcp, 80/tcp, and the WireGuard UDP port.
+
+## AWS CloudFormation (`netbird-proxy-cfn.yaml`)
+
+CloudFormation requires templates to be served from S3 (GitHub raw URLs are
+rejected), so upload on change:
+
+```bash
+aws s3 cp netbird-proxy-cfn.yaml s3://<bucket>/netbird-proxy-cfn.yaml
+```
+
+The `CFN_TEMPLATE_URL` constant in `ClusterCloudDeploy.tsx` must point at that
+object. The dashboard opens the CloudFormation quick-create form with domain
+and management URL pre-filled; the proxy token is entered by the user in the
+AWS console (`NoEcho` parameter, kept out of URLs, logs, and stack outputs).
+
+The template launches one EC2 instance (Ubuntu 24.04 resolved via public SSM
+parameter), a security group for 443/80/WG, an optional Elastic IP, and boots
+the container via cloud-init. SSH stays disabled unless a key pair is given.
+
+## Cloud-init (`netbird-proxy-cloud-init.yaml`)
+
+Canonical bootstrap for VM user data. The Hetzner and DigitalOcean deploy
+flows render this same content inline (see `buildCloudInit` in
+`ClusterCloudDeploy.tsx`) with the proxy token substituted at deploy time —
+keep the two in sync when changing either. Also usable manually:
+
+```bash
+hcloud server create --name netbird-proxy --type cx22 --image ubuntu-24.04 \
+  --user-data-from-file netbird-proxy.rendered.yaml
+```
+
+The token must never be committed or baked into a public image; it is always
+injected at deploy time.
+
+## After deployment
+
+Point the proxy domain's DNS records at the instance's public IP. The proxy
+issues its ACME certificate (tls-alpn-01 on 443) within about a minute and
+registers itself with the management service using the proxy token.

--- a/templates/reverse-proxy/README.md
+++ b/templates/reverse-proxy/README.md
@@ -20,9 +20,13 @@ object. The dashboard opens the CloudFormation quick-create form with domain
 and management URL pre-filled; the proxy token is entered by the user in the
 AWS console (`NoEcho` parameter, kept out of URLs, logs, and stack outputs).
 
-The template launches one EC2 instance (Ubuntu 24.04 resolved via public SSM
+The template launches one EC2 instance (Ubuntu 26.04 resolved via public SSM
 parameter), a security group for 443/80/WG, an optional Elastic IP, and boots
-the container via cloud-init. SSH stays disabled unless a key pair is given.
+the container via Docker Compose from cloud-init. SSH stays disabled unless a
+key pair is given; alternatively an IAM instance profile can be attached
+(existing one by name, or created by the template with SSM Session Manager
+access — creating one requires acknowledging IAM capabilities in the console
+form).
 
 ## Cloud-init (`netbird-proxy-cloud-init.yaml`)
 

--- a/templates/reverse-proxy/netbird-proxy-cfn.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cfn.yaml
@@ -21,6 +21,7 @@ Metadata:
           - WireGuardPort
           - AllocateElasticIP
           - IamInstanceProfile
+          - CreateInstanceRole
           - KeyName
           - SSHAllowedCIDR
     ParameterLabels:
@@ -39,7 +40,9 @@ Metadata:
       AllocateElasticIP:
         default: Allocate a static Elastic IP
       IamInstanceProfile:
-        default: IAM instance profile (optional)
+        default: Existing IAM instance profile (optional)
+      CreateInstanceRole:
+        default: Create IAM role with SSM access
       KeyName:
         default: SSH key pair (optional)
       SSHAllowedCIDR:
@@ -89,7 +92,12 @@ Parameters:
   IamInstanceProfile:
     Type: String
     Default: ""
-    Description: Optional name of an existing IAM instance profile to attach (e.g. for SSM Session Manager access or CloudWatch logging). Leave empty for none.
+    Description: Optional name of an existing IAM instance profile to attach. Takes precedence over CreateInstanceRole. Leave empty for none.
+  CreateInstanceRole:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Create an IAM role and instance profile granting SSM Session Manager access (shell access without SSH). Ignored when an existing instance profile is provided.
   KeyName:
     Type: String
     Default: ""
@@ -101,12 +109,15 @@ Parameters:
     Description: CIDR allowed to reach SSH. Only used when a key pair is set.
   LatestUbuntuAmi:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
-    Description: Resolved automatically to the latest Ubuntu 24.04 AMI. Do not change.
+    Default: /aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+    Description: Resolved automatically to the latest Ubuntu 26.04 AMI. Do not change.
 
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, ""]]
   HasInstanceProfile: !Not [!Equals [!Ref IamInstanceProfile, ""]]
+  CreateRole: !And
+    - !Equals [!Ref CreateInstanceRole, "true"]
+    - !Equals [!Ref IamInstanceProfile, ""]
   UseElasticIP: !Equals [!Ref AllocateElasticIP, "true"]
 
 Resources:
@@ -142,14 +153,40 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-netbird-proxy"
 
+  ProxyInstanceRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRole
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-netbird-proxy"
+
+  ProxyInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Condition: CreateRole
+    Properties:
+      Roles:
+        - !Ref ProxyInstanceRole
+
   ProxyInstance:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref LatestUbuntuAmi
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref AWS::NoValue]
-      IamInstanceProfile:
-        !If [HasInstanceProfile, !Ref IamInstanceProfile, !Ref AWS::NoValue]
+      IamInstanceProfile: !If
+        - HasInstanceProfile
+        - !Ref IamInstanceProfile
+        - !If [CreateRole, !Ref ProxyInstanceProfile, !Ref AWS::NoValue]
       SecurityGroups:
         - !Ref ProxySecurityGroup
       MetadataOptions:
@@ -223,3 +260,7 @@ Outputs:
   InstanceId:
     Description: EC2 instance ID.
     Value: !Ref ProxyInstance
+  InstanceRole:
+    Condition: CreateRole
+    Description: IAM role created for the instance (SSM Session Manager access).
+    Value: !Ref ProxyInstanceRole

--- a/templates/reverse-proxy/netbird-proxy-cfn.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cfn.yaml
@@ -20,6 +20,7 @@ Metadata:
           - InstanceType
           - WireGuardPort
           - AllocateElasticIP
+          - IamInstanceProfile
           - KeyName
           - SSHAllowedCIDR
     ParameterLabels:
@@ -37,6 +38,8 @@ Metadata:
         default: WireGuard UDP port
       AllocateElasticIP:
         default: Allocate a static Elastic IP
+      IamInstanceProfile:
+        default: IAM instance profile (optional)
       KeyName:
         default: SSH key pair (optional)
       SSHAllowedCIDR:
@@ -83,6 +86,10 @@ Parameters:
     Default: "true"
     AllowedValues: ["true", "false"]
     Description: Allocate a static Elastic IP so the DNS record survives instance restarts.
+  IamInstanceProfile:
+    Type: String
+    Default: ""
+    Description: Optional name of an existing IAM instance profile to attach (e.g. for SSM Session Manager access or CloudWatch logging). Leave empty for none.
   KeyName:
     Type: String
     Default: ""
@@ -99,6 +106,7 @@ Parameters:
 
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, ""]]
+  HasInstanceProfile: !Not [!Equals [!Ref IamInstanceProfile, ""]]
   UseElasticIP: !Equals [!Ref AllocateElasticIP, "true"]
 
 Resources:
@@ -140,6 +148,8 @@ Resources:
       ImageId: !Ref LatestUbuntuAmi
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref AWS::NoValue]
+      IamInstanceProfile:
+        !If [HasInstanceProfile, !Ref IamInstanceProfile, !Ref AWS::NoValue]
       SecurityGroups:
         - !Ref ProxySecurityGroup
       MetadataOptions:
@@ -154,7 +164,7 @@ Resources:
         Fn::Base64: !Sub |
           #cloud-config
           write_files:
-            - path: /etc/netbird-proxy/env
+            - path: /opt/netbird-proxy/env
               permissions: "0600"
               content: |
                 NB_PROXY_TOKEN=${ProxyToken}
@@ -167,15 +177,26 @@ Resources:
                 NB_PROXY_LOG_LEVEL=info
                 NB_PROXY_ADDRESS=:443
                 NB_PROXY_WG_PORT=${WireGuardPort}
+            - path: /opt/netbird-proxy/docker-compose.yml
+              permissions: "0644"
+              content: |
+                services:
+                  reverse-proxy:
+                    image: netbirdio/reverse-proxy:${ImageTag}
+                    restart: unless-stopped
+                    ports:
+                      - "80:80"
+                      - "443:443"
+                      - "${WireGuardPort}:${WireGuardPort}/udp"
+                    env_file:
+                      - /opt/netbird-proxy/env
+                    volumes:
+                      - proxy_certs:/certs
+                volumes:
+                  proxy_certs:
           runcmd:
             - curl -fsSL https://get.docker.com | sh
-            - >-
-              docker run -d --name netbird-proxy --restart unless-stopped
-              -p 443:443 -p 80:80
-              -p ${WireGuardPort}:${WireGuardPort}/udp
-              --env-file /etc/netbird-proxy/env
-              -v proxy_certs:/certs
-              netbirdio/reverse-proxy:${ImageTag}
+            - docker compose -f /opt/netbird-proxy/docker-compose.yml up -d
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-netbird-proxy"

--- a/templates/reverse-proxy/netbird-proxy-cfn.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cfn.yaml
@@ -1,0 +1,204 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  NetBird Reverse Proxy - launches a single EC2 instance running the
+  netbirdio/reverse-proxy container with ACME certificates. Point your proxy
+  domain's DNS A record at the instance IP after stack creation.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: NetBird configuration
+        Parameters:
+          - ProxyToken
+          - ProxyDomain
+          - ManagementURL
+          - ImageTag
+      - Label:
+          default: Instance configuration
+        Parameters:
+          - InstanceType
+          - WireGuardPort
+          - AllocateElasticIP
+          - KeyName
+          - SSHAllowedCIDR
+    ParameterLabels:
+      ProxyToken:
+        default: Proxy access token (nbx_...)
+      ProxyDomain:
+        default: Proxy domain
+      ManagementURL:
+        default: Management URL
+      ImageTag:
+        default: Container image tag
+      InstanceType:
+        default: EC2 instance type
+      WireGuardPort:
+        default: WireGuard UDP port
+      AllocateElasticIP:
+        default: Allocate a static Elastic IP
+      KeyName:
+        default: SSH key pair (optional)
+      SSHAllowedCIDR:
+        default: SSH allowed CIDR
+
+Parameters:
+  ProxyToken:
+    Type: String
+    NoEcho: true
+    AllowedPattern: "^nbx_\\S+$"
+    ConstraintDescription: must be a NetBird proxy access token starting with nbx_
+    Description: NetBird proxy access token created in the dashboard (kept out of logs and console output).
+  ProxyDomain:
+    Type: String
+    AllowedPattern: "^[a-zA-Z0-9.-]+$"
+    Description: Public domain the proxy serves, e.g. proxy.example.com. Create a DNS A record for it after the stack is up.
+  ManagementURL:
+    Type: String
+    Default: https://api.netbird.io:443
+    Description: NetBird management service address.
+  ImageTag:
+    Type: String
+    Default: latest
+    Description: netbirdio/reverse-proxy image tag to run.
+  InstanceType:
+    Type: String
+    Default: t3.small
+    AllowedValues:
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - c5.large
+      - c5.xlarge
+    Description: EC2 instance type.
+  WireGuardPort:
+    Type: Number
+    Default: 51820
+    MinValue: 1024
+    MaxValue: 65535
+    Description: UDP port for direct WireGuard connectivity (relay is used as fallback if unreachable).
+  AllocateElasticIP:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: Allocate a static Elastic IP so the DNS record survives instance restarts.
+  KeyName:
+    Type: String
+    Default: ""
+    Description: Optional EC2 key pair name for SSH access. Leave empty to disable SSH entirely.
+  SSHAllowedCIDR:
+    Type: String
+    Default: 0.0.0.0/0
+    AllowedPattern: "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/\\d{1,2}$"
+    Description: CIDR allowed to reach SSH. Only used when a key pair is set.
+  LatestUbuntuAmi:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+    Description: Resolved automatically to the latest Ubuntu 24.04 AMI. Do not change.
+
+Conditions:
+  HasKeyName: !Not [!Equals [!Ref KeyName, ""]]
+  UseElasticIP: !Equals [!Ref AllocateElasticIP, "true"]
+
+Resources:
+  ProxySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: NetBird reverse proxy - HTTPS, ACME HTTP challenge, WireGuard
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: HTTPS and ACME tls-alpn-01
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+          Description: ACME http-01 challenge
+        - IpProtocol: udp
+          FromPort: !Ref WireGuardPort
+          ToPort: !Ref WireGuardPort
+          CidrIp: 0.0.0.0/0
+          Description: WireGuard direct connectivity
+        - !If
+          - HasKeyName
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp: !Ref SSHAllowedCIDR
+            Description: SSH
+          - !Ref AWS::NoValue
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-netbird-proxy"
+
+  ProxyInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref LatestUbuntuAmi
+      InstanceType: !Ref InstanceType
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref AWS::NoValue]
+      SecurityGroups:
+        - !Ref ProxySecurityGroup
+      MetadataOptions:
+        HttpTokens: required
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 20
+            VolumeType: gp3
+            Encrypted: true
+      UserData:
+        Fn::Base64: !Sub |
+          #cloud-config
+          write_files:
+            - path: /etc/netbird-proxy/env
+              permissions: "0600"
+              content: |
+                NB_PROXY_TOKEN=${ProxyToken}
+                NB_PROXY_DOMAIN=${ProxyDomain}
+                NB_PROXY_MANAGEMENT_ADDRESS=${ManagementURL}
+                NB_PROXY_ACME_CERTIFICATES=true
+                NB_PROXY_CERTIFICATE_DIRECTORY=/certs
+                NB_PROXY_ALLOW_INSECURE=true
+                NB_PROXY_PRIVATE=true
+                NB_PROXY_LOG_LEVEL=info
+                NB_PROXY_ADDRESS=:443
+                NB_PROXY_WG_PORT=${WireGuardPort}
+          runcmd:
+            - curl -fsSL https://get.docker.com | sh
+            - >-
+              docker run -d --name netbird-proxy --restart unless-stopped
+              -p 443:443 -p 80:80
+              -p ${WireGuardPort}:${WireGuardPort}/udp
+              --env-file /etc/netbird-proxy/env
+              -v proxy_certs:/certs
+              netbirdio/reverse-proxy:${ImageTag}
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-netbird-proxy"
+
+  ProxyElasticIP:
+    Type: AWS::EC2::EIP
+    Condition: UseElasticIP
+    Properties:
+      InstanceId: !Ref ProxyInstance
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-netbird-proxy"
+
+Outputs:
+  PublicIP:
+    Description: Public IP of the proxy instance. Point your proxy domain's A record here.
+    Value: !If [UseElasticIP, !Ref ProxyElasticIP, !GetAtt ProxyInstance.PublicIp]
+  ProxyURL:
+    Description: URL the proxy will serve once DNS is set and certificates are issued.
+    Value: !Sub "https://${ProxyDomain}"
+  NextStep:
+    Description: What to do after stack creation.
+    Value: !Sub "Create a DNS A record for ${ProxyDomain} pointing to the PublicIP output, then wait ~1 minute for ACME certificate issuance."
+  InstanceId:
+    Description: EC2 instance ID.
+    Value: !Ref ProxyInstance

--- a/templates/reverse-proxy/netbird-proxy-cfn.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cfn.yaml
@@ -221,6 +221,11 @@ Resources:
                   reverse-proxy:
                     image: netbirdio/reverse-proxy:${ImageTag}
                     restart: unless-stopped
+                    logging:
+                      driver: json-file
+                      options:
+                        max-size: "500m"
+                        max-file: "2"
                     ports:
                       - "80:80"
                       - "443:443"

--- a/templates/reverse-proxy/netbird-proxy-cloud-init.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cloud-init.yaml
@@ -1,13 +1,15 @@
 # NetBird Reverse Proxy - canonical cloud-init bootstrap.
 #
 # This is the single source template all provider deployments derive from
-# (Hetzner user_data, AWS CloudFormation UserData, hcloud CLI, Terraform).
-# The environment matches the dashboard's cluster setup snippets exactly.
+# (Hetzner user_data, DigitalOcean user_data, AWS CloudFormation UserData,
+# hcloud CLI, Terraform). The environment matches the dashboard's cluster
+# setup snippets exactly; keep it in sync with buildCloudInit in
+# src/modules/reverse-proxy/clusters/ClusterCloudDeploy.tsx.
 # Placeholders in {{...}} are replaced at deploy time; the token must never
 # be committed or baked into a public image.
 #cloud-config
 write_files:
-  - path: /etc/netbird-proxy/env
+  - path: /opt/netbird-proxy/env
     permissions: "0600"
     content: |
       NB_PROXY_TOKEN={{NB_PROXY_TOKEN}}
@@ -20,12 +22,23 @@ write_files:
       NB_PROXY_LOG_LEVEL=info
       NB_PROXY_ADDRESS=:443
       NB_PROXY_WG_PORT={{NB_PROXY_WG_PORT}}
+  - path: /opt/netbird-proxy/docker-compose.yml
+    permissions: "0644"
+    content: |
+      services:
+        reverse-proxy:
+          image: netbirdio/reverse-proxy:{{IMAGE_TAG}}
+          restart: unless-stopped
+          ports:
+            - "80:80"
+            - "443:443"
+            - "{{NB_PROXY_WG_PORT}}:{{NB_PROXY_WG_PORT}}/udp"
+          env_file:
+            - /opt/netbird-proxy/env
+          volumes:
+            - proxy_certs:/certs
+      volumes:
+        proxy_certs:
 runcmd:
   - curl -fsSL https://get.docker.com | sh
-  - >-
-    docker run -d --name netbird-proxy --restart unless-stopped
-    -p 443:443 -p 80:80
-    -p {{NB_PROXY_WG_PORT}}:{{NB_PROXY_WG_PORT}}/udp
-    --env-file /etc/netbird-proxy/env
-    -v proxy_certs:/certs
-    netbirdio/reverse-proxy:{{IMAGE_TAG}}
+  - docker compose -f /opt/netbird-proxy/docker-compose.yml up -d

--- a/templates/reverse-proxy/netbird-proxy-cloud-init.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cloud-init.yaml
@@ -29,6 +29,11 @@ write_files:
         reverse-proxy:
           image: netbirdio/reverse-proxy:{{IMAGE_TAG}}
           restart: unless-stopped
+          logging:
+            driver: json-file
+            options:
+              max-size: "500m"
+              max-file: "2"
           ports:
             - "80:80"
             - "443:443"

--- a/templates/reverse-proxy/netbird-proxy-cloud-init.yaml
+++ b/templates/reverse-proxy/netbird-proxy-cloud-init.yaml
@@ -1,0 +1,31 @@
+# NetBird Reverse Proxy - canonical cloud-init bootstrap.
+#
+# This is the single source template all provider deployments derive from
+# (Hetzner user_data, AWS CloudFormation UserData, hcloud CLI, Terraform).
+# The environment matches the dashboard's cluster setup snippets exactly.
+# Placeholders in {{...}} are replaced at deploy time; the token must never
+# be committed or baked into a public image.
+#cloud-config
+write_files:
+  - path: /etc/netbird-proxy/env
+    permissions: "0600"
+    content: |
+      NB_PROXY_TOKEN={{NB_PROXY_TOKEN}}
+      NB_PROXY_DOMAIN={{NB_PROXY_DOMAIN}}
+      NB_PROXY_MANAGEMENT_ADDRESS={{NB_PROXY_MANAGEMENT_ADDRESS}}
+      NB_PROXY_ACME_CERTIFICATES=true
+      NB_PROXY_CERTIFICATE_DIRECTORY=/certs
+      NB_PROXY_ALLOW_INSECURE=true
+      NB_PROXY_PRIVATE=true
+      NB_PROXY_LOG_LEVEL=info
+      NB_PROXY_ADDRESS=:443
+      NB_PROXY_WG_PORT={{NB_PROXY_WG_PORT}}
+runcmd:
+  - curl -fsSL https://get.docker.com | sh
+  - >-
+    docker run -d --name netbird-proxy --restart unless-stopped
+    -p 443:443 -p 80:80
+    -p {{NB_PROXY_WG_PORT}}:{{NB_PROXY_WG_PORT}}/udp
+    --env-file /etc/netbird-proxy/env
+    -v proxy_certs:/certs
+    netbirdio/reverse-proxy:{{IMAGE_TAG}}


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-click reverse-proxy cluster deployment UI with a deployment method selector (Docker/Docker Compose/Kubernetes and Hetzner Cloud/DigitalOcean/AWS).
  * Added cloud deployment flows with provider-specific provisioning and live registration/progress checks, plus DNS guidance for cloud setups.
  * Added AWS CloudFormation and canonical cloud-init templates for reverse-proxy provisioning.
* **Bug Fixes**
  * Expanded the outbound connection allowlist for the security policy to include additional cloud/API endpoints.
* **Documentation**
  * Added reverse-proxy one-click deployment template documentation.
* **Chores**
  * Added automation to sync, validate, and test reverse-proxy deployment template changes via CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->