### PR TITLE
Make Agent Network menu available via dashboard_features

### DIFF
--- a/e2e/tests/agent-network-focused-view.spec.ts
+++ b/e2e/tests/agent-network-focused-view.spec.ts
@@ -217,10 +217,14 @@ test.describe.serial("Agent Network focused view @agent-network", () => {
       await expect(navItem(page, "Agent Network")).toBeVisible();
       await expect(navItem(page, "Networks")).toHaveCount(0);
 
-      // The signup source is persisted as the account setting.
+      // The signup source is persisted: focused view plus the Agent Network
+      // menu flag, so turning focus off later keeps access to Agent Network.
       await expect
         .poll(() => captured.putBody?.settings?.agent_network_only)
         .toBe(true);
+      expect(
+        captured.putBody?.settings?.dashboard_features?.agent_network,
+      ).toBe(true);
 
       // The focused view is retained after the write settles.
       await expect(navItem(page, "Networks")).toHaveCount(0);

--- a/e2e/tests/agent-network-focused-view.spec.ts
+++ b/e2e/tests/agent-network-focused-view.spec.ts
@@ -17,6 +17,11 @@ import { loginToApp, navigateTo } from "../helpers/auth";
 
 const SIGNUP_SOURCE_KEY = "netbird-signup-source";
 const AGENT_NETWORK_SOURCE = "netbird.ai";
+// Drives the NETBIRD_AGENT_NETWORK_ONLY / _ENABLED deployment flags against the
+// test build (see testAgentNetworkOverride in utils/netbird.ts).
+const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
+
+type AgentNetworkConfig = "only" | "enabled" | "off";
 
 type AccountMock = {
   // undefined leaves the setting absent (as an un-onboarded account would be).
@@ -86,7 +91,10 @@ function mockAccounts(
 async function openWithAccount(
   browser: Browser,
   account: AccountMock,
-  opts: { signupSource?: boolean } = {},
+  opts: {
+    signupSource?: boolean;
+    agentNetworkConfig?: AgentNetworkConfig;
+  } = {},
 ): Promise<{
   page: Page;
   captured: { putBody?: any };
@@ -103,6 +111,16 @@ async function openWithAccount(
         } catch (e) {}
       },
       [SIGNUP_SOURCE_KEY, AGENT_NETWORK_SOURCE],
+    );
+  }
+  if (opts.agentNetworkConfig) {
+    await context.addInitScript(
+      ([key, value]) => {
+        try {
+          window.localStorage.setItem(key as string, value as string);
+        } catch (e) {}
+      },
+      [AGENT_NETWORK_CONFIG_KEY, opts.agentNetworkConfig],
     );
   }
   const page = await context.newPage();
@@ -263,6 +281,71 @@ test.describe.serial("Agent Network focused view @agent-network", () => {
       await close();
     }
   });
+
+  // Matrix of the two deployment flags (NETBIRD_AGENT_NETWORK_ONLY / _ENABLED,
+  // "off" = neither) crossed with the netbird.ai signup source, with no explicit
+  // account settings. The API defaults agent_network_only to false, so the
+  // deployment flags must still take effect. A present source implies a new
+  // signup (signup_form_pending), which focuses the dashboard optimistically
+  // regardless of the flags.
+  type Expectation = "hidden" | "available" | "focused";
+
+  const ENV_SIGNUP_MATRIX: {
+    env: AgentNetworkConfig;
+    signupSource: boolean;
+    expected: Expectation;
+  }[] = [
+    { env: "off", signupSource: false, expected: "hidden" },
+    { env: "off", signupSource: true, expected: "focused" },
+    { env: "enabled", signupSource: false, expected: "available" },
+    { env: "enabled", signupSource: true, expected: "focused" },
+    { env: "only", signupSource: false, expected: "focused" },
+    { env: "only", signupSource: true, expected: "focused" },
+  ];
+
+  async function expectAgentNetworkState(page: Page, expected: Expectation) {
+    // Peers always renders for an owner, confirming the sidebar loaded.
+    await expect(navItem(page, "Peers")).toBeVisible();
+
+    if (expected === "hidden") {
+      await expect(navItemContaining(page, "Agent Network")).toHaveCount(0);
+      // The regular dashboard stays intact.
+      await expect(navItemContaining(page, "Reverse Proxy")).toBeVisible();
+      return;
+    }
+
+    await expect(navItemContaining(page, "Agent Network")).toBeVisible();
+
+    if (expected === "focused") {
+      for (const label of FOCUS_HIDDEN_NAV) {
+        await expect(navItem(page, label)).toHaveCount(0);
+      }
+      return;
+    }
+
+    // available: the menu shows alongside the regular dashboard.
+    await expect(navItemContaining(page, "Reverse Proxy")).toBeVisible();
+  }
+
+  for (const { env, signupSource, expected } of ENV_SIGNUP_MATRIX) {
+    const sourceLabel = signupSource ? "netbird.ai" : "none";
+    test(`env=${env} signup_source=${sourceLabel} -> ${expected}`, async ({
+      browser,
+    }) => {
+      const { page, close } = await openWithAccount(
+        browser,
+        // A source present means a fresh netbird.ai signup (form still pending);
+        // otherwise a plain account with no agent-network settings.
+        { signupFormPending: signupSource },
+        { agentNetworkConfig: env, signupSource },
+      );
+      try {
+        await expectAgentNetworkState(page, expected);
+      } finally {
+        await close();
+      }
+    });
+  }
 
   test("exposes the focused-view toggle in client settings", async ({
     browser,

--- a/e2e/tests/agent-network-focused-view.spec.ts
+++ b/e2e/tests/agent-network-focused-view.spec.ts
@@ -229,6 +229,29 @@ test.describe.serial("Agent Network focused view @agent-network", () => {
     }
   });
 
+  test("existing netbird.ai account gets dashboard_features, not the focused view", async ({
+    browser,
+  }) => {
+    // An existing account (signup form already submitted) with the netbird.ai
+    // source should have the Agent Network menu made available via
+    // dashboard_features, not the focused agent_network_only view.
+    const { page, captured, close } = await openWithAccount(
+      browser,
+      { signupFormPending: false },
+      { signupSource: true },
+    );
+    try {
+      await expect
+        .poll(
+          () => captured.putBody?.settings?.dashboard_features?.agent_network,
+        )
+        .toBe(true);
+      expect(captured.putBody?.settings?.agent_network_only).not.toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
   test("exposes the focused-view toggle in client settings", async ({
     browser,
   }) => {

--- a/e2e/tests/agent-network-focused-view.spec.ts
+++ b/e2e/tests/agent-network-focused-view.spec.ts
@@ -118,6 +118,13 @@ function navItem(page: Page, text: string) {
     .getByText(text, { exact: true });
 }
 
+// navItemContaining matches a sidebar entry by a substring of its label. Some
+// entries (Agent Network, Reverse Proxy) render a "Beta" badge inside the label
+// when the dashboard is not focused, so exact text matching would miss them.
+function navItemContaining(page: Page, text: string) {
+  return page.getByTestId("left-navigation-item").filter({ hasText: text });
+}
+
 // Regular dashboard sections that the focused view hides (gated on
 // !agentNetworkOnly in Navigation.tsx).
 const FOCUS_HIDDEN_NAV = ["Networks", "Reverse Proxy", "DNS", "Activity"];
@@ -194,11 +201,12 @@ test.describe.serial("Agent Network focused view @agent-network", () => {
       dashboardFeaturesAgentNetwork: true,
     });
     try {
-      // The Agent Network menu is available...
-      await expect(navItem(page, "Agent Network")).toBeVisible();
+      // The Agent Network menu is available (the label carries a "Beta" badge
+      // outside focused mode, so match on the label substring)...
+      await expect(navItemContaining(page, "Agent Network")).toBeVisible();
       // ...but the dashboard is not focused: a regular section that focused
       // mode hides (Reverse Proxy) is still present.
-      await expect(navItem(page, "Reverse Proxy")).toBeVisible();
+      await expect(navItemContaining(page, "Reverse Proxy")).toBeVisible();
     } finally {
       await close();
     }

--- a/e2e/tests/agent-network-focused-view.spec.ts
+++ b/e2e/tests/agent-network-focused-view.spec.ts
@@ -22,6 +22,9 @@ type AccountMock = {
   // undefined leaves the setting absent (as an un-onboarded account would be).
   agentNetworkOnly?: boolean;
   signupFormPending?: boolean;
+  // dashboardFeaturesAgentNetwork sets settings.dashboard_features.agent_network,
+  // which makes the Agent Network menu available without focusing the dashboard.
+  dashboardFeaturesAgentNetwork?: boolean;
 };
 
 // mockAccounts rewrites GET /accounts to inject the focused-view setting and
@@ -50,6 +53,11 @@ function mockAccounts(
         delete body[0].settings.agent_network_only;
       } else {
         body[0].settings.agent_network_only = applied;
+      }
+      if (initial.dashboardFeaturesAgentNetwork !== undefined) {
+        body[0].settings.dashboard_features = {
+          agent_network: initial.dashboardFeaturesAgentNetwork,
+        };
       }
       body[0].onboarding = {
         ...(body[0].onboarding ?? {}),
@@ -174,6 +182,23 @@ test.describe.serial("Agent Network focused view @agent-network", () => {
       // ...and the Agent Network section is gone: the explicit opt-out wins
       // and, without a deployment config flag, the section is not enabled.
       await expect(navItem(page, "Agent Network")).toHaveCount(0);
+    } finally {
+      await close();
+    }
+  });
+
+  test("dashboard_features.agent_network makes the menu available without focusing", async ({
+    browser,
+  }) => {
+    const { page, close } = await openWithAccount(browser, {
+      dashboardFeaturesAgentNetwork: true,
+    });
+    try {
+      // The Agent Network menu is available...
+      await expect(navItem(page, "Agent Network")).toBeVisible();
+      // ...but the dashboard is not focused: a regular section that focused
+      // mode hides (Reverse Proxy) is still present.
+      await expect(navItem(page, "Reverse Proxy")).toBeVisible();
     } finally {
       await close();
     }

--- a/src/cloud/contexts/NetBirdCloudProvider.tsx
+++ b/src/cloud/contexts/NetBirdCloudProvider.tsx
@@ -51,32 +51,44 @@ export const NetBirdCloudProvider = () => {
     } catch (e) {}
   }, []);
 
-  // Apply the netbird.ai signup source once the account is available. Only
-  // new accounts (signup form still pending) are switched to the Agent
-  // Network focused view — a stale flag from an existing user is discarded.
+  // Apply the netbird.ai signup source once the account is available. New
+  // accounts (signup form still pending) get the focused view
+  // (agent_network_only); existing accounts just get the Agent Network menu
+  // made available (dashboard_features.agent_network), leaving the rest of
+  // their dashboard intact.
   useEffect(() => {
     if (!account || signupSourceApplied.current) return;
     try {
       const source = localStorage.getItem(SIGNUP_SOURCE_LOCAL_STORAGE_KEY);
       if (source !== AGENT_NETWORK_SIGNUP_SOURCE) return;
 
-      if (
-        account.onboarding?.signup_form_pending !== true ||
-        account.settings?.agent_network_only === true
-      ) {
+      const isNewAccount = account.onboarding?.signup_form_pending === true;
+      const alreadyApplied = isNewAccount
+        ? account.settings?.agent_network_only === true
+        : account.settings?.dashboard_features?.agent_network === true;
+
+      if (alreadyApplied) {
         localStorage.removeItem(SIGNUP_SOURCE_LOCAL_STORAGE_KEY);
         return;
       }
 
       signupSourceApplied.current = true;
+      const settings = isNewAccount
+        ? { ...account.settings, agent_network_only: true }
+        : {
+            ...account.settings,
+            dashboard_features: {
+              ...account.settings?.dashboard_features,
+              agent_network: true,
+            },
+          };
       notify({
         title: "Agent Network",
-        description: "Agent Network focused view enabled for your account.",
+        description: isNewAccount
+          ? "Agent Network focused view enabled for your account."
+          : "Agent Network enabled for your account.",
         promise: accountRequest(
-          {
-            id: account.id,
-            settings: { ...account.settings, agent_network_only: true },
-          },
+          { id: account.id, settings },
           "/" + account.id,
         ).then(async () => {
           // Revalidate before clearing the source key so the persisted
@@ -87,7 +99,9 @@ export const NetBirdCloudProvider = () => {
           await mutate("/accounts");
           localStorage.removeItem(SIGNUP_SOURCE_LOCAL_STORAGE_KEY);
         }),
-        loadingMessage: "Enabling Agent Network focused view...",
+        loadingMessage: isNewAccount
+          ? "Enabling Agent Network focused view..."
+          : "Enabling Agent Network...",
       });
     } catch (e) {}
   }, [account]);

--- a/src/cloud/contexts/NetBirdCloudProvider.tsx
+++ b/src/cloud/contexts/NetBirdCloudProvider.tsx
@@ -73,15 +73,18 @@ export const NetBirdCloudProvider = () => {
       }
 
       signupSourceApplied.current = true;
-      const settings = isNewAccount
-        ? { ...account.settings, agent_network_only: true }
-        : {
-            ...account.settings,
-            dashboard_features: {
-              ...account.settings?.dashboard_features,
-              agent_network: true,
-            },
-          };
+      // Always enable the Agent Network menu (dashboard_features). New accounts
+      // additionally get the focused view (agent_network_only). Keeping the
+      // menu flag set means that if a focused account later turns the focused
+      // view off, it keeps access to Agent Network rather than losing the menu.
+      const settings = {
+        ...account.settings,
+        dashboard_features: {
+          ...account.settings?.dashboard_features,
+          agent_network: true,
+        },
+        ...(isNewAccount ? { agent_network_only: true } : {}),
+      };
       notify({
         title: "Agent Network",
         description: isNewAccount

--- a/src/interfaces/Account.ts
+++ b/src/interfaces/Account.ts
@@ -36,8 +36,15 @@ export interface Account {
     ipv6_enabled_groups?: string[];
     network_range_v6?: string;
     agent_network_only?: boolean;
+    dashboard_features?: AccountDashboardFeatures;
   };
   onboarding?: AccountOnboarding;
+}
+
+// AccountDashboardFeatures holds per-account dashboard section visibility
+// overrides. Omitted keys follow the default dashboard behavior.
+export interface AccountDashboardFeatures {
+  agent_network?: boolean;
 }
 
 export interface AccountOnboarding {

--- a/src/modules/agent-network/useAgentNetworkMode.ts
+++ b/src/modules/agent-network/useAgentNetworkMode.ts
@@ -48,12 +48,15 @@ export const useAgentNetworkMode = () => {
 
   return useMemo(() => {
     const account = accounts?.[0];
-    // An explicit account setting (true or false) always wins so a user can
-    // opt out even when the deployment config enables focused mode. Only when
-    // the setting is absent do signup optimism and deployment config apply.
+    // Deployment config is a floor: NETBIRD_AGENT_NETWORK_ONLY focuses the
+    // dashboard regardless of the per-account setting. The management API always
+    // serializes agent_network_only (defaulting to false), so a false value
+    // can't be read as "unset" — without this floor it would silently override
+    // the env flag. When the config flag is off (e.g. cloud) the per-account
+    // setting decides, so a user can still opt in via signup or the toggle.
     const setting = account?.settings?.agent_network_only;
     const only =
-      setting ?? (isAgentNetworkSignupPending(account) || isAgentNetworkOnly());
+      isAgentNetworkOnly() || (setting ?? isAgentNetworkSignupPending(account));
     // dashboard_features.agent_network makes the Agent Network menu available
     // alongside the full dashboard (unlike "only", which hides everything else).
     const featureEnabled =

--- a/src/modules/agent-network/useAgentNetworkMode.ts
+++ b/src/modules/agent-network/useAgentNetworkMode.ts
@@ -54,7 +54,11 @@ export const useAgentNetworkMode = () => {
     const setting = account?.settings?.agent_network_only;
     const only =
       setting ?? (isAgentNetworkSignupPending(account) || isAgentNetworkOnly());
-    const enabled = only || isAgentNetworkEnabled();
+    // dashboard_features.agent_network makes the Agent Network menu available
+    // alongside the full dashboard (unlike "only", which hides everything else).
+    const featureEnabled =
+      account?.settings?.dashboard_features?.agent_network === true;
+    const enabled = only || featureEnabled || isAgentNetworkEnabled();
     const loading = permission.accounts.read ? isLoading : false;
     return { only, enabled, loading } as const;
   }, [accounts, isLoading, permission.accounts.read]);

--- a/src/utils/netbird.ts
+++ b/src/utils/netbird.ts
@@ -71,10 +71,35 @@ export const hasLicensedFlag = () => {
   return config.licensed || isNetBirdCloud();
 };
 
+// testAgentNetworkOverride lets e2e tests drive the deployment flags
+// NETBIRD_AGENT_NETWORK_ONLY / NETBIRD_AGENT_NETWORK_ENABLED against the test
+// build via localStorage. "off" forces both flags off regardless of the build
+// config. Inert outside test builds, where the APP_ENV check is replaced at
+// compile time and tree-shaken away.
+export const testAgentNetworkOverride = ():
+  | "only"
+  | "enabled"
+  | "off"
+  | undefined => {
+  if (process.env.APP_ENV !== "test") return undefined;
+  if (typeof window === "undefined") return undefined;
+  try {
+    const value = window.localStorage.getItem("netbird-test-agent-network");
+    if (value === "only" || value === "enabled" || value === "off") {
+      return value;
+    }
+  } catch (e) {
+    return undefined;
+  }
+  return undefined;
+};
+
 // isAgentNetworkOnly returns true for the dedicated Agent Network surface:
 // the regular UI (network routing, DNS, reverse proxy, activity) is hidden and
 // the Agent Network menu shows without a Beta badge.
 export const isAgentNetworkOnly = () => {
+  const override = testAgentNetworkOverride();
+  if (override) return override === "only";
   return config.agentNetworkOnly;
 };
 
@@ -91,6 +116,8 @@ export const pkgsDownloadUrl = (path: string) =>
 // (Providers, Policies, Usage & Logs) is available — in either the dedicated
 // "only" mode or alongside the regular UI (where it carries a Beta badge).
 export const isAgentNetworkEnabled = () => {
+  const override = testAgentNetworkOverride();
+  if (override) return override === "only" || override === "enabled";
   return config.agentNetworkEnabled || config.agentNetworkOnly;
 };
 


### PR DESCRIPTION
## Issue ticket number and link

<!-- internal: make the Agent Network menu available to existing accounts -->

Adds dashboard support for the `dashboard_features` account setting
(backend: netbirdio/netbird#6742, merged) and extends the netbird.ai signup
flow to existing accounts. No settings-menu UI.

**Signup source now branches on account existence**
The merged flow only handled new accounts (set `agent_network_only`) and
discarded the source for existing ones. It now checks `signup_form_pending`:
- **New** account → `agent_network_only=true` (focused view) **and**
  `dashboard_features.agent_network=true`.
- **Existing** account → `dashboard_features.agent_network=true` (Agent Network
  menu made available, full dashboard kept).

Both paths set `dashboard_features.agent_network`. Setting it on new accounts
too means that if a focused account later turns the focused view off, it keeps
access to the Agent Network menu rather than losing it entirely (since the menu
would otherwise depend on `agent_network_only`).

There is no dashboard UI to write `dashboard_features` — it is set only by this
onboarding flow (the Client Settings toggle only controls `agent_network_only`).

**Mode resolution**
- `Account.settings.dashboard_features` added to the interface (settings updates
  round-trip it).
- `useAgentNetworkMode()` treats `dashboard_features.agent_network === true` as
  **enabling** the Agent Network menu — it feeds `enabled`, not `only`, so
  unlike `agent_network_only` it does not focus/hide the rest of the dashboard.

**No onboarding change:** the onboarding decision keys off `only` (+ signup
source), so a menu-available (existing) account gets the menu and reachable
Agent Network routes but no onboarding takeover. Onboarding for existing
accounts is a deliberate follow-up (they have no pending onboarding flags).

**Tests (e2e)**
- `dashboard_features.agent_network` makes the Agent Network menu available
  while leaving the regular dashboard (Reverse Proxy) intact — enabled, not
  focused.
- An existing netbird.ai account is marked with `dashboard_features`
  (`agent_network=true`), not `agent_network_only`.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

API-level plumbing of an account setting with no new user-facing UI; the
focused-view behavior and toggle are already documented (netbirdio/docs#848).

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account-level dashboard feature override to control whether the Agent Network section is available.
  * Agent Network can now be enabled independently of the Agent Network-only focused dashboard mode.
* **Bug Fixes**
  * Improved Agent Network availability logic to combine deployment and per-account settings correctly.
  * Updated onboarding behavior so existing accounts can enable Agent Network without losing other sidebar sections (e.g., Reverse Proxy).
* **Tests**
  * Added/expanded serial end-to-end coverage for menu visibility and for persisting the correct Agent Network settings during signup-source onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->