### PR TITLE
Show RDP for Linux and FreeBSD peers and harden the browser RDP client

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: netbirdio/IronRDP
-          latest: true
+          tag: v0.0.2
           fileName: "*.ts"
           out-file-path: 'public/ironrdp-pkg'
 
@@ -48,7 +48,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: netbirdio/IronRDP
-          latest: true
+          tag: v0.0.2
           fileName: "*.js"
           out-file-path: 'public/ironrdp-pkg'
 
@@ -57,7 +57,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: netbirdio/IronRDP
-          latest: true
+          tag: v0.0.2
           fileName: "ironrdp_web_bg.wasm"
           out-file-path: 'public/ironrdp-pkg'
 

--- a/src/app/(remote-access)/peer/rdp/page.tsx
+++ b/src/app/(remote-access)/peer/rdp/page.tsx
@@ -7,6 +7,8 @@ import useFetchApi from "@utils/api";
 import { Loader2Icon } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { Peer } from "@/interfaces/Peer";
+import { getOperatingSystem } from "@hooks/useOperatingSystem";
+import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import { RDPCertificateModal } from "@/modules/remote-access/rdp/RDPCertificateModal";
 import { RDPCredentialsModal } from "@/modules/remote-access/rdp/RDPCredentialsModal";
 import { useRDPQueryParams } from "@/modules/remote-access/rdp/useRDPQueryParams";
@@ -138,6 +140,8 @@ function RDPSession({ peer }: Props) {
         domain: credentials.domain,
         width: window.innerWidth,
         height: window.innerHeight,
+        dynamicResize:
+          getOperatingSystem(peer?.os) === OperatingSystem.WINDOWS,
       });
       if (result === RDPStatus.CONNECTED) {
         connected.current = true;
@@ -182,7 +186,18 @@ function RDPSession({ peer }: Props) {
     if (client.error) {
       sendErrorNotification("NetBird Client Error", client.error);
     }
-  }, [rdp, client]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rdp.error, client.error]);
+
+  /**
+   * Return to the credentials screen when an established session drops with an
+   * error, so the user can see what happened and retry.
+   */
+  useEffect(() => {
+    if (connected.current && rdp.error) {
+      reset();
+    }
+  }, [rdp.error, reset]);
 
   /**
    * Close credentials modal when RDP is connected

--- a/src/modules/remote-access/rdp/RDPButton.tsx
+++ b/src/modules/remote-access/rdp/RDPButton.tsx
@@ -3,26 +3,30 @@ import { DropdownMenuItem } from "@components/DropdownMenu";
 import { getOperatingSystem } from "@hooks/useOperatingSystem";
 import { CircleHelpIcon, MonitorIcon } from "lucide-react";
 import * as React from "react";
-import { useState } from "react";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import { Peer } from "@/interfaces/Peer";
 import { RDPTooltip } from "@/modules/remote-access/rdp/RDPTooltip";
-import { SSHCredentialsModal } from "@/modules/remote-access/ssh/SSHCredentialsModal";
 
 type Props = {
   peer: Peer;
   isDropdown?: boolean;
 };
 
+const RDP_SUPPORTED_OS = new Set([
+  OperatingSystem.WINDOWS,
+  OperatingSystem.LINUX,
+  OperatingSystem.FREEBSD,
+]);
+
 export const RDPButton = ({ peer, isDropdown = false }: Props) => {
-  const [modal, setModal] = useState(false);
   const { permission } = usePermissions();
+
+  const os = getOperatingSystem(peer?.os);
+  if (!RDP_SUPPORTED_OS.has(os)) return null;
 
   const disabled = !peer.connected || !permission.peers.update;
   const hasPermission = permission.peers.update;
-
-  const isWindows = getOperatingSystem(peer?.os) === OperatingSystem.WINDOWS;
 
   const openRDPPage = () => {
     window.open(
@@ -33,40 +37,36 @@ export const RDPButton = ({ peer, isDropdown = false }: Props) => {
   };
 
   return (
-    isWindows && (
-      <>
-        <div>
-          <RDPTooltip
-            disabled={!disabled}
-            hasPermission={hasPermission}
-            side={isDropdown ? "left" : "top"}
+    <div>
+      <RDPTooltip
+        disabled={!disabled}
+        hasPermission={hasPermission}
+        side={isDropdown ? "left" : "top"}
+      >
+        {isDropdown ? (
+          <DropdownMenuItem
+            onClick={openRDPPage}
+            disabled={disabled}
+            className={"w-full"}
           >
-            {isDropdown ? (
-              <DropdownMenuItem
-                onClick={openRDPPage}
-                disabled={disabled}
-                className={"w-full"}
-              >
-                <div className={"flex gap-3 items-center w-full"}>
-                  <MonitorIcon size={14} className={"shrink-0"} />
-                  RDP
-                </div>
-              </DropdownMenuItem>
-            ) : (
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={openRDPPage}
-                disabled={disabled}
-              >
-                <MonitorIcon size={16} />
-                RDP
-                {disabled && <CircleHelpIcon size={12} />}
-              </Button>
-            )}
-          </RDPTooltip>
-        </div>
-      </>
-    )
+            <div className={"flex gap-3 items-center w-full"}>
+              <MonitorIcon size={14} className={"shrink-0"} />
+              RDP
+            </div>
+          </DropdownMenuItem>
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={openRDPPage}
+            disabled={disabled}
+          >
+            <MonitorIcon size={16} />
+            RDP
+            {disabled && <CircleHelpIcon size={12} />}
+          </Button>
+        )}
+      </RDPTooltip>
+    </div>
   );
 };

--- a/src/modules/remote-access/rdp/RDPCredentialsModal.tsx
+++ b/src/modules/remote-access/rdp/RDPCredentialsModal.tsx
@@ -3,6 +3,8 @@ import { useCallback, useMemo, useState } from "react";
 import { Modal, ModalContent, ModalFooter } from "@components/modal/Modal";
 import ModalHeader from "@components/modal/ModalHeader";
 import { Peer } from "@/interfaces/Peer";
+import { getOperatingSystem } from "@hooks/useOperatingSystem";
+import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import {
   ChevronsLeftRightEllipsis,
   ExternalLinkIcon,
@@ -38,7 +40,11 @@ export const RDPCredentialsModal = ({
   error,
   loading,
 }: Props) => {
-  const [username, setUsername] = useState("Administrator");
+  const defaultUsername =
+    getOperatingSystem(peer?.os) === OperatingSystem.WINDOWS
+      ? "Administrator"
+      : "root";
+  const [username, setUsername] = useState(defaultUsername);
   const [password, setPassword] = useState("");
 
   const [port, setPort] = useState("3389");

--- a/src/modules/remote-access/rdp/ironrdp-wasm-bridge.ts
+++ b/src/modules/remote-access/rdp/ironrdp-wasm-bridge.ts
@@ -2,12 +2,17 @@ export interface IronRDPModule {
   SessionBuilder: new () => SessionBuilder;
   DesktopSize: new (width: number, height: number) => DesktopSize;
   ClipboardData?: new () => ClipboardData;
+  Extension?: new (ident: string, value: unknown) => Extension;
   default?: () => Promise<void>;
   init?: () => Promise<void>;
+  setup?: (logLevel: string) => void;
 }
 interface DesktopSize {
   width: number;
   height: number;
+}
+interface Extension {
+  free(): void;
 }
 interface SessionBuilder {
   username(user: string): SessionBuilder;
@@ -18,6 +23,7 @@ interface SessionBuilder {
   renderCanvas(canvas: HTMLCanvasElement): SessionBuilder;
   proxyAddress(url: string): SessionBuilder;
   authToken(token: string): SessionBuilder;
+  extension(ext: Extension): SessionBuilder;
   setCursorStyleCallback(cb: (style: string) => void): void;
   setCursorStyleCallbackContext(ctx: unknown): void;
   remoteClipboardChangedCallback(cb: (data: ClipboardData) => void): void;
@@ -28,6 +34,13 @@ export interface RDPSession {
   run(): Promise<TerminationInfo>;
   shutdown(): void;
   sendInput(input: unknown): void;
+  resize(
+    width: number,
+    height: number,
+    scaleFactor?: number | null,
+    physicalWidth?: number | null,
+    physicalHeight?: number | null,
+  ): void;
   onClipboardPaste?(content: ClipboardData): Promise<void>;
 }
 interface TerminationInfo {
@@ -67,6 +80,30 @@ declare global {
 
 const IRON_RDP_PKG = "/ironrdp-pkg/ironrdp_web.js";
 
+// IronErrorKind values as exposed by the IronRDP wasm module's kind() method,
+// indexed by the enum's numeric value.
+const IRON_ERROR_KIND_NAMES = [
+  "General",
+  "WrongPassword",
+  "LogonFailure",
+  "AccessDenied",
+  "RDCleanPath",
+  "ProxyConnect",
+  "NegotiationFailure",
+] as const;
+
+// User-facing message per error kind. "General" is intentionally absent: it
+// carries no structured detail, so its reason is read from the backtrace.
+const IRON_ERROR_KIND_MESSAGES: Record<string, string> = {
+  WrongPassword: "Incorrect username or password.",
+  LogonFailure: "Login failed. Check your username and password.",
+  AccessDenied: "The remote host denied access.",
+  RDCleanPath: "Could not establish the RDP connection to the host.",
+  ProxyConnect: "Could not reach the remote host.",
+  NegotiationFailure:
+    "RDP negotiation failed. The host may not support the required security protocol.",
+};
+
 export class IronRDPWASMBridge {
   private ironrdp: IronRDPModule | null = null;
   private initialized = false;
@@ -91,6 +128,13 @@ export class IronRDPWASMBridge {
           await ironrdpModule.init();
         }
       }
+      if (ironrdpModule.setup) {
+        try {
+          ironrdpModule.setup("info");
+        } catch (e) {
+          console.warn("IronRDP log setup failed:", e);
+        }
+      }
       this.ironrdp = ironrdpModule;
       this.initialized = true;
       if (window.onIronRDPReady) {
@@ -112,6 +156,8 @@ export class IronRDPWASMBridge {
     netbirdClient?: {
       createRDPProxy: (hostname: string, port: string) => Promise<string>;
     },
+    onSessionEnd?: (error: string | null) => void,
+    enableDisplayControl = false,
   ): Promise<string> {
     if (!this.initialized) {
       await this.initialize();
@@ -144,6 +190,15 @@ export class IronRDPWASMBridge {
         config.height,
       );
       builder.desktopSize(desktopSize);
+
+      // Enable the Display Control dynamic channel so the desktop can be
+      // resized in-session (Session.resize) instead of reconnecting. Gated to
+      // hosts known to handle it (Windows); xrdp mishandles the reactivation.
+      if (enableDisplayControl && this.ironrdp.Extension) {
+        builder.extension(
+          new this.ironrdp.Extension("display_control", true),
+        );
+      }
       if (canvas) {
         const ctx = canvas.getContext("2d");
         if (ctx) {
@@ -172,7 +227,7 @@ export class IronRDPWASMBridge {
       if (enableClipboard) {
         this.startClipboardEventListeners();
       }
-      this.startSession(session, sessionId);
+      this.startSession(session, sessionId, onSessionEnd);
       return sessionId;
     } catch (error) {
       console.error(`IronRDP connection failed:`, error);
@@ -193,16 +248,22 @@ export class IronRDPWASMBridge {
     });
   }
 
-  private startSession(session: RDPSession, sessionId: string): void {
+  private startSession(
+    session: RDPSession,
+    sessionId: string,
+    onSessionEnd?: (error: string | null) => void,
+  ): void {
     session
       .run()
       .then((termInfo) => {
         this.cleanupSession(session, sessionId);
+        onSessionEnd?.(null);
       })
       .catch((err) => {
         console.error("IronRDP session error:", err);
+        this.logIronError(err);
         this.cleanupSession(session, sessionId);
-        throw Error(err);
+        onSessionEnd?.(this.getReadableError(err));
       });
   }
   private cleanupSession(session: RDPSession, sessionId: string): void {
@@ -282,11 +343,24 @@ export class IronRDPWASMBridge {
 
   private getReadableError(error: unknown): string {
     const ironError = error as any;
-    if (typeof ironError?.backtrace === "function") {
+    if (ironError && ironError.__wbg_ptr) {
       try {
-        const formatted = this.formatRDCleanPathError(ironError.backtrace());
-        if (formatted.startsWith("Connection failed:")) {
-          return formatted;
+        if (typeof ironError.kind === "function") {
+          const kindName = IRON_ERROR_KIND_NAMES[ironError.kind()];
+          if (kindName && IRON_ERROR_KIND_MESSAGES[kindName]) {
+            return IRON_ERROR_KIND_MESSAGES[kindName];
+          }
+        }
+        if (typeof ironError.backtrace === "function") {
+          const backtrace = ironError.backtrace();
+          const formatted = this.formatRDCleanPathError(backtrace);
+          if (formatted.startsWith("Connection failed:")) {
+            return formatted;
+          }
+          const reason = this.extractIronReason(backtrace);
+          if (reason) {
+            return `RDP session error: ${reason}`;
+          }
         }
       } catch {
         // Fall through to generic handling below.
@@ -296,6 +370,19 @@ export class IronRDPWASMBridge {
       return error.message;
     }
     return "RDP connection failed";
+  }
+
+  // extractIronReason pulls the human-readable reason out of an IronRDP
+  // backtrace like `[IO channel] reason: unhandled PDU: "Update PDU"`. The
+  // wasm error has no structured field for this, so General-kind errors can
+  // only expose it as free text.
+  private extractIronReason(backtrace: string): string {
+    if (!backtrace) return "";
+    const reasonMatch = backtrace.match(/reason:\s*(.+)/);
+    if (reasonMatch) {
+      return reasonMatch[1].trim();
+    }
+    return backtrace.replace(/^\[[^\]]*\]\s*/, "").trim();
   }
 
   private logIronError(error: unknown): void {
@@ -310,16 +397,7 @@ export class IronRDPWASMBridge {
       }
       if (ironError.kind) {
         const errorKind = ironError.kind();
-        const errorKindNames = [
-          "General",
-          "WrongPassword",
-          "LogonFailure",
-          "AccessDenied",
-          "RDCleanPath",
-          "ProxyConnect",
-          "NegotiationFailure",
-        ];
-        const errorKindName = errorKindNames[errorKind] || "Unknown";
+        const errorKindName = IRON_ERROR_KIND_NAMES[errorKind] || "Unknown";
         console.error("IronRDP error kind:", errorKindName, `(${errorKind})`);
       }
     } catch (e) {
@@ -328,6 +406,12 @@ export class IronRDPWASMBridge {
   }
   getSession(sessionId: string): RDPSession | null {
     return this.sessions.get(sessionId) || null;
+  }
+
+  resize(sessionId: string, width: number, height: number): void {
+    const session = this.sessions.get(sessionId);
+    if (!session || typeof session.resize !== "function") return;
+    session.resize(width, height);
   }
 
   disconnect(sessionId: string): void {

--- a/src/modules/remote-access/rdp/ironrdp-wasm-bridge.ts
+++ b/src/modules/remote-access/rdp/ironrdp-wasm-bridge.ts
@@ -156,7 +156,7 @@ export class IronRDPWASMBridge {
     netbirdClient?: {
       createRDPProxy: (hostname: string, port: string) => Promise<string>;
     },
-    onSessionEnd?: (error: string | null) => void,
+    onSessionEnd?: (error: string | null, sessionId: string) => void,
     enableDisplayControl = false,
   ): Promise<string> {
     if (!this.initialized) {
@@ -251,19 +251,19 @@ export class IronRDPWASMBridge {
   private startSession(
     session: RDPSession,
     sessionId: string,
-    onSessionEnd?: (error: string | null) => void,
+    onSessionEnd?: (error: string | null, sessionId: string) => void,
   ): void {
     session
       .run()
       .then((termInfo) => {
         this.cleanupSession(session, sessionId);
-        onSessionEnd?.(null);
+        onSessionEnd?.(null, sessionId);
       })
       .catch((err) => {
         console.error("IronRDP session error:", err);
         this.logIronError(err);
         this.cleanupSession(session, sessionId);
-        onSessionEnd?.(this.getReadableError(err));
+        onSessionEnd?.(this.getReadableError(err), sessionId);
       });
   }
   private cleanupSession(session: RDPSession, sessionId: string): void {

--- a/src/modules/remote-access/rdp/useRemoteDesktop.ts
+++ b/src/modules/remote-access/rdp/useRemoteDesktop.ts
@@ -13,6 +13,10 @@ interface RDPConfig {
   domain?: string;
   width?: number;
   height?: number;
+  // dynamicResize enables the Display Control channel and in-session resize.
+  // Only reliable against Windows hosts; xrdp mishandles the reactivation, so
+  // non-Windows peers fall back to reconnect-on-resize.
+  dynamicResize?: boolean;
 }
 
 export interface RDPCredentials {
@@ -186,6 +190,11 @@ export const useRemoteDesktop = (client: any) => {
             canvas,
             true,
             client.client,
+            (sessionError: string | null) => {
+              resetState();
+              if (sessionError) setError(sessionError);
+            },
+            rdpConfig.dynamicResize ?? false,
           );
 
           // Store the ironrdp module and session for the input handler hook
@@ -265,7 +274,9 @@ export const useRemoteDesktop = (client: any) => {
   }, []);
 
   /**
-   * Handle window resize events - reconnect with new dimensions
+   * Handle window resize events. Hosts that support the Display Control channel
+   * (Windows) resize the live session in place; others reconnect with the new
+   * dimensions.
    */
   useEffect(() => {
     const handleResize = () => {
@@ -277,6 +288,31 @@ export const useRemoteDesktop = (client: any) => {
       // Clear any existing timeout
       if (resizeTimeoutRef.current) {
         clearTimeout(resizeTimeoutRef.current);
+      }
+
+      if (lastConnectedConfigRef.current.dynamicResize) {
+        // In-session resize via Display Control, no reconnect.
+        resizeTimeoutRef.current = setTimeout(() => {
+          const width = window.innerWidth;
+          const height = window.innerHeight;
+
+          if (canvasRef.current) {
+            canvasRef.current.width = width;
+            canvasRef.current.height = height;
+          }
+
+          if (session.current && client?.ironRDPBridge) {
+            client.ironRDPBridge.resize(session.current.id, width, height);
+          }
+
+          lastConnectedConfigRef.current = {
+            ...lastConnectedConfigRef.current!,
+            width,
+            height,
+          };
+          canvasRef?.current?.focus();
+        }, 200);
+        return;
       }
 
       setIsResizing(true);
@@ -317,7 +353,7 @@ export const useRemoteDesktop = (client: any) => {
         clearTimeout(resizeTimeoutRef.current);
       }
     };
-  }, [status, connect]);
+  }, [status, connect, client]);
 
   /**
    * Auto accept certificate if previously accepted (for reconnects)

--- a/src/modules/remote-access/rdp/useRemoteDesktop.ts
+++ b/src/modules/remote-access/rdp/useRemoteDesktop.ts
@@ -190,7 +190,10 @@ export const useRemoteDesktop = (client: any) => {
             canvas,
             true,
             client.client,
-            (sessionError: string | null) => {
+            (sessionError: string | null, endedSessionId: string) => {
+              // Ignore terminations from superseded sessions (e.g. a resize
+              // reconnect) so they can't tear down a newer connection.
+              if (endedSessionId !== session.current?.id) return;
               resetState();
               if (sessionError) setError(sessionError);
             },


### PR DESCRIPTION
## Issue ticket number and link

Fixes #616

Shows the RDP button for Linux and FreeBSD peers (previously Windows-only) and hardens the browser RDP client's error handling and resize behavior.

- Render the RDP button for Windows, Linux, and FreeBSD peers instead of Windows only
- Surface RDP session errors as a notification and return to the connect screen instead of leaving a blank window
- Show readable IronRDP error messages, mapping the error kind to a clear message
- Default the connect username per OS (Administrator on Windows, root otherwise)
- Resize the live session in place on Windows via the Display Control channel, falling back to reconnect on other hosts
- Pin the IronRDP WASM package to the 0.0.2 release

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The docs already state RDP has no OS restriction; this aligns the UI with that.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - RDP actions are now available for Windows, Linux, and FreeBSD hosts (not Windows-only).
  - Added optional dynamic in-session display resizing to reduce reconnects during window resizing.
  - RDP credentials now default to **“Administrator”** on Windows and **“root”** on other supported systems.

- **Bug Fixes**
  - Improved RDP session error handling with clearer error messages and automatic recovery back to the credentials screen for retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->