### PR TITLE
doc: add restart policy to Docker NetBird installation

### DIFF
--- a/src/modules/setup-netbird-modal/DockerTab.tsx
+++ b/src/modules/setup-netbird-modal/DockerTab.tsx
@@ -59,7 +59,7 @@ export default function DockerTab({
               {showSetupKeyInfo && <RoutingPeerSetupKeyInfo />}
             </p>
             <Code>
-              <Code.Line>docker run --rm -d \</Code.Line>
+              <Code.Line>docker run -d \</Code.Line>
               <Code.Line> --cap-add=NET_ADMIN \</Code.Line>
               <Code.Line> --restart unless-stopped \</Code.Line>
               <Code.Line>

--- a/src/modules/setup-netbird-modal/DockerTab.tsx
+++ b/src/modules/setup-netbird-modal/DockerTab.tsx
@@ -61,6 +61,7 @@ export default function DockerTab({
             <Code>
               <Code.Line>docker run --rm -d \</Code.Line>
               <Code.Line> --cap-add=NET_ADMIN \</Code.Line>
+              <Code.Line> --restart unless-stopped \</Code.Line>
               <Code.Line>
                 {" "}
                 -e NB_SETUP_KEY=


### PR DESCRIPTION
Hi there

Little documentation improvement for the running command of Docker container for NetBird
I realize with a friend installation that, by default there is no restart policy in the command provided by the helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the Docker setup command to automatically restart the NetBird container unless it is explicitly stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->