### PR TITLE
[agent-network] per-provider disable-metadata toggle

### DIFF
--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -1254,8 +1254,11 @@ export default function AIProviderModal({
           <div className={"w-full"}>
             <Paragraph className={"text-sm mt-auto"}>
               Learn more about
-              <InlineLink href={"https://docs.netbird.io/"} target={"_blank"}>
-                Agent Network
+              <InlineLink
+                href={"https://docs.netbird.io/agent-network/providers"}
+                target={"_blank"}
+              >
+                Agent Network Providers
                 <ExternalLinkIcon size={12} />
               </InlineLink>
             </Paragraph>

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -273,7 +273,8 @@ export default function AIProviderModal({
     providerId === "bifrost" ||
     providerId === "cloudflare_ai_gateway" ||
     providerId === "vercel_ai_gateway" ||
-    providerId === "openrouter";
+    providerId === "openrouter" ||
+    providerId === "bedrock_api";
 
   // If the user flips provider type while viewing the Mappings tab and
   // the new type doesn't show mappings, snap back to the Provider tab
@@ -1036,6 +1037,41 @@ export default function AIProviderModal({
                 >
                   <MappingRow header={"_user"} sourceLabel={"User Email"} />
                   <MappingRow header={"groups"} sourceLabel={"Groups"} />
+                </div>
+              </div>
+            </TabsContent>
+          )}
+
+          {showMappings && providerId === "bedrock_api" && (
+            <TabsContent value={"mappings"} className={"pb-8"}>
+              <div className={"px-8 pt-3 flex-col flex gap-4"}>
+                <div>
+                  <Label>Identity Metadata</Label>
+                  <HelpText className={"mb-0"}>
+                    NetBird stamps the{" "}
+                    <code
+                      className={
+                        "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
+                      }
+                    >
+                      X-Amzn-Bedrock-Request-Metadata
+                    </code>{" "}
+                    header with a JSON object carrying the caller&apos;s
+                    identity, so you can break Bedrock spend down by user and
+                    group with AWS cost-allocation tags. The proxy strips any
+                    client-supplied value first, so an app can&apos;t spoof
+                    identity. Values are sanitized to Bedrock&apos;s accepted
+                    character set. The mapping is fixed.
+                  </HelpText>
+                </div>
+
+                <div
+                  className={
+                    "rounded-md overflow-hidden border border-nb-gray-900 bg-nb-gray-920/30"
+                  }
+                >
+                  <MappingRow header={"user"} sourceLabel={"User Email"} />
+                  <MappingRow header={"group"} sourceLabel={"Groups"} />
                 </div>
               </div>
             </TabsContent>

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -793,6 +793,23 @@ export default function AIProviderModal({
           {showMappings && providerId === "litellm_proxy" && (
             <TabsContent value={"mappings"} className={"pb-8"}>
               <div className={"px-8 pt-3 flex-col flex gap-4"}>
+                {/* The forwarding toggle sits first: it gates the identity
+                    mappings described below, so turning it off makes the fixed
+                    mapping that follows moot. */}
+                <FancyToggleSwitch
+                  value={!metadataDisabled}
+                  onChange={(v) => setMetadataDisabled(!v)}
+                  label={
+                    <>
+                      <ArrowRightLeft size={15} />
+                      Forward Identity Metadata
+                    </>
+                  }
+                  helpText={
+                    "Stamp the identity mappings below onto LiteLLM requests."
+                  }
+                />
+
                 <div>
                   <Label>Identity Mappings</Label>
                   <HelpText className={"mb-0"}>

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -225,14 +225,6 @@ export default function AIProviderModal({
   // Custom-kind providers (the generic "Custom" entry and named self-hosted
   // ones like vLLM) share the self-hosted extras, e.g. Skip TLS verification.
   const isCustomKind = catalog?.kind === "custom";
-  // injectsIdentity is true only for providers whose catalog entry declares an
-  // identity shape (HeaderPair or JSONMetadata) — i.e. the ones NetBird actually
-  // stamps the caller's identity onto. The metadata toggle is meaningless for
-  // the rest (plain OpenAI/Anthropic/Azure/Vertex/Mistral, vLLM, custom), so it
-  // is hidden for them.
-  const injectsIdentity =
-    !!catalog?.identity_injection?.header_pair ||
-    !!catalog?.identity_injection?.json_metadata;
   const customizableHeaderPair =
     catalog?.identity_injection?.header_pair?.customizable === true;
   const customizableJsonMetadata =
@@ -672,45 +664,6 @@ export default function AIProviderModal({
                 />
               )}
 
-              {injectsIdentity && (
-                <FancyToggleSwitch
-                  value={!metadataDisabled}
-                  onChange={(v) => setMetadataDisabled(!v)}
-                  label={
-                    <>
-                      <ArrowRightLeft size={15} />
-                      Forward identity metadata
-                      <span onClick={(e) => e.stopPropagation()}>
-                        <HelpTooltip
-                          interactive
-                          content={
-                            <>
-                              Forwards the caller&apos;s user and authorizing group
-                              to the provider as metadata (e.g. AWS Bedrock&apos;s
-                              X-Amzn-Bedrock-Request-Metadata header for cost
-                              allocation), so it can attribute usage to the real
-                              caller. Turn off to stop sending it.{" "}
-                              <InlineLink
-                                href={
-                                  "https://docs.netbird.io/agent-network/providers#identity-metadata"
-                                }
-                                target={"_blank"}
-                              >
-                                Learn more
-                                <ExternalLinkIcon size={12} />
-                              </InlineLink>
-                            </>
-                          }
-                        />
-                      </span>
-                    </>
-                  }
-                  helpText={
-                    "Forward the caller's user and authorizing group to this provider."
-                  }
-                />
-              )}
-
               {providerId === "vertex_ai_api" ? (
                 <FormRow
                   label={
@@ -1045,23 +998,43 @@ export default function AIProviderModal({
           {showMappings && providerId === "bedrock_api" && (
             <TabsContent value={"mappings"} className={"pb-8"}>
               <div className={"px-8 pt-3 flex-col flex gap-4"}>
+                {/* The forwarding toggle sits first: it gates the identity
+                    metadata described below, so turning it off makes the fixed
+                    mapping that follows moot. */}
+                <FancyToggleSwitch
+                  value={!metadataDisabled}
+                  onChange={(v) => setMetadataDisabled(!v)}
+                  label={
+                    <>
+                      <ArrowRightLeft size={15} />
+                      Forward Identity Metadata
+                    </>
+                  }
+                  helpText={
+                    "Stamp the identity metadata below onto Bedrock requests."
+                  }
+                />
+
                 <div>
                   <Label>Identity Metadata</Label>
                   <HelpText className={"mb-0"}>
-                    NetBird stamps the{" "}
-                    <code
-                      className={
-                        "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
+                    NetBird stamps the caller&apos;s identity into the{" "}
+                    <InlineLink
+                      href={
+                        "https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html"
                       }
+                      target={"_blank"}
                     >
-                      X-Amzn-Bedrock-Request-Metadata
-                    </code>{" "}
-                    header with a JSON object carrying the caller&apos;s
-                    identity, so you can break Bedrock spend down by user and
-                    group with AWS cost-allocation tags. The proxy strips any
-                    client-supplied value first, so an app can&apos;t spoof
-                    identity. Values are sanitized to Bedrock&apos;s accepted
-                    character set. The mapping is fixed.
+                      <code
+                        className={
+                          "text-xs font-mono bg-nb-gray-900/60 rounded px-1.5 py-0.5"
+                        }
+                      >
+                        X-Amzn-Bedrock-Request-Metadata
+                      </code>
+                    </InlineLink>{" "}
+                    header, so you can break Bedrock spend down by user and
+                    group. Client-supplied values are stripped and sanitized.
                   </HelpText>
                 </div>
 

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -225,6 +225,14 @@ export default function AIProviderModal({
   // Custom-kind providers (the generic "Custom" entry and named self-hosted
   // ones like vLLM) share the self-hosted extras, e.g. Skip TLS verification.
   const isCustomKind = catalog?.kind === "custom";
+  // injectsIdentity is true only for providers whose catalog entry declares an
+  // identity shape (HeaderPair or JSONMetadata) — i.e. the ones NetBird actually
+  // stamps the caller's identity onto. The metadata toggle is meaningless for
+  // the rest (plain OpenAI/Anthropic/Azure/Vertex/Mistral, vLLM, custom), so it
+  // is hidden for them.
+  const injectsIdentity =
+    !!catalog?.identity_injection?.header_pair ||
+    !!catalog?.identity_injection?.json_metadata;
   const customizableHeaderPair =
     catalog?.identity_injection?.header_pair?.customizable === true;
   const customizableJsonMetadata =
@@ -663,41 +671,44 @@ export default function AIProviderModal({
                 />
               )}
 
-              <FancyToggleSwitch
-                value={metadataDisabled}
-                onChange={setMetadataDisabled}
-                label={
-                  <>
-                    <ArrowRightLeft size={15} />
-                    Disable identity metadata
-                    <span onClick={(e) => e.stopPropagation()}>
-                      <HelpTooltip
-                        interactive
-                        content={
-                          <>
-                            By default NetBird forwards the caller&apos;s user and
-                            authorizing group to the provider as metadata (e.g. AWS
-                            Bedrock&apos;s X-Amzn-Bedrock-Request-Metadata header for
-                            cost allocation). Turn on to stop sending it.{" "}
-                            <InlineLink
-                              href={
-                                "https://docs.netbird.io/agent-network/providers#identity-metadata"
-                              }
-                              target={"_blank"}
-                            >
-                              Learn more
-                              <ExternalLinkIcon size={12} />
-                            </InlineLink>
-                          </>
-                        }
-                      />
-                    </span>
-                  </>
-                }
-                helpText={
-                  "Stop forwarding the caller's user and authorizing group to this provider."
-                }
-              />
+              {injectsIdentity && (
+                <FancyToggleSwitch
+                  value={!metadataDisabled}
+                  onChange={(v) => setMetadataDisabled(!v)}
+                  label={
+                    <>
+                      <ArrowRightLeft size={15} />
+                      Forward identity metadata
+                      <span onClick={(e) => e.stopPropagation()}>
+                        <HelpTooltip
+                          interactive
+                          content={
+                            <>
+                              Forwards the caller&apos;s user and authorizing group
+                              to the provider as metadata (e.g. AWS Bedrock&apos;s
+                              X-Amzn-Bedrock-Request-Metadata header for cost
+                              allocation), so it can attribute usage to the real
+                              caller. Turn off to stop sending it.{" "}
+                              <InlineLink
+                                href={
+                                  "https://docs.netbird.io/agent-network/providers#identity-metadata"
+                                }
+                                target={"_blank"}
+                              >
+                                Learn more
+                                <ExternalLinkIcon size={12} />
+                              </InlineLink>
+                            </>
+                          }
+                        />
+                      </span>
+                    </>
+                  }
+                  helpText={
+                    "Forward the caller's user and authorizing group to this provider."
+                  }
+                />
+              )}
 
               {providerId === "vertex_ai_api" ? (
                 <FormRow

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -217,6 +217,9 @@ export default function AIProviderModal({
   const [skipTlsVerification, setSkipTlsVerification] = useState<boolean>(
     provider?.skipTlsVerification ?? false,
   );
+  const [metadataDisabled, setMetadataDisabled] = useState<boolean>(
+    provider?.metadataDisabled ?? false,
+  );
 
   const catalog = getById(providerId);
   // Custom-kind providers (the generic "Custom" entry and named self-hosted
@@ -340,6 +343,7 @@ export default function AIProviderModal({
       setIdentityHeaderUserId(provider.identityHeaderUserId ?? "");
       setIdentityHeaderGroups(provider.identityHeaderGroups ?? "");
       setSkipTlsVerification(provider.skipTlsVerification ?? false);
+      setMetadataDisabled(provider.metadataDisabled ?? false);
     } else {
       const fallback = getById("openai_api");
       setProviderId("openai_api");
@@ -354,6 +358,7 @@ export default function AIProviderModal({
       setIdentityHeaderUserId("");
       setIdentityHeaderGroups("");
       setSkipTlsVerification(false);
+      setMetadataDisabled(false);
     }
   };
 
@@ -405,6 +410,7 @@ export default function AIProviderModal({
         extraValues: sanitizedExtraValues,
         ...identityOverrides,
         skipTlsVerification: isCustomKind ? skipTlsVerification : false,
+        metadataDisabled,
         // Only forward the API key when the user actually rotated it
         ...(apiKey && apiKey !== "••••••••" ? { apiKey } : {}),
       });
@@ -420,6 +426,7 @@ export default function AIProviderModal({
       extraValues: sanitizedExtraValues,
       ...identityOverrides,
       skipTlsVerification: isCustomKind ? skipTlsVerification : false,
+      metadataDisabled,
       models,
       enabled: true,
     });
@@ -655,6 +662,42 @@ export default function AIProviderModal({
                   helpText={"Disable upstream TLS certificate validation."}
                 />
               )}
+
+              <FancyToggleSwitch
+                value={metadataDisabled}
+                onChange={setMetadataDisabled}
+                label={
+                  <>
+                    <ArrowRightLeft size={15} />
+                    Disable identity metadata
+                    <span onClick={(e) => e.stopPropagation()}>
+                      <HelpTooltip
+                        interactive
+                        content={
+                          <>
+                            By default NetBird forwards the caller&apos;s user and
+                            authorizing group to the provider as metadata (e.g. AWS
+                            Bedrock&apos;s X-Amzn-Bedrock-Request-Metadata header for
+                            cost allocation). Turn on to stop sending it.{" "}
+                            <InlineLink
+                              href={
+                                "https://docs.netbird.io/agent-network/providers#identity-metadata"
+                              }
+                              target={"_blank"}
+                            >
+                              Learn more
+                              <ExternalLinkIcon size={12} />
+                            </InlineLink>
+                          </>
+                        }
+                      />
+                    </span>
+                  </>
+                }
+                helpText={
+                  "Stop forwarding the caller's user and authorizing group to this provider."
+                }
+              />
 
               {providerId === "vertex_ai_api" ? (
                 <FormRow

--- a/src/modules/agent-network/AIProvidersProvider.tsx
+++ b/src/modules/agent-network/AIProvidersProvider.tsx
@@ -50,6 +50,9 @@ export type APIProvider = {
   // Skip TLS certificate verification on upstream requests (custom providers
   // with self-signed certs). Off by default.
   skip_tls_verification?: boolean;
+  // Disable identity metadata injection (caller user + authorizing group) on
+  // upstream requests. Off by default (metadata is sent).
+  metadata_disabled?: boolean;
   enabled: boolean;
   created_at: string;
   updated_at: string;
@@ -67,6 +70,7 @@ export type APIProviderRequest = {
   identity_header_user_id?: string;
   identity_header_groups?: string;
   skip_tls_verification?: boolean;
+  metadata_disabled?: boolean;
   models: APIProviderModel[];
   enabled?: boolean;
 };
@@ -84,6 +88,8 @@ export type ProviderConnectInput = {
   identityHeaderGroups?: string;
   // Skip upstream TLS verification (custom providers with self-signed certs).
   skipTlsVerification?: boolean;
+  // Disable identity metadata injection (user + authorizing group). Off by default.
+  metadataDisabled?: boolean;
   models: ProviderModel[];
   enabled?: boolean;
 };
@@ -97,6 +103,7 @@ export type ProviderUpdateInput = {
   identityHeaderUserId?: string;
   identityHeaderGroups?: string;
   skipTlsVerification?: boolean;
+  metadataDisabled?: boolean;
   models?: ProviderModel[];
   enabled?: boolean;
 };
@@ -159,6 +166,7 @@ function fromAPI(p: APIProvider): AIProvider {
     identityHeaderUserId: p.identity_header_user_id,
     identityHeaderGroups: p.identity_header_groups,
     skipTlsVerification: p.skip_tls_verification ?? false,
+    metadataDisabled: p.metadata_disabled ?? false,
     status: p.enabled ? "active" : "disabled",
     models,
     allowedGroups: [],
@@ -201,6 +209,7 @@ function toCreateRequest(input: ProviderConnectInput): APIProviderRequest {
     identity_header_user_id: input.identityHeaderUserId,
     identity_header_groups: input.identityHeaderGroups,
     skip_tls_verification: input.skipTlsVerification,
+    metadata_disabled: input.metadataDisabled,
     models: toAPIModels(input.models),
     enabled: input.enabled,
   };
@@ -647,6 +656,8 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
           updates.identityHeaderGroups ?? existing.identity_header_groups,
         skip_tls_verification:
           updates.skipTlsVerification ?? existing.skip_tls_verification,
+        metadata_disabled:
+          updates.metadataDisabled ?? existing.metadata_disabled,
         models: updates.models
           ? toAPIModels(updates.models)
           : existing.models ?? [],

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -64,6 +64,9 @@ export type AIProvider = {
   // Skip TLS certificate verification on upstream requests — for custom
   // providers using self-signed certs. Off by default.
   skipTlsVerification?: boolean;
+  // Disable identity metadata injection (caller user + authorizing group) on
+  // upstream requests, e.g. AWS Bedrock cost-allocation. Off by default.
+  metadataDisabled?: boolean;
   status: AIProviderStatus;
   models: ProviderModel[];
   allowedGroups: string[];

--- a/src/modules/agent-network/table/AgentProvidersTable.tsx
+++ b/src/modules/agent-network/table/AgentProvidersTable.tsx
@@ -169,8 +169,11 @@ export default function AgentProvidersTable({
           learnMore={
             <>
               Learn more about
-              <InlineLink href={"https://docs.netbird.io/"} target={"_blank"}>
-                Agent Network
+              <InlineLink
+                href={"https://docs.netbird.io/agent-network/providers"}
+                target={"_blank"}
+              >
+                Agent Network Providers
                 <ExternalLinkIcon size={12} />
               </InlineLink>
             </>


### PR DESCRIPTION
## Issue ticket number and link
<img width="672" height="583" alt="Screenshot 2026-07-16 at 20 50 20" src="https://github.com/user-attachments/assets/a3231b42-a974-4077-aa87-158e24d69067" />

<!-- internal: dashboard support for the per-provider metadata_disabled setting -->

Adds a **"Forward identity metadata"** toggle to the Agent Network provider modal,
backed by the `metadata_disabled` provider API field (netbirdio/netbird#6791).

By default the proxy stamps the caller's user and authorizing group onto upstream
requests as provider-specific metadata (e.g. AWS Bedrock's
`X-Amzn-Bedrock-Request-Metadata` cost-allocation header). The toggle is a positive
control — **on by default**, wired to `metadata_disabled` inverted (`value={!metadataDisabled}`) —
so an operator can turn it **off** to stop forwarding identity per provider. Wired
through the provider types, the create and update mappers, and the modal
(state/reset/submit), mirroring the existing `skip_tls_verification` field.

The toggle is shown **only for providers NetBird actually injects identity into**
(Bedrock, LiteLLM, Portkey, Bifrost, Cloudflare, Vercel, OpenRouter — those whose
catalog entry declares an identity shape), and hidden for providers with no metadata
channel (OpenAI, Anthropic, Azure OpenAI, Vertex AI, Mistral, vLLM, Custom).

The provider catalog is fetched from the management API, so the new Bedrock
metadata-injection catalog entry surfaces automatically — no dashboard catalog
change needed.

## Screenshots

The toggle in the Connect Provider modal (AWS Bedrock selected):

Its info tooltip explaining the default-on behavior:

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

Narrative docs added in netbirdio/docs (provider "Identity Metadata" setting + AWS Bedrock cost-allocation section).

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/857

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Forward identity metadata” option for supported providers to control whether identity metadata is sent upstream.
  - Bedrock API provider now includes an “Identity Metadata” mappings section with guidance on fixed request-metadata behavior.
  - Provider settings now preserve the identity-metadata forwarding preference when creating or updating providers.
- **Documentation**
  - Updated “Learn more” links to the Agent Network Providers documentation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->