### PR TITLE
Fix network resource policy creation with single peer source

### DIFF
--- a/src/contexts/PoliciesProvider.tsx
+++ b/src/contexts/PoliciesProvider.tsx
@@ -64,9 +64,11 @@ export default function PoliciesProvider({ children }: Props) {
       return created.id!;
     };
 
-    const sources = await Promise.all(
-      (rule.sources ?? []).map(resolveGroup),
-    ).then((ids) => ids.filter(Boolean) as string[]);
+    const sources = rule.sourceResource
+      ? undefined
+      : await Promise.all(
+          (rule.sources ?? []).map(resolveGroup),
+        ).then((ids) => ids.filter(Boolean) as string[]);
 
     const destinations = rule.destinationResource
       ? undefined


### PR DESCRIPTION
## Problem

When creating a network resource in the `NetworkResourceModal`:
1. Go to the **Access Control** tab
2. Add a policy
3. Select a single peer as the source and add it
4. Try to add the resource

The request fails with: **`failed to create network resource: specify either sources or source resources not both`**.

## Cause

Selecting a single peer as the source stores it as a `sourceResource` on the rule. However, `createPolicyForResource` in `src/contexts/PoliciesProvider.tsx` *always* computed `sources` as an array (`rule.sources ?? []` → `[]`), and the `...rule` spread carried `sourceResource` through. The resulting payload contained **both** `sources: []` and `sourceResource`, which the backend rejects.

The destination side already handled this correctly — `destinations` is gated on `rule.destinationResource`. The source side had no equivalent gating.

## Fix

Mirror the destinations handling: gate `sources` on `rule.sourceResource` so it becomes `undefined` (and is dropped during JSON serialization) when a source resource is set. This matches the upstream builder `getPolicyData` in `useAccessControl.ts`.

## Testing

- `npx tsc --noEmit` passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/dashboard/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787129491&installation_id=146802194&pr_number=721&repository=netbirdio%2Fdashboard&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdashboard%2Fpull%2F721&signature=dbe019d10c22d071f3a658eaa3f32a4fae7eb2d3126ed3bac684adce3f5b7876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy creation for rules that specify a source resource.
  * Prevented conflicting source identifiers from being included when a source resource is selected.
  * Preserved existing source selection behavior for rules without a source resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->