### PR TITLE
Add Kimi (Moonshot AI) provider support to Agent Network UI

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -433,3 +433,53 @@ export async function deleteUserByEmail(page: Page, email: string) {
     await deleteUserById(page, user.id);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Agent Network
+// ---------------------------------------------------------------------------
+
+type AgentNetworkCatalogProvider = {
+  id: string;
+  name: string;
+};
+
+type AgentNetworkProvider = {
+  id: string;
+  name: string;
+  provider_id: string;
+};
+
+/** List the Agent Network provider catalog (server-defined provider types). */
+export async function listAgentNetworkCatalog(
+  page: Page,
+): Promise<AgentNetworkCatalogProvider[]> {
+  return apiGet<AgentNetworkCatalogProvider[]>(
+    page,
+    "/agent-network/catalog/providers",
+  );
+}
+
+/** List connected Agent Network providers. */
+export async function listAgentNetworkProviders(
+  page: Page,
+): Promise<AgentNetworkProvider[]> {
+  return apiGet<AgentNetworkProvider[]>(page, "/agent-network/providers");
+}
+
+/** Delete an Agent Network provider by ID. */
+export async function deleteAgentNetworkProviderById(page: Page, id: string) {
+  await apiDelete(page, `/agent-network/providers/${id}`);
+}
+
+/** Delete all Agent Network providers whose name starts with the prefix. */
+export async function deleteAgentNetworkProvidersByPrefix(
+  page: Page,
+  prefix: string,
+) {
+  const providers = await listAgentNetworkProviders(page);
+  for (const p of providers) {
+    if (p.name.startsWith(prefix)) {
+      await deleteAgentNetworkProviderById(page, p.id);
+    }
+  }
+}

--- a/e2e/tests/agent-network-kimi-provider.spec.ts
+++ b/e2e/tests/agent-network-kimi-provider.spec.ts
@@ -138,6 +138,11 @@ test.describe.serial("Agent Network Kimi provider @agent-network", () => {
       await expect(
         page.getByText('"ENABLE_TOOL_SEARCH": "false"'),
       ).toBeVisible();
+      // The base URL carries the /anthropic shape prefix that rides through
+      // the endpoint to Moonshot's Anthropic surface.
+      await expect(
+        page.getByText(/"ANTHROPIC_BASE_URL": "https:\/\/[^"]+\/anthropic"/),
+      ).toBeVisible();
 
       // Kimi CLI tab carries the ~/.kimi/config.toml provider block.
       await page.getByRole("tab", { name: "Kimi CLI" }).click({ force: true });

--- a/e2e/tests/agent-network-kimi-provider.spec.ts
+++ b/e2e/tests/agent-network-kimi-provider.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Agent Network Kimi (Moonshot AI) provider spec.
+ *
+ * Walks the Kimi provider lifecycle end to end against the real backend:
+ * pick kimi_api from the catalog (prefilled host, catalog models with
+ * pricing), connect it, then verify the Kimi-gated config surfaces in the
+ * "Configure Your Agent" modal (Kimi CLI tab, Kimi backend option in the
+ * Claude Code tab) that only render when a Kimi provider is connected.
+ *
+ * The kimi_api catalog entry ships with newer management builds. When the
+ * backend under test predates it, the whole suite skips instead of failing —
+ * same trade-off as the provider matrix in netbird's agent-network e2e
+ * harness, which skips per-provider on missing credentials.
+ *
+ * The Agent Network menu is deployment-gated; the test build honors the
+ * localStorage override (see testAgentNetworkOverride in utils/netbird.ts),
+ * set via addInitScript on a dedicated context below.
+ */
+import { test, expect, type Browser, type Page } from "@playwright/test";
+import { loginToApp } from "../helpers/auth";
+import { generateRandomName } from "../helpers/utils";
+import {
+  deleteAgentNetworkProvidersByPrefix,
+  listAgentNetworkCatalog,
+} from "../helpers/api";
+
+const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
+const KIMI_CATALOG_ID = "kimi_api";
+const KIMI_CATALOG_NAME = "Kimi (Moonshot AI) API";
+const PROVIDER_PREFIX = "e2e-kimi-";
+
+async function newAgentNetworkPage(browser: Browser): Promise<{
+  page: Page;
+  close: () => Promise<void>;
+}> {
+  const context = await browser.newContext({
+    storageState: "e2e/fixtures/auth/owner.json",
+  });
+  await context.addInitScript(
+    ([key, value]) => {
+      try {
+        window.localStorage.setItem(key as string, value as string);
+      } catch (e) {}
+    },
+    [AGENT_NETWORK_CONFIG_KEY, "enabled"],
+  );
+  const page = await context.newPage();
+  await loginToApp(page, "owner");
+  return { page, close: () => context.close() };
+}
+
+test.describe.serial("Agent Network Kimi provider @agent-network", () => {
+  test("connect a Kimi provider and see Kimi agent configs", async ({
+    browser,
+  }) => {
+    const { page, close } = await newAgentNetworkPage(browser);
+    try {
+      // Backend support probe: skip the suite on management builds whose
+      // catalog predates kimi_api.
+      const catalog = await listAgentNetworkCatalog(page);
+      test.skip(
+        !catalog.some((c) => c.id === KIMI_CATALOG_ID),
+        `management catalog has no ${KIMI_CATALOG_ID} entry`,
+      );
+
+      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
+
+      await page.goto("/agent-network/providers");
+      await page.keyboard.press("Escape");
+
+      // ---- connect the provider ----
+      await page
+        .getByRole("button", { name: "Connect Provider" })
+        .first()
+        .click({ force: true });
+
+      // The provider select defaults to OpenAI API; search the catalog for
+      // the Kimi entry.
+      await page
+        .getByRole("button", { name: /OpenAI API/ })
+        .first()
+        .click({ force: true });
+      await page.getByPlaceholder("Search providers...").fill("kimi");
+      await page.getByText(KIMI_CATALOG_NAME).first().click({ force: true });
+
+      // Catalog default host lands in the upstream URL input.
+      await expect(
+        page.locator('input[value="https://api.moonshot.ai"]'),
+      ).toBeVisible();
+
+      await page
+        .getByPlaceholder("sk-...")
+        .first()
+        .fill("sk-e2e-kimi-test-key");
+
+      const providerName = generateRandomName(PROVIDER_PREFIX);
+      const nameInput = page.locator(`input[value="${KIMI_CATALOG_NAME}"]`);
+      await nameInput.fill(providerName);
+
+      // ---- models tab: catalog models carry pricing ----
+      await page.getByRole("tab", { name: "Models" }).click({ force: true });
+      await page.getByRole("button", { name: "Add More" }).click({ force: true });
+      await page.getByText("Kimi K3", { exact: false }).first().click({ force: true });
+      // Catalog price for kimi-k3 input tokens pre-fills the price cell.
+      await expect(page.locator('input[value="0.003"]')).toBeVisible();
+
+      const createResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/agent-network/providers") &&
+          resp.request().method() === "POST",
+        { timeout: 30_000 },
+      );
+      await page
+        .getByRole("button", { name: "Connect Provider" })
+        .last()
+        .click({ force: true });
+      expect([200, 201]).toContain((await createResponse).status());
+
+      // Row lands in the providers table.
+      await expect(page.getByText(providerName).first()).toBeVisible();
+
+      // ---- Kimi-gated agent config surfaces ----
+      await page
+        .getByRole("button", { name: "Agent Config" })
+        .click({ force: true });
+
+      // Kimi CLI tab only renders when a kimi_api provider is connected.
+      await expect(page.getByRole("tab", { name: "Kimi CLI" })).toBeVisible();
+
+      // Claude Code tab's backend dropdown offers (and, with Kimi as the only
+      // Anthropic-shaped provider, pre-selects) Kimi — its settings.json
+      // snippet pins the model tiers to kimi-k3.
+      await expect(page.getByText('"ANTHROPIC_MODEL": "kimi-k3"')).toBeVisible();
+
+      // Kimi CLI tab carries the ~/.kimi/config.toml provider block.
+      await page.getByRole("tab", { name: "Kimi CLI" }).click({ force: true });
+      await expect(page.getByText('default_model = "kimi-k3"')).toBeVisible();
+
+      // Codex tab's Kimi variant switches the wire API to Chat Completions.
+      await page.getByRole("tab", { name: "Codex" }).click({ force: true });
+      await expect(page.getByText('wire_api = "chat"')).toBeVisible();
+
+      await page.keyboard.press("Escape");
+
+      // ---- cleanup ----
+      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/e2e/tests/agent-network-kimi-provider.spec.ts
+++ b/e2e/tests/agent-network-kimi-provider.spec.ts
@@ -129,16 +129,25 @@ test.describe.serial("Agent Network Kimi provider @agent-network", () => {
 
       // Claude Code tab's backend dropdown offers (and, with Kimi as the only
       // Anthropic-shaped provider, pre-selects) Kimi — its settings.json
-      // snippet pins the model tiers to kimi-k3.
+      // snippet pins every model slot to kimi-k3 and disables tool search,
+      // per Moonshot's Claude Code guide.
       await expect(page.getByText('"ANTHROPIC_MODEL": "kimi-k3"')).toBeVisible();
+      await expect(
+        page.getByText('"CLAUDE_CODE_SUBAGENT_MODEL": "kimi-k3"'),
+      ).toBeVisible();
+      await expect(
+        page.getByText('"ENABLE_TOOL_SEARCH": "false"'),
+      ).toBeVisible();
 
       // Kimi CLI tab carries the ~/.kimi/config.toml provider block.
       await page.getByRole("tab", { name: "Kimi CLI" }).click({ force: true });
       await expect(page.getByText('default_model = "kimi-k3"')).toBeVisible();
 
-      // Codex tab's Kimi variant switches the wire API to Chat Completions.
+      // Codex has no Kimi variant — Kimi's upstream doesn't support Codex, so
+      // the tab keeps the plain Responses-API config with no backend dropdown.
       await page.getByRole("tab", { name: "Codex" }).click({ force: true });
-      await expect(page.getByText('wire_api = "chat"')).toBeVisible();
+      await expect(page.getByText('wire_api = "responses"')).toBeVisible();
+      await expect(page.getByText('wire_api = "chat"')).not.toBeVisible();
 
       await page.keyboard.press("Escape");
 

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -139,7 +139,7 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
     case "vllm":
       return "Your local vLLM server's OpenAI-compatible base URL.";
     case "kimi_api":
-      return "Moonshot AI's international platform endpoint. Append /anthropic for Anthropic-shaped agents like Claude Code and Kimi CLI, or keep https://api.moonshot.ai for OpenAI-shaped callers (OpenAI SDK, Chat Completions) — Moonshot serves both APIs with the same key. Mainland-China accounts use api.moonshot.cn instead.";
+      return "Moonshot AI's international platform endpoint — keep the bare host. Moonshot serves both API shapes with the same key: agents pick one via their base URL path against your endpoint (/anthropic for Claude Code and Kimi CLI, /v1 for OpenAI-shaped callers), and the path rides through to Moonshot. Mainland-China accounts use api.moonshot.cn instead.";
     default:
       return "Where NetBird forwards the traffic.";
   }

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -139,7 +139,7 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
     case "vllm":
       return "Your local vLLM server's OpenAI-compatible base URL.";
     case "kimi_api":
-      return "Moonshot AI's international platform endpoint — keep the bare host. Moonshot serves both API shapes with the same key: agents pick one via their base URL path against your endpoint (/anthropic for Claude Code and Kimi CLI, /v1 for OpenAI-shaped callers), and the path rides through to Moonshot. Mainland-China accounts use api.moonshot.cn instead.";
+      return "Moonshot AI's international platform endpoint — keep the bare host. Moonshot serves both API shapes with the same key: the path an agent calls rides through to Moonshot, so its base URL picks the shape (Claude Code appends /anthropic; Kimi CLI and OpenAI-shaped callers use the bare endpoint). Mainland-China accounts use api.moonshot.cn instead.";
     default:
       return "Where NetBird forwards the traffic.";
   }

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -139,7 +139,7 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
     case "vllm":
       return "Your local vLLM server's OpenAI-compatible base URL.";
     case "kimi_api":
-      return "Moonshot AI's international platform endpoint. Keep https://api.moonshot.ai for OpenAI-shaped agents (Codex, OpenAI SDK) or append /anthropic for Anthropic-shaped agents like Claude Code and Kimi CLI — Moonshot serves both APIs with the same key. Mainland-China accounts use api.moonshot.cn instead.";
+      return "Moonshot AI's international platform endpoint. Append /anthropic for Anthropic-shaped agents like Claude Code and Kimi CLI, or keep https://api.moonshot.ai for OpenAI-shaped callers (OpenAI SDK, Chat Completions) — Moonshot serves both APIs with the same key. Mainland-China accounts use api.moonshot.cn instead.";
     default:
       return "Where NetBird forwards the traffic.";
   }

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -113,6 +113,8 @@ function upstreamUrlPlaceholder(providerId: AIProviderId): string {
       return "https://api.portkey.ai";
     case "vllm":
       return "https://your-vllm-host:8000";
+    case "kimi_api":
+      return "https://api.moonshot.ai";
     case "custom":
       return "https://your-llm-host";
     default:
@@ -136,6 +138,8 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
       return "OpenRouter uses a fixed endpoint, openrouter.ai/api/v1; apps choose the upstream provider via the model prefix, e.g. anthropic/claude-* or openai/gpt-*.";
     case "vllm":
       return "Your local vLLM server's OpenAI-compatible base URL.";
+    case "kimi_api":
+      return "Moonshot AI's international platform endpoint. Keep https://api.moonshot.ai for OpenAI-shaped agents (Codex, OpenAI SDK) or append /anthropic for Anthropic-shaped agents like Claude Code and Kimi CLI — Moonshot serves both APIs with the same key. Mainland-China accounts use api.moonshot.cn instead.";
     default:
       return "Where NetBird forwards the traffic.";
   }
@@ -738,7 +742,7 @@ export default function AIProviderModal({
                     onChange={(e) => setApiKey(e.target.value)}
                     customPrefix={<KeyRound size={14} />}
                     placeholder={
-                      providerId === "openai_api"
+                      providerId === "openai_api" || providerId === "kimi_api"
                         ? "sk-..."
                         : providerId === "anthropic_api"
                         ? "sk-ant-..."

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -138,8 +138,6 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
       return "OpenRouter uses a fixed endpoint, openrouter.ai/api/v1; apps choose the upstream provider via the model prefix, e.g. anthropic/claude-* or openai/gpt-*.";
     case "vllm":
       return "Your local vLLM server's OpenAI-compatible base URL.";
-    case "kimi_api":
-      return "Moonshot AI's international platform endpoint — keep the bare host. Moonshot serves both API shapes with the same key: the path an agent calls rides through to Moonshot, so its base URL picks the shape (Claude Code appends /anthropic; Kimi CLI and OpenAI-shaped callers use the bare endpoint). Mainland-China accounts use api.moonshot.cn instead.";
     default:
       return "Where NetBird forwards the traffic.";
   }
@@ -621,7 +619,20 @@ export default function AIProviderModal({
               </FormRow>
 
               <FormRow
-                label={"Upstream URL"}
+                label={
+                  providerId === "kimi_api" ? (
+                    <>
+                      Upstream URL
+                      <HelpTooltip
+                        content={
+                          "Moonshot AI's international platform endpoint. Keep the bare host. Moonshot serves both API shapes with the same key: the path an agent calls rides through to Moonshot, so its base URL picks the shape (Claude Code appends /anthropic; Kimi CLI and OpenAI shaped callers use the bare endpoint). Mainland China accounts use api.moonshot.cn instead."
+                        }
+                      />
+                    </>
+                  ) : (
+                    "Upstream URL"
+                  )
+                }
                 helpText={upstreamUrlHelpText(providerId)}
               >
                 <Input

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -310,13 +310,6 @@ export function AgentConnectTabs({
               `max_context_size = 1000000`,
             ]}
           />
-          <SmallParagraph className={"mt-3"}>
-            Pairs with a Kimi provider keeping the default upstream URL{" "}
-            <code className={"font-mono"}>https://api.moonshot.ai</code>. The{" "}
-            <code className={"font-mono"}>/anthropic</code> suffix in the base
-            URL rides through the endpoint to Moonshot, which serves the
-            Anthropic Messages API under that path.
-          </SmallParagraph>
         </div>
       </TabsContent>
 

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -122,7 +122,7 @@ export function AgentConnectTabs({
                   : []),
               ]}
               showValues={false}
-              className={"w-[160px]"}
+              className={"!w-auto min-w-[160px]"}
             />
           </div>
 
@@ -262,8 +262,8 @@ export function AgentConnectTabs({
               />
               <SmallParagraph className={"mt-3"}>
                 Pairs with a Kimi provider keeping the default upstream URL{" "}
-                <code className={"font-mono"}>https://api.moonshot.ai</code> —
-                the <code className={"font-mono"}>/anthropic</code> suffix in
+                <code className={"font-mono"}>https://api.moonshot.ai</code>.
+                The <code className={"font-mono"}>/anthropic</code> suffix in
                 the base URL rides through the endpoint to Moonshot, which
                 serves the Anthropic Messages API under that path.
               </SmallParagraph>
@@ -312,10 +312,10 @@ export function AgentConnectTabs({
           />
           <SmallParagraph className={"mt-3"}>
             Pairs with a Kimi provider keeping the default upstream URL{" "}
-            <code className={"font-mono"}>https://api.moonshot.ai</code>. For
-            the OpenAI shape instead, use{" "}
-            <code className={"font-mono"}>type = &quot;openai_legacy&quot;</code>{" "}
-            with <code className={"font-mono"}>base_url = &quot;{openaiBase}&quot;</code>.
+            <code className={"font-mono"}>https://api.moonshot.ai</code>. The{" "}
+            <code className={"font-mono"}>/anthropic</code> suffix in the base
+            URL rides through the endpoint to Moonshot, which serves the
+            Anthropic Messages API under that path.
           </SmallParagraph>
         </div>
       </TabsContent>

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -2,6 +2,7 @@
 
 import Code from "@components/Code";
 import { Modal, ModalContent } from "@components/modal/Modal";
+import { useAIProviders } from "@/modules/agent-network/AIProvidersProvider";
 import Paragraph from "@components/Paragraph";
 import SmallParagraph from "@components/SmallParagraph";
 import SquareIcon from "@components/SquareIcon";
@@ -56,6 +57,7 @@ export function AgentConnectTabs({
   listClassName = "px-8",
   contentClassName = "px-6 py-2",
   defaultTab = "claude-code",
+  providerIds = [],
 }: {
   endpoint: string;
   listClassName?: string;
@@ -64,23 +66,48 @@ export function AgentConnectTabs({
   // matching tool (e.g. Anthropic → claude-code, OpenAI → curl). Keyed below
   // so a late-resolving defaultTab still re-initialises the tabs.
   defaultTab?: string;
+  // Catalog ids of the account's connected providers. Kimi-specific config
+  // surfaces (the Kimi CLI tab and the Kimi variants inside the Claude Code /
+  // Codex tabs) only render when a kimi_api provider is actually connected —
+  // showing Moonshot setup against an endpoint that can't route to Kimi
+  // would just be a trap.
+  providerIds?: string[];
 }) {
   const baseUrl = `https://${endpoint}`;
   const openaiBase = `${baseUrl}/v1`;
+  const hasKimi = providerIds.includes("kimi_api");
   const [claudeMode, setClaudeMode] = React.useState<"config" | "shell">(
     "config",
   );
-  // Which backend the Claude Code config targets — Anthropic API direct, or
-  // via Vertex AI / Bedrock. Switched in-tab instead of separate tabs.
+  // Which backend the Claude Code config targets — Anthropic API direct,
+  // via Vertex AI / Bedrock, or Kimi (Moonshot AI, whose upstream speaks the
+  // Anthropic Messages API too). Switched in-tab instead of separate tabs.
+  // When Kimi is the only Anthropic-shaped provider connected, it's the only
+  // config that can work, so start there.
+  const kimiOnlyAnthropicShape =
+    hasKimi &&
+    !["anthropic_api", "vertex_ai_api", "bedrock_api"].some((id) =>
+      providerIds.includes(id),
+    );
   const [claudeProvider, setClaudeProvider] = React.useState<
-    "anthropic" | "vertex" | "bedrock"
-  >("anthropic");
+    "anthropic" | "vertex" | "bedrock" | "kimi"
+  >(kimiOnlyAnthropicShape ? "kimi" : "anthropic");
+  // Which upstream the Codex config targets. Codex speaks the Responses API
+  // natively; Kimi's OpenAI-compatible upstream is Chat Completions only, so
+  // its variant needs wire_api = "chat" plus a Kimi model id.
+  const kimiOnlyOpenAIShape =
+    hasKimi &&
+    !["openai_api", "azure_openai_api"].some((id) => providerIds.includes(id));
+  const [codexProvider, setCodexProvider] = React.useState<"openai" | "kimi">(
+    kimiOnlyOpenAIShape ? "kimi" : "openai",
+  );
 
   return (
     <Tabs key={defaultTab} defaultValue={defaultTab} className={"mt-2"}>
       <TabsList justify={"start"} className={listClassName}>
         <TabsTrigger value={"claude-code"}>Claude Code</TabsTrigger>
         <TabsTrigger value={"codex"}>Codex</TabsTrigger>
+        {hasKimi && <TabsTrigger value={"kimi-cli"}>Kimi CLI</TabsTrigger>}
         <TabsTrigger value={"openai-sdk"}>OpenAI SDK</TabsTrigger>
         <TabsTrigger value={"curl"}>cURL</TabsTrigger>
       </TabsList>
@@ -91,12 +118,17 @@ export function AgentConnectTabs({
             <SelectDropdown
               value={claudeProvider}
               onChange={(v) =>
-                setClaudeProvider(v as "anthropic" | "vertex" | "bedrock")
+                setClaudeProvider(
+                  v as "anthropic" | "vertex" | "bedrock" | "kimi",
+                )
               }
               options={[
                 { label: "Anthropic API", value: "anthropic" },
                 { label: "Vertex AI", value: "vertex" },
                 { label: "Bedrock", value: "bedrock" },
+                ...(hasKimi
+                  ? [{ label: "Kimi (Moonshot AI)", value: "kimi" }]
+                  : []),
               ]}
               showValues={false}
               className={"w-[160px]"}
@@ -176,22 +208,158 @@ export function AgentConnectTabs({
               ]}
             />
           )}
+
+          {claudeProvider === "kimi" && (
+            <>
+              <div className={"flex items-center justify-between gap-3 mb-2"}>
+                <SmallParagraph className={"!mb-0"}>
+                  {claudeMode === "config"
+                    ? "Add to ~/.claude/settings.json:"
+                    : "Run in your shell:"}
+                </SmallParagraph>
+                <button
+                  type={"button"}
+                  onClick={() =>
+                    setClaudeMode(claudeMode === "config" ? "shell" : "config")
+                  }
+                  className={
+                    "shrink-0 mr-2 text-[11px] text-white hover:underline underline-offset-2 cursor-pointer"
+                  }
+                >
+                  {claudeMode === "config" ? "Shell" : "JSON"}
+                </button>
+              </div>
+              <Snippet
+                // Claude Code speaks the Anthropic Messages API, which
+                // Moonshot serves under the /anthropic path prefix — the Kimi
+                // provider's upstream URL must be
+                // https://api.moonshot.ai/anthropic. The model tiers point at
+                // a Kimi model id since the upstream has no Claude models.
+                lines={
+                  claudeMode === "config"
+                    ? [
+                        `{`,
+                        `  "apiKeyHelper": "echo '-'",`,
+                        `  "env": {`,
+                        `    "ANTHROPIC_BASE_URL": "${baseUrl}",`,
+                        `    "ANTHROPIC_MODEL": "kimi-k3",`,
+                        `    "ANTHROPIC_SMALL_FAST_MODEL": "kimi-k3"`,
+                        `  }`,
+                        `}`,
+                      ]
+                    : [
+                        `export ANTHROPIC_BASE_URL=${baseUrl}`,
+                        `export ANTHROPIC_API_KEY=none`,
+                        `export ANTHROPIC_MODEL=kimi-k3`,
+                        `export ANTHROPIC_SMALL_FAST_MODEL=kimi-k3`,
+                        `claude`,
+                      ]
+                }
+              />
+              <SmallParagraph className={"mt-3"}>
+                Requires the Kimi provider&apos;s upstream URL to be{" "}
+                <code className={"font-mono"}>
+                  https://api.moonshot.ai/anthropic
+                </code>{" "}
+                — Moonshot serves the Anthropic Messages API under that path.
+              </SmallParagraph>
+            </>
+          )}
         </div>
       </TabsContent>
 
       <TabsContent value={"codex"}>
         <div className={contentClassName}>
+          {hasKimi && (
+            <div className={"mb-3"}>
+              <SelectDropdown
+                value={codexProvider}
+                onChange={(v) => setCodexProvider(v as "openai" | "kimi")}
+                options={[
+                  { label: "OpenAI API", value: "openai" },
+                  { label: "Kimi (Moonshot AI)", value: "kimi" },
+                ]}
+                showValues={false}
+                className={"w-[180px]"}
+              />
+            </div>
+          )}
+          {codexProvider === "openai" && (
+            <Snippet
+              caption={"Add to ~/.codex/config.toml:"}
+              lines={[
+                `model_provider = "netbird"`,
+                ``,
+                `[model_providers.netbird]`,
+                `name = "NetBird"`,
+                `base_url = "${openaiBase}"`,
+                `wire_api = "responses"`,
+              ]}
+            />
+          )}
+          {codexProvider === "kimi" && (
+            <>
+              <Snippet
+                // Kimi's OpenAI-compatible upstream speaks Chat Completions,
+                // not the Responses API Codex defaults to — wire_api "chat"
+                // is what makes Codex talk to it.
+                caption={"Add to ~/.codex/config.toml:"}
+                lines={[
+                  `model_provider = "netbird"`,
+                  `model = "kimi-k3"`,
+                  ``,
+                  `[model_providers.netbird]`,
+                  `name = "NetBird"`,
+                  `base_url = "${openaiBase}"`,
+                  `wire_api = "chat"`,
+                ]}
+              />
+              <SmallParagraph className={"mt-3"}>
+                Requires the Kimi provider&apos;s upstream URL to be{" "}
+                <code className={"font-mono"}>https://api.moonshot.ai</code> —
+                Codex sends OpenAI-shaped requests on /v1, and{" "}
+                <code className={"font-mono"}>wire_api = &quot;chat&quot;</code>{" "}
+                switches it from the Responses API to Chat Completions, which
+                is what Kimi&apos;s upstream speaks.
+              </SmallParagraph>
+            </>
+          )}
+        </div>
+      </TabsContent>
+
+      <TabsContent value={"kimi-cli"}>
+        <div className={contentClassName} hidden={!hasKimi}>
           <Snippet
-            caption={"Add to ~/.codex/config.toml:"}
+            // Kimi CLI reads providers from ~/.kimi/config.toml. The
+            // "anthropic" provider type matches a Kimi provider whose
+            // upstream URL is https://api.moonshot.ai/anthropic; api_key is
+            // a placeholder since NetBird injects the real key server-side.
+            caption={"Add to ~/.kimi/config.toml:"}
             lines={[
-              `model_provider = "netbird"`,
+              `default_model = "kimi-k3"`,
               ``,
-              `[model_providers.netbird]`,
-              `name = "NetBird"`,
-              `base_url = "${openaiBase}"`,
-              `wire_api = "responses"`,
+              `[providers.netbird]`,
+              `type = "anthropic"`,
+              `base_url = "${baseUrl}"`,
+              `api_key = "-"`,
+              ``,
+              `[models.kimi-k3]`,
+              `provider = "netbird"`,
+              `model = "kimi-k3"`,
+              `max_context_size = 1000000`,
             ]}
           />
+          <SmallParagraph className={"mt-3"}>
+            Pairs with a Kimi provider whose upstream URL is{" "}
+            <code className={"font-mono"}>
+              https://api.moonshot.ai/anthropic
+            </code>
+            . For an OpenAI-shaped provider (upstream{" "}
+            <code className={"font-mono"}>https://api.moonshot.ai</code>), use{" "}
+            <code className={"font-mono"}>type = &quot;openai_legacy&quot;</code>{" "}
+            with <code className={"font-mono"}>base_url = &quot;{openaiBase}&quot;</code>{" "}
+            instead.
+          </SmallParagraph>
         </div>
       </TabsContent>
 
@@ -243,6 +411,9 @@ export default function AgentConnectModal({
   onOpenChange,
   endpoint,
 }: Readonly<Props>) {
+  // Rendered inside <AIProvidersProvider> (providers page); the connected
+  // provider ids gate which per-tool config variants the tabs offer.
+  const { providers } = useAIProviders();
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent maxWidthClass={"max-w-2xl"}>
@@ -258,7 +429,10 @@ export default function AgentConnectModal({
           </Paragraph>
         </div>
 
-        <AgentConnectTabs endpoint={endpoint} />
+        <AgentConnectTabs
+          endpoint={endpoint}
+          providerIds={providers.map((p) => p.providerId)}
+        />
       </ModalContent>
     </Modal>
   );

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -222,21 +222,22 @@ export function AgentConnectTabs({
               </div>
               <Snippet
                 // Claude Code speaks the Anthropic Messages API, which
-                // Moonshot serves under the /anthropic path prefix — the Kimi
-                // provider's upstream URL must be
-                // https://api.moonshot.ai/anthropic. Every model slot Claude
-                // Code fills on its own (opus/sonnet/haiku tiers, subagents)
-                // is pinned to kimi-k3 so no Claude model names leak into
-                // requests the upstream can't serve, and tool search is off
-                // because Moonshot rejects its tool_reference blocks — both
-                // per Moonshot's Claude Code guide.
+                // Moonshot serves under the /anthropic path prefix. The
+                // prefix goes in the agent's base URL and rides through the
+                // endpoint to the bare https://api.moonshot.ai upstream, so
+                // one Kimi provider serves both API shapes. Every model slot
+                // Claude Code fills on its own (opus/sonnet/haiku tiers,
+                // subagents) is pinned to kimi-k3 so no Claude model names
+                // leak into requests the upstream can't serve, and tool
+                // search is off because Moonshot rejects its tool_reference
+                // blocks — both per Moonshot's Claude Code guide.
                 lines={
                   claudeMode === "config"
                     ? [
                         `{`,
                         `  "apiKeyHelper": "echo '-'",`,
                         `  "env": {`,
-                        `    "ANTHROPIC_BASE_URL": "${baseUrl}",`,
+                        `    "ANTHROPIC_BASE_URL": "${baseUrl}/anthropic",`,
                         `    "ANTHROPIC_MODEL": "kimi-k3",`,
                         `    "ANTHROPIC_DEFAULT_OPUS_MODEL": "kimi-k3",`,
                         `    "ANTHROPIC_DEFAULT_SONNET_MODEL": "kimi-k3",`,
@@ -247,7 +248,7 @@ export function AgentConnectTabs({
                         `}`,
                       ]
                     : [
-                        `export ANTHROPIC_BASE_URL=${baseUrl}`,
+                        `export ANTHROPIC_BASE_URL=${baseUrl}/anthropic`,
                         `export ANTHROPIC_API_KEY=none`,
                         `export ANTHROPIC_MODEL=kimi-k3`,
                         `export ANTHROPIC_DEFAULT_OPUS_MODEL=kimi-k3`,
@@ -260,11 +261,11 @@ export function AgentConnectTabs({
                 }
               />
               <SmallParagraph className={"mt-3"}>
-                Requires the Kimi provider&apos;s upstream URL to be{" "}
-                <code className={"font-mono"}>
-                  https://api.moonshot.ai/anthropic
-                </code>{" "}
-                — Moonshot serves the Anthropic Messages API under that path.
+                Pairs with a Kimi provider keeping the default upstream URL{" "}
+                <code className={"font-mono"}>https://api.moonshot.ai</code> —
+                the <code className={"font-mono"}>/anthropic</code> suffix in
+                the base URL rides through the endpoint to Moonshot, which
+                serves the Anthropic Messages API under that path.
               </SmallParagraph>
             </>
           )}
@@ -291,16 +292,17 @@ export function AgentConnectTabs({
         <div className={contentClassName} hidden={!hasKimi}>
           <Snippet
             // Kimi CLI reads providers from ~/.kimi/config.toml. The
-            // "anthropic" provider type matches a Kimi provider whose
-            // upstream URL is https://api.moonshot.ai/anthropic; api_key is
-            // a placeholder since NetBird injects the real key server-side.
+            // "anthropic" provider type speaks the Anthropic Messages API,
+            // so like Claude Code its base_url carries the /anthropic
+            // prefix that rides through to Moonshot; api_key is a
+            // placeholder since NetBird injects the real key server-side.
             caption={"Add to ~/.kimi/config.toml:"}
             lines={[
               `default_model = "kimi-k3"`,
               ``,
               `[providers.netbird]`,
               `type = "anthropic"`,
-              `base_url = "${baseUrl}"`,
+              `base_url = "${baseUrl}/anthropic"`,
               `api_key = "-"`,
               ``,
               `[models.kimi-k3]`,
@@ -310,15 +312,11 @@ export function AgentConnectTabs({
             ]}
           />
           <SmallParagraph className={"mt-3"}>
-            Pairs with a Kimi provider whose upstream URL is{" "}
-            <code className={"font-mono"}>
-              https://api.moonshot.ai/anthropic
-            </code>
-            . For an OpenAI-shaped provider (upstream{" "}
-            <code className={"font-mono"}>https://api.moonshot.ai</code>), use{" "}
+            Pairs with a Kimi provider keeping the default upstream URL{" "}
+            <code className={"font-mono"}>https://api.moonshot.ai</code>. For
+            the OpenAI shape instead, use{" "}
             <code className={"font-mono"}>type = &quot;openai_legacy&quot;</code>{" "}
-            with <code className={"font-mono"}>base_url = &quot;{openaiBase}&quot;</code>{" "}
-            instead.
+            with <code className={"font-mono"}>base_url = &quot;{openaiBase}&quot;</code>.
           </SmallParagraph>
         </div>
       </TabsContent>

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -291,10 +291,9 @@ export function AgentConnectTabs({
       <TabsContent value={"kimi-cli"}>
         <div className={contentClassName} hidden={!hasKimi}>
           <Snippet
-            // Kimi CLI reads providers from ~/.kimi/config.toml. The
-            // "anthropic" provider type speaks the Anthropic Messages API,
-            // so like Claude Code its base_url carries the /anthropic
-            // prefix that rides through to Moonshot; api_key is a
+            // Kimi CLI reads providers from ~/.kimi/config.toml. Unlike
+            // Claude Code, its "anthropic" provider type needs the bare
+            // endpoint — no /anthropic prefix in base_url; api_key is a
             // placeholder since NetBird injects the real key server-side.
             caption={"Add to ~/.kimi/config.toml:"}
             lines={[
@@ -302,7 +301,7 @@ export function AgentConnectTabs({
               ``,
               `[providers.netbird]`,
               `type = "anthropic"`,
-              `base_url = "${baseUrl}/anthropic"`,
+              `base_url = "${baseUrl}"`,
               `api_key = "-"`,
               ``,
               `[models.kimi-k3]`,

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -310,6 +310,13 @@ export function AgentConnectTabs({
               `max_context_size = 1000000`,
             ]}
           />
+          <SmallParagraph className={"mt-3"}>
+            Pairs with a Kimi provider keeping the default upstream URL{" "}
+            <code className={"font-mono"}>https://api.moonshot.ai</code>. For
+            the OpenAI shape instead, use{" "}
+            <code className={"font-mono"}>type = &quot;openai_legacy&quot;</code>{" "}
+            with <code className={"font-mono"}>base_url = &quot;{openaiBase}&quot;</code>.
+          </SmallParagraph>
         </div>
       </TabsContent>
 

--- a/src/modules/agent-network/AgentConnectModal.tsx
+++ b/src/modules/agent-network/AgentConnectModal.tsx
@@ -67,8 +67,8 @@ export function AgentConnectTabs({
   // so a late-resolving defaultTab still re-initialises the tabs.
   defaultTab?: string;
   // Catalog ids of the account's connected providers. Kimi-specific config
-  // surfaces (the Kimi CLI tab and the Kimi variants inside the Claude Code /
-  // Codex tabs) only render when a kimi_api provider is actually connected —
+  // surfaces (the Kimi CLI tab and the Kimi variant inside the Claude Code
+  // tab) only render when a kimi_api provider is actually connected —
   // showing Moonshot setup against an endpoint that can't route to Kimi
   // would just be a trap.
   providerIds?: string[];
@@ -92,15 +92,6 @@ export function AgentConnectTabs({
   const [claudeProvider, setClaudeProvider] = React.useState<
     "anthropic" | "vertex" | "bedrock" | "kimi"
   >(kimiOnlyAnthropicShape ? "kimi" : "anthropic");
-  // Which upstream the Codex config targets. Codex speaks the Responses API
-  // natively; Kimi's OpenAI-compatible upstream is Chat Completions only, so
-  // its variant needs wire_api = "chat" plus a Kimi model id.
-  const kimiOnlyOpenAIShape =
-    hasKimi &&
-    !["openai_api", "azure_openai_api"].some((id) => providerIds.includes(id));
-  const [codexProvider, setCodexProvider] = React.useState<"openai" | "kimi">(
-    kimiOnlyOpenAIShape ? "kimi" : "openai",
-  );
 
   return (
     <Tabs key={defaultTab} defaultValue={defaultTab} className={"mt-2"}>
@@ -233,8 +224,12 @@ export function AgentConnectTabs({
                 // Claude Code speaks the Anthropic Messages API, which
                 // Moonshot serves under the /anthropic path prefix — the Kimi
                 // provider's upstream URL must be
-                // https://api.moonshot.ai/anthropic. The model tiers point at
-                // a Kimi model id since the upstream has no Claude models.
+                // https://api.moonshot.ai/anthropic. Every model slot Claude
+                // Code fills on its own (opus/sonnet/haiku tiers, subagents)
+                // is pinned to kimi-k3 so no Claude model names leak into
+                // requests the upstream can't serve, and tool search is off
+                // because Moonshot rejects its tool_reference blocks — both
+                // per Moonshot's Claude Code guide.
                 lines={
                   claudeMode === "config"
                     ? [
@@ -243,7 +238,11 @@ export function AgentConnectTabs({
                         `  "env": {`,
                         `    "ANTHROPIC_BASE_URL": "${baseUrl}",`,
                         `    "ANTHROPIC_MODEL": "kimi-k3",`,
-                        `    "ANTHROPIC_SMALL_FAST_MODEL": "kimi-k3"`,
+                        `    "ANTHROPIC_DEFAULT_OPUS_MODEL": "kimi-k3",`,
+                        `    "ANTHROPIC_DEFAULT_SONNET_MODEL": "kimi-k3",`,
+                        `    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-k3",`,
+                        `    "CLAUDE_CODE_SUBAGENT_MODEL": "kimi-k3",`,
+                        `    "ENABLE_TOOL_SEARCH": "false"`,
                         `  }`,
                         `}`,
                       ]
@@ -251,7 +250,11 @@ export function AgentConnectTabs({
                         `export ANTHROPIC_BASE_URL=${baseUrl}`,
                         `export ANTHROPIC_API_KEY=none`,
                         `export ANTHROPIC_MODEL=kimi-k3`,
-                        `export ANTHROPIC_SMALL_FAST_MODEL=kimi-k3`,
+                        `export ANTHROPIC_DEFAULT_OPUS_MODEL=kimi-k3`,
+                        `export ANTHROPIC_DEFAULT_SONNET_MODEL=kimi-k3`,
+                        `export ANTHROPIC_DEFAULT_HAIKU_MODEL=kimi-k3`,
+                        `export CLAUDE_CODE_SUBAGENT_MODEL=kimi-k3`,
+                        `export ENABLE_TOOL_SEARCH=false`,
                         `claude`,
                       ]
                 }
@@ -270,60 +273,17 @@ export function AgentConnectTabs({
 
       <TabsContent value={"codex"}>
         <div className={contentClassName}>
-          {hasKimi && (
-            <div className={"mb-3"}>
-              <SelectDropdown
-                value={codexProvider}
-                onChange={(v) => setCodexProvider(v as "openai" | "kimi")}
-                options={[
-                  { label: "OpenAI API", value: "openai" },
-                  { label: "Kimi (Moonshot AI)", value: "kimi" },
-                ]}
-                showValues={false}
-                className={"w-[180px]"}
-              />
-            </div>
-          )}
-          {codexProvider === "openai" && (
-            <Snippet
-              caption={"Add to ~/.codex/config.toml:"}
-              lines={[
-                `model_provider = "netbird"`,
-                ``,
-                `[model_providers.netbird]`,
-                `name = "NetBird"`,
-                `base_url = "${openaiBase}"`,
-                `wire_api = "responses"`,
-              ]}
-            />
-          )}
-          {codexProvider === "kimi" && (
-            <>
-              <Snippet
-                // Kimi's OpenAI-compatible upstream speaks Chat Completions,
-                // not the Responses API Codex defaults to — wire_api "chat"
-                // is what makes Codex talk to it.
-                caption={"Add to ~/.codex/config.toml:"}
-                lines={[
-                  `model_provider = "netbird"`,
-                  `model = "kimi-k3"`,
-                  ``,
-                  `[model_providers.netbird]`,
-                  `name = "NetBird"`,
-                  `base_url = "${openaiBase}"`,
-                  `wire_api = "chat"`,
-                ]}
-              />
-              <SmallParagraph className={"mt-3"}>
-                Requires the Kimi provider&apos;s upstream URL to be{" "}
-                <code className={"font-mono"}>https://api.moonshot.ai</code> —
-                Codex sends OpenAI-shaped requests on /v1, and{" "}
-                <code className={"font-mono"}>wire_api = &quot;chat&quot;</code>{" "}
-                switches it from the Responses API to Chat Completions, which
-                is what Kimi&apos;s upstream speaks.
-              </SmallParagraph>
-            </>
-          )}
+          <Snippet
+            caption={"Add to ~/.codex/config.toml:"}
+            lines={[
+              `model_provider = "netbird"`,
+              ``,
+              `[model_providers.netbird]`,
+              `name = "NetBird"`,
+              `base_url = "${openaiBase}"`,
+              `wire_api = "responses"`,
+            ]}
+          />
         </div>
       </TabsContent>
 

--- a/src/modules/agent-network/agentAccessLogApi.ts
+++ b/src/modules/agent-network/agentAccessLogApi.ts
@@ -132,6 +132,7 @@ const KNOWN_PROVIDER_IDS: AIProviderId[] = [
   "bedrock_api",
   "vertex_ai_api",
   "mistral_api",
+  "kimi_api",
   "custom",
 ];
 

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -12,6 +12,7 @@ export type AIProviderId =
   | "bedrock_api"
   | "vertex_ai_api"
   | "mistral_api"
+  | "kimi_api"
   | "litellm_proxy"
   | "portkey"
   | "bifrost"

--- a/src/modules/onboarding/agent-network/OnboardingAgentConfigure.tsx
+++ b/src/modules/onboarding/agent-network/OnboardingAgentConfigure.tsx
@@ -15,9 +15,12 @@ type Props = {
 export const OnboardingAgentConfigure = ({ onBack, onNext }: Props) => {
   const { settings, providers } = useAIProviders();
 
-  // Open the tab that matches the connected provider: Anthropic speaks the
-  // Claude Code config, everything else is OpenAI-shaped so default to cURL.
-  const defaultTab = providers.some((p) => p.providerId === "anthropic_api")
+  // Open the tab that matches the connected provider: Anthropic and Kimi
+  // (whose upstream also speaks the Anthropic Messages API) get the Claude
+  // Code config, everything else is OpenAI-shaped so default to cURL.
+  const defaultTab = providers.some(
+    (p) => p.providerId === "anthropic_api" || p.providerId === "kimi_api",
+  )
     ? "claude-code"
     : "curl";
 
@@ -42,6 +45,7 @@ export const OnboardingAgentConfigure = ({ onBack, onNext }: Props) => {
           listClassName={"px-0"}
           contentClassName={"px-0 py-2"}
           defaultTab={defaultTab}
+          providerIds={providers.map((p) => p.providerId)}
         />
       ) : (
         <div


### PR DESCRIPTION
Pairs with the management catalog's new `kimi_api` entry (netbirdio/netbird#6853): Kimi (Moonshot AI) in the provider picker, and per-tool config help for the CLIs people actually run against Kimi.

**Changes**

- `kimi_api` in the `AIProviderId` union and access-log provider-id normalization.
- Provider modal: `api.moonshot.ai` host placeholder, upstream-URL help explaining the OpenAI-shape (`/v1`) vs Anthropic-shape (`/anthropic`) path choice, `sk-...` key placeholder.
- **Configure Your Agent**: Kimi backend option in the Claude Code tab (JSON + shell modes), a Kimi variant in the Codex tab using `wire_api = "chat"`, and a new Kimi CLI tab with the `~/.kimi/config.toml` setup (format verified against Moonshot's official CLI docs). All Kimi surfaces render **only when a `kimi_api` provider is connected**, and pre-select themselves when Kimi is the only provider of its shape.
- Playwright spec walking the full lifecycle against the real backend (catalog pick → prefilled host → catalog pricing → create → gated config surfaces → cleanup via new agent-network API helpers). **Self-skips when the management build's catalog lacks `kimi_api`**, so this can merge ahead of the backend and activate once the `management-cloud` image carries it.

## Screenshots

Connect Provider modal with the Kimi catalog entry:

<img width="672" src="https://raw.githubusercontent.com/netbirdio/docs/3eaf7dcbd872e7840f94c486a2685b2fa4009855/public/docs-static/img/agent-network/integrations/agent-network-connect-kimi.png" />

Catalog model with pricing:
<img width="672" src="https://raw.githubusercontent.com/netbirdio/docs/3eaf7dcbd872e7840f94c486a2685b2fa4009855/public/docs-static/img/agent-network/integrations/agent-network-kimi-models.png" />

Configure Your Agent — Claude Code tab (Kimi pre-selected):
<img width="672" src="https://raw.githubusercontent.com/netbirdio/docs/597aee90c4d33fd4f7884cf9ee765e27eeb97848/public/docs-static/img/agent-network/integrations/agent-network-configure-agent-kimi-claude-code.png" />

Configure Your Agent — Kimi CLI tab:
<img width="672" src="https://raw.githubusercontent.com/netbirdio/docs/597aee90c4d33fd4f7884cf9ee765e27eeb97848/public/docs-static/img/agent-network/integrations/agent-network-configure-agent-kimi-cli.png" />
## Issue ticket number and link

N/A — companion to netbirdio/netbird#6853.

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/872

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for connecting Moonshot AI’s Kimi provider in Agent Network, including Kimi-specific upstream URL behavior and `sk-...` API key placeholder.
  * Enabled Kimi-aware UI: shows Kimi CLI and applies `kimi-k3` defaults plus gated Codex surfaces when a Kimi connection exists.
  * Updated onboarding to route users based on existing `kimi_api` (in addition to `anthropic_api`) connections.
* **Bug Fixes**
  * Improved provider ID normalization to reliably recognize `kimi_api`.
* **Tests**
  * Added end-to-end coverage for the Kimi provider lifecycle and expanded provider CRUD-style test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->