### PR TITLE
Show a login screen instead of auto-redirecting to the IdP

### DIFF
--- a/src/auth/LoginScreen.tsx
+++ b/src/auth/LoginScreen.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Button from "@components/Button";
+import Image from "next/image";
+import * as React from "react";
+import { ArrowRight } from "lucide-react";
+import NetBirdLogoFull from "@/assets/netbird-full.svg";
+
+type Props = {
+  onLogin: () => void;
+};
+
+export const LoginScreen = ({ onLogin }: Props) => {
+  return (
+    <div className={"flex w-screen h-screen bg-nb-gray-950"}>
+      <div
+        className={
+          "relative flex flex-col w-full lg:w-1/2 px-8 sm:px-16 lg:px-24"
+        }
+      >
+        <div className={"pt-10"}>
+          <Image src={NetBirdLogoFull} height={24} alt={"NetBird Logo"} />
+        </div>
+
+        <div className={"flex flex-col justify-center flex-1 max-w-md"}>
+          <h1 className={"text-3xl font-medium text-white mb-2"}>
+            Welcome back
+          </h1>
+          <p className={"text-nb-gray-300 mb-8"}>
+            Sign in to access your NetBird network.
+          </p>
+
+          <Button variant={"primary"} size={"lg"} onClick={onLogin}>
+            Sign in
+            <ArrowRight size={16} />
+          </Button>
+
+          <p className={"text-sm text-nb-gray-400 mt-8"}>
+            Don&apos;t have an account yet?{" "}
+            <a
+              href={"https://netbird.io/pricing"}
+              target={"_blank"}
+              rel={"noreferrer"}
+              className={"text-netbird underline underline-offset-4"}
+            >
+              Get started
+            </a>
+          </p>
+        </div>
+      </div>
+
+      <div
+        className={
+          "hidden lg:flex flex-col items-center justify-center w-1/2 bg-nb-gray-920 border-l border-nb-gray-900 px-16"
+        }
+      >
+        <div
+          className={
+            "relative w-full max-w-md rounded-2xl bg-nb-gray-950 border border-nb-gray-900 p-6 shadow-xl"
+          }
+        >
+          <div className={"flex items-center justify-between mb-6"}>
+            <span className={"text-sm text-nb-gray-300"}>Connected peers</span>
+            <span className={"flex items-center gap-2 text-xs text-nb-gray-400"}>
+              <span className={"w-2 h-2 rounded-full bg-netbird"} /> Active
+              <span className={"w-2 h-2 rounded-full bg-nb-blue ml-2"} /> Idle
+            </span>
+          </div>
+          <div className={"flex flex-col gap-3"}>
+            {[90, 76, 64, 48, 33, 22].map((w, i) => (
+              <div key={i} className={"h-3 w-full rounded-full bg-nb-gray-900"}>
+                <div
+                  className={
+                    i % 2 === 0
+                      ? "h-3 rounded-full bg-netbird"
+                      : "h-3 rounded-full bg-nb-blue"
+                  }
+                  style={{ width: `${w}%` }}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <p className={"text-sm text-nb-gray-400 mt-10"}>
+          Secure networking, zero config
+        </p>
+        <h2
+          className={
+            "text-2xl font-medium text-white text-center mt-2 max-w-md"
+          }
+        >
+          Connect your devices into a secure private network in minutes.
+        </h2>
+      </div>
+    </div>
+  );
+};

--- a/src/auth/SecureProvider.tsx
+++ b/src/auth/SecureProvider.tsx
@@ -2,6 +2,7 @@ import { OidcSecure, useOidc } from "@axa-fr/react-oidc";
 import { usePathname } from "next/navigation";
 import * as React from "react";
 import { useEffect } from "react";
+import { LoginScreen } from "@/auth/LoginScreen";
 
 const QUERY_PARAMS_KEY = "netbird-query-params";
 
@@ -72,19 +73,9 @@ export const SecureProvider = ({ children }: Props) => {
     }
   }, [isAuthenticated, currentPath]);
 
-  useEffect(() => {
-    let timeout: NodeJS.Timeout | undefined = undefined;
-    if (!isAuthenticated) {
-      timeout = setTimeout(async () => {
-        if (!isAuthenticated) {
-          await login(currentPath);
-        }
-      }, 1500);
-    }
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [currentPath, isAuthenticated, login]);
+  if (!isAuthenticated) {
+    return <LoginScreen onLogin={() => login(currentPath)} />;
+  }
 
   return (
     <>


### PR DESCRIPTION
Currently unauthenticated users get bounced to the identity provider after a 1.5s delay, which looks like a broken blank page. This adds a simple login screen with a sign-in button instead, plus a small marketing panel on the right for larger screens. The actual authentication flow is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/dashboard/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787498702&installation_model_id=427504&pr_number=729&repository=netbirdio%2Fdashboard&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdashboard%2Fpull%2F729&signature=bbe48f898843b40a504f7e9eb618adf175c19741a426d4f389b355f53a47ce48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->