### PR TITLE
Add allow_match toggle and browser-detected country to access rules

### DIFF
--- a/src/components/ui/CountrySelector.tsx
+++ b/src/components/ui/CountrySelector.tsx
@@ -6,6 +6,26 @@ import { createElement, useMemo } from "react";
 import RoundedFlag from "@/assets/countries/RoundedFlag";
 import { useCountries } from "@/contexts/CountryProvider";
 
+// browserCountryCode returns the ISO 3166-1 alpha-2 region from the browser's
+// preferred languages (e.g. "en-US" -> "US"), or undefined when none carries a
+// region. It reads navigator.languages, so it is client-only.
+function browserCountryCode(): string | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  const langs = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language];
+  for (const lang of langs) {
+    if (!lang) continue;
+    try {
+      const region = new Intl.Locale(lang).region;
+      if (region) return region.toUpperCase();
+    } catch {
+      // Ignore malformed language tags and try the next one.
+    }
+  }
+  return undefined;
+}
+
 type Props = {
   value: string;
   onChange: (value: string) => void;
@@ -13,7 +33,13 @@ type Props = {
   popoverWidth?: "auto" | "content" | number;
   truncate?: boolean;
 };
-export const CountrySelector = ({ value, onChange, iconSize = 20, popoverWidth, truncate }: Props) => {
+export const CountrySelector = ({
+  value,
+  onChange,
+  iconSize = 20,
+  popoverWidth,
+  truncate,
+}: Props) => {
   const { countries, isLoading } = useCountries();
 
   const countryList = useMemo(() => {
@@ -36,6 +62,20 @@ export const CountrySelector = ({ value, onChange, iconSize = 20, popoverWidth, 
     }) as SelectOption[];
   }, [countries]);
 
+  // Surface the browser-detected country at the top so the common case is one
+  // click away. Falls back to the original order when detection fails or the
+  // code is not in the list.
+  const orderedList = useMemo(() => {
+    if (!countryList?.length) return countryList;
+    const code = browserCountryCode();
+    if (!code) return countryList;
+    const index = countryList.findIndex((option) => option.value === code);
+    if (index <= 0) return countryList;
+    const reordered = countryList.slice();
+    const [detected] = reordered.splice(index, 1);
+    return [detected, ...reordered];
+  }, [countryList]);
+
   return (
     <div className={"block w-full"}>
       <SelectDropdown
@@ -46,7 +86,7 @@ export const CountrySelector = ({ value, onChange, iconSize = 20, popoverWidth, 
         value={value}
         onChange={onChange}
         iconSize={iconSize}
-        options={countryList || []}
+        options={orderedList || []}
         popoverWidth={popoverWidth}
         truncate={truncate}
       />

--- a/src/interfaces/ReverseProxy.ts
+++ b/src/interfaces/ReverseProxy.ts
@@ -33,12 +33,20 @@ export const CrowdSecMode = {
 
 export type CrowdSecMode = (typeof CrowdSecMode)[keyof typeof CrowdSecMode];
 
+export const AllowMatch = {
+  ALL: "all",
+  ANY: "any",
+} as const;
+
+export type AllowMatch = (typeof AllowMatch)[keyof typeof AllowMatch];
+
 export interface AccessRestrictions {
   allowed_cidrs?: string[];
   blocked_cidrs?: string[];
   allowed_countries?: string[];
   blocked_countries?: string[];
   crowdsec_mode?: CrowdSecMode;
+  allow_match?: AllowMatch;
 }
 
 export interface ReverseProxyMeta {

--- a/src/modules/reverse-proxy/ReverseProxyAccessControlRules.tsx
+++ b/src/modules/reverse-proxy/ReverseProxyAccessControlRules.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Label } from "@components/Label";
 import HelpText from "@components/HelpText";
+import FullTooltip from "@components/FullTooltip";
+import { ToggleSwitch } from "@components/ToggleSwitch";
 import Button from "@components/Button";
 import { Input } from "@components/Input";
 import cidr from "ip-cidr";
 import { hostSuffixFor, isIPv6 } from "@utils/ip";
 import {
   FlagIcon,
+  InfoIcon,
   MinusCircleIcon,
   NetworkIcon,
   PlusIcon,
@@ -19,7 +22,11 @@ import {
   SelectOption,
 } from "@components/select/SelectDropdown";
 import { CountrySelector } from "@/components/ui/CountrySelector";
-import { AccessRestrictions, CrowdSecMode } from "@/interfaces/ReverseProxy";
+import {
+  AccessRestrictions,
+  AllowMatch,
+  CrowdSecMode,
+} from "@/interfaces/ReverseProxy";
 import { ReverseProxyCrowdSecIPReputation } from "@/modules/reverse-proxy/ReverseProxyCrowdSecIPReputation";
 
 type AccessAction = "allow" | "block";
@@ -118,9 +125,33 @@ function restrictionsToRules(
   return rules;
 }
 
+// allowSpansCategories reports whether the allow rules cover both a location
+// (country) and an IP/CIDR category. The all-vs-any combine mode only changes
+// the outcome in that case, so allow_match is only persisted then.
+//
+// requireValue distinguishes the two callers: persistence needs a real value
+// (an empty rule contributes no allowlist), while the toggle's visibility keys
+// off the selected type alone so it appears as soon as a category is chosen,
+// before the user finishes typing.
+function allowSpansCategories(
+  rules: AccessRule[],
+  requireValue: boolean,
+): boolean {
+  let hasCountry = false;
+  let hasCidr = false;
+  for (const rule of rules) {
+    if (rule.action !== "allow") continue;
+    if (requireValue && !rule.value) continue;
+    if (rule.type === "country") hasCountry = true;
+    else hasCidr = true;
+  }
+  return hasCountry && hasCidr;
+}
+
 function rulesToRestrictions(
   rules: AccessRule[],
   crowdsecMode?: CrowdSecMode,
+  allowMatch?: AllowMatch,
 ): AccessRestrictions | undefined {
   const allowed_countries: string[] = [];
   const blocked_countries: string[] = [];
@@ -153,12 +184,19 @@ function rulesToRestrictions(
 
   if (!hasAny) return undefined;
 
+  // Only emit allow_match when "any" is selected and the allow rules actually
+  // span both categories; otherwise the mode is a no-op and the backend
+  // defaults to "all".
+  const emitAllowMatch =
+    allowMatch === AllowMatch.ANY && allowSpansCategories(rules, true);
+
   return {
     ...(allowed_countries.length > 0 && { allowed_countries }),
     ...(blocked_countries.length > 0 && { blocked_countries }),
     ...(allowed_cidrs.length > 0 && { allowed_cidrs }),
     ...(blocked_cidrs.length > 0 && { blocked_cidrs }),
     ...(hasCrowdSec && { crowdsec_mode: crowdsecMode }),
+    ...(emitAllowMatch && { allow_match: AllowMatch.ANY }),
   };
 }
 
@@ -167,6 +205,10 @@ type Props = {
   onChange: (value: AccessRestrictions | undefined) => void;
   onValidationChange?: (hasErrors: boolean) => void;
   supportsCrowdSec?: boolean;
+  // isNewService selects the default allow-combine mode: new services default
+  // to "any" (OR across categories), while existing services without a stored
+  // allow_match keep "all" (AND) for backward compatibility.
+  isNewService?: boolean;
 };
 
 function validateRule(rule: AccessRule): string {
@@ -193,6 +235,7 @@ export const ReverseProxyAccessControlRules = ({
   onChange,
   onValidationChange,
   supportsCrowdSec,
+  isNewService,
 }: Props) => {
   const [rules, dispatch] = useReducer(
     rulesReducer,
@@ -202,6 +245,15 @@ export const ReverseProxyAccessControlRules = ({
 
   const [crowdsecMode, setCrowdsecMode] = useState<CrowdSecMode>(
     value?.crowdsec_mode ?? CrowdSecMode.OFF,
+  );
+
+  const [allowMatch, setAllowMatch] = useState<AllowMatch>(
+    value?.allow_match ?? (isNewService ? AllowMatch.ANY : AllowMatch.ALL),
+  );
+
+  const showAllowMatch = useMemo(
+    () => allowSpansCategories(rules, false),
+    [rules],
   );
 
   const errors = useMemo(
@@ -227,8 +279,8 @@ export const ReverseProxyAccessControlRules = ({
   }, [supportsCrowdSec]);
 
   useEffect(() => {
-    onChangeRef.current(rulesToRestrictions(rules, crowdsecMode));
-  }, [rules, crowdsecMode]);
+    onChangeRef.current(rulesToRestrictions(rules, crowdsecMode, allowMatch));
+  }, [rules, crowdsecMode, allowMatch]);
 
   useEffect(() => {
     onValidationChangeRef.current?.(hasErrors);
@@ -242,6 +294,42 @@ export const ReverseProxyAccessControlRules = ({
           onChange={setCrowdsecMode}
         />
       )}
+      <div
+        className={`flex items-center justify-between gap-4 mb-4 ${
+          showAllowMatch ? "" : "opacity-60"
+        }`}
+        data-testid="allow-match"
+      >
+        <div>
+          <Label className="flex items-center gap-2">
+            Require all allow rules
+            <FullTooltip
+              content={
+                <div className="text-xs max-w-xs">
+                  When on, a connection must match every allow category (an
+                  allowed country and an allowed IP/CIDR). When off, matching
+                  any one is enough. Block rules always take priority.
+                </div>
+              }
+            >
+              <InfoIcon size={14} className="text-nb-gray-500" />
+            </FullTooltip>
+          </Label>
+          <HelpText margin={false}>
+            {showAllowMatch
+              ? "Off: match any allow rule. On: match all of them."
+              : "Applies once you have both a country and an IP/CIDR allow rule."}
+          </HelpText>
+        </div>
+        <ToggleSwitch
+          checked={allowMatch === AllowMatch.ALL}
+          onCheckedChange={(checked) =>
+            setAllowMatch(checked ? AllowMatch.ALL : AllowMatch.ANY)
+          }
+          disabled={!showAllowMatch}
+          data-testid="allow-match-toggle"
+        />
+      </div>
       <div>
         <Label>Access Control Rules</Label>
         <HelpText>

--- a/src/modules/reverse-proxy/ReverseProxyModal.tsx
+++ b/src/modules/reverse-proxy/ReverseProxyModal.tsx
@@ -814,6 +814,7 @@ export default function ReverseProxyModal({
                 onChange={setAccessRestrictions}
                 onValidationChange={setAccessControlHasErrors}
                 supportsCrowdSec={selectedDomain?.supports_crowdsec}
+                isNewService={!reverseProxy?.id}
               />
             </div>
           </TabsContent>


### PR DESCRIPTION
Adds a UI for the reverse proxy `allow_match` mode and improves the country picker.

- Add a "Require all allow rules" toggle on the access control tab that controls how allow rules combine: off matches any allow category (country OR IP/CIDR), on requires all of them. It stays disabled until allow rules span both a country and an IP/CIDR, since that is the only case where the mode changes the outcome.
- Default new services to match-any; existing services without a stored value keep match-all for backward compatibility.
- Surface the browser-detected country at the top of the country selector.

<img width="673" height="657" alt="image" src="https://github.com/user-attachments/assets/9b0ad524-4afb-4607-8713-bae178e6d0a4" />


## Issue ticket number and link

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/884

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/dashboard/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787552788&installation_model_id=427504&pr_number=730&repository=netbirdio%2Fdashboard&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdashboard%2Fpull%2F730&signature=5bd118d79d9b61dd145c39ea0ad6acd60398eb91d78d966adbed29631a10c70c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Country selection now prioritizes the option matching the browser’s preferred region when available.
  - Reverse proxy access controls now support choosing whether users must match **all** configured allow rules or **any** of them.
  - The match mode is available when both country and IP/CIDR rules are configured, with sensible defaults for new and existing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->