### PR TITLE
Show agent-network prompt-cache tokens and cost on hover

### DIFF
--- a/e2e/tests/agent-network-cache-accounting.spec.ts
+++ b/e2e/tests/agent-network-cache-accounting.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Agent Network prompt-cache accounting spec.
+ *
+ * Drives the Usage & Logs page against mocked agent-network endpoints whose
+ * rows carry the cache fields (cached_input_tokens / cache_creation_tokens /
+ * cache_cost_usd) and verifies the hover breakdowns: the access-log Tokens
+ * tooltip gains cache read/write rows and a cache-aware total, the Cost
+ * tooltip splits out the cache share, and the usage overview's daily table
+ * surfaces the day's cache buckets. Route mocks keep the spec hermetic, so it
+ * passes against management builds that predate the cache fields.
+ */
+import { test, expect, type Browser, type Page } from "@playwright/test";
+import { loginToApp } from "../helpers/auth";
+
+const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
+
+// The reported field scenario: a session-start request that wrote a ~32k-token
+// prompt cache, and a follow-up that read it back.
+const writeEntry = {
+  id: "anlog-cache-write",
+  service_id: "svc-e2e",
+  timestamp: new Date().toISOString(),
+  status_code: 200,
+  duration_ms: 29000,
+  input_tokens: 10,
+  output_tokens: 1472,
+  total_tokens: 33591,
+  cached_input_tokens: 0,
+  cache_creation_tokens: 32109,
+  cost_usd: 0.142519,
+  cache_cost_usd: 0.120409,
+  provider: "bedrock",
+  model: "anthropic.claude-sonnet-4-5",
+  session_id: "sess-cache-write",
+  decision: "allow",
+  stream: false,
+};
+
+const readEntry = {
+  ...writeEntry,
+  id: "anlog-cache-read",
+  output_tokens: 800,
+  total_tokens: 32919,
+  cached_input_tokens: 32109,
+  cache_creation_tokens: 0,
+  cost_usd: 0.021663,
+  cache_cost_usd: 0.009633,
+  session_id: "sess-cache-read",
+};
+
+const todayBucket = {
+  period_start: new Date().toISOString().slice(0, 10),
+  input_tokens: 20,
+  output_tokens: 2272,
+  total_tokens: 66510,
+  cached_input_tokens: 32109,
+  cache_creation_tokens: 32109,
+  cost_usd: 0.164182,
+  cache_cost_usd: 0.130042,
+};
+
+async function mockCacheUsage(page: Page) {
+  await page.route("**/api/agent-network/access-logs*", (route) =>
+    route.fulfill({
+      json: {
+        data: [writeEntry, readEntry],
+        page: 1,
+        page_size: 25,
+        total_records: 2,
+        total_pages: 1,
+      },
+    }),
+  );
+  await page.route("**/api/agent-network/usage/overview*", (route) =>
+    route.fulfill({ json: [todayBucket] }),
+  );
+}
+
+async function newUsagePage(browser: Browser): Promise<{
+  page: Page;
+  close: () => Promise<void>;
+}> {
+  const context = await browser.newContext({
+    storageState: "e2e/fixtures/auth/owner.json",
+  });
+  await context.addInitScript(
+    ([key, value]) => {
+      try {
+        window.localStorage.setItem(key as string, value as string);
+      } catch (e) {}
+    },
+    [AGENT_NETWORK_CONFIG_KEY, "enabled"],
+  );
+  const page = await context.newPage();
+  await mockCacheUsage(page);
+  await loginToApp(page, "owner");
+  return { page, close: () => context.close() };
+}
+
+// Only the open tooltip carries role=tooltip, so this resolves to the hovered one.
+function tooltip(page: Page) {
+  return page.getByRole("tooltip");
+}
+
+test.describe.serial("Agent Network cache accounting @agent-network", () => {
+  test("access-log hover breaks out prompt-cache tokens and cost", async ({
+    browser,
+  }) => {
+    const { page, close } = await newUsagePage(browser);
+    try {
+      await page.goto("/agent-network/usage?tab=access-logs");
+
+      const writeRow = page.getByRole("row").filter({ hasText: "$0.1425" });
+      await expect(writeRow).toBeVisible();
+
+      // Tokens tooltip: cache-write bucket plus a total that includes it.
+      await writeRow.getByText("1,472").hover();
+      await expect(tooltip(page)).toContainText("32,109");
+      await expect(tooltip(page)).toContainText("cache write");
+      await expect(tooltip(page)).toContainText("33,591");
+
+      // Cost tooltip: base vs cache vs total split.
+      await writeRow.getByText("$0.1425").hover();
+      await expect(tooltip(page)).toContainText("$0.0221");
+      await expect(tooltip(page)).toContainText("$0.1204");
+      await expect(tooltip(page)).toContainText("cache");
+
+      // The follow-up request reads the cache back: read bucket, no write row.
+      const readRow = page.getByRole("row").filter({ hasText: "$0.0217" });
+      await readRow.getByText("800", { exact: true }).hover();
+      await expect(tooltip(page)).toContainText("cache read");
+      await expect(tooltip(page)).toContainText("32,919");
+      await expect(tooltip(page)).not.toContainText("cache write");
+    } finally {
+      await close();
+    }
+  });
+
+  test("usage overview daily table surfaces the day's cache buckets", async ({
+    browser,
+  }) => {
+    const { page, close } = await newUsagePage(browser);
+    try {
+      await page.goto("/agent-network/usage");
+
+      // Total Tokens includes the additive cache buckets; hover splits them.
+      await expect(page.getByText("66,510")).toBeVisible();
+      await page.getByText("66,510").hover();
+      await expect(tooltip(page)).toContainText("cache read: 32,109");
+      await expect(tooltip(page)).toContainText("cache write: 32,109");
+
+      // Cost hover shows the cache share of the day's spend.
+      await page.getByText("$0.16", { exact: true }).hover();
+      await expect(tooltip(page)).toContainText("cache: $0.13");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/e2e/tests/agent-network-cache-accounting.spec.ts
+++ b/e2e/tests/agent-network-cache-accounting.spec.ts
@@ -110,17 +110,23 @@ async function newUsagePage(browser: Browser): Promise<{
   return { page, close: () => context.close() };
 }
 
-// Only the open tooltip carries role=tooltip, so this resolves to the hovered one.
+// FullTooltip force-mounts its content, so a tooltip keeps its role=tooltip
+// element in the DOM after closing — a bare getByRole("tooltip") accumulates
+// every tooltip the test has ever opened. Radix puts role=tooltip on a
+// visually-hidden span and the open/closed flag on that span's parent
+// ("delayed-open"/"instant-open" vs "closed"), so match the parent that is
+// currently open. Its text covers both the visible copy and the hidden one.
 function tooltip(page: Page) {
-  return page.getByRole("tooltip");
+  return page.locator(
+    '[data-state="delayed-open"]:has(> [role="tooltip"]), [data-state="instant-open"]:has(> [role="tooltip"])',
+  );
 }
 
-// Radix keeps a tooltip mounted until the pointer leaves its trigger, and
-// hovering straight from one cell to the next in the same row can leave both
-// open — which makes tooltip() match two elements. Park the pointer off the
-// table and wait for the open one to unmount before the next hover.
-async function hoverAway(page: Page) {
-  await page.mouse.move(0, 0);
+// Radix's hoverable content holds a tooltip open while the pointer travels
+// toward it, so moving straight to the next cell can leave two open at once.
+// Escape dismisses the open one deterministically, wherever the pointer sits.
+async function closeTooltip(page: Page) {
+  await page.keyboard.press("Escape");
   await expect(tooltip(page)).toHaveCount(0);
 }
 
@@ -144,7 +150,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       // Cost tooltip: all four buckets are listed plus the total, including
       // buckets that cost nothing — this request wrote the cache but never read
       // it, so "cache read" is present with a $0.0000 amount.
-      await hoverAway(page);
+      await closeTooltip(page);
       await writeRow.getByText("$0.1425").hover();
       await expect(tooltip(page)).toContainText("input");
       await expect(tooltip(page)).toContainText("cache read");
@@ -159,7 +165,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       // bucket still listed as a zero row.
       // No exact match: the output count renders behind an sr-only "Output:" prefix.
       const readRow = page.getByRole("row").filter({ hasText: "$0.0217" });
-      await hoverAway(page);
+      await closeTooltip(page);
       await readRow.getByText("800").hover();
       await expect(tooltip(page)).toContainText("cache read");
       await expect(tooltip(page)).toContainText("32,919");
@@ -183,7 +189,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       await expect(tooltip(page)).toContainText("cache write: 32,109");
 
       // Cost hover shows the cache share of the day's spend.
-      await hoverAway(page);
+      await closeTooltip(page);
       await page.getByText("$0.16", { exact: true }).hover();
       await expect(tooltip(page)).toContainText("cache: $0.13");
     } finally {

--- a/e2e/tests/agent-network-cache-accounting.spec.ts
+++ b/e2e/tests/agent-network-cache-accounting.spec.ts
@@ -182,16 +182,30 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
     try {
       await navigateTo(page, "/agent-network/usage");
 
-      // Total Tokens includes the additive cache buckets; hover splits them.
-      await expect(page.getByText("66,510")).toBeVisible();
-      await page.getByText("66,510").hover();
-      await expect(tooltip(page)).toContainText("cache read: 32,109");
-      await expect(tooltip(page)).toContainText("cache write: 32,109");
+      // Row-scoped on purpose: the hovers now repeat the cell's own figure on
+      // their total row, and FullTooltip force-mounts that content, so a
+      // page-wide getByText would match the cell and the tooltip both. Radix
+      // portals tooltip content to <body>, outside the row.
+      const dayRow = page.getByRole("row").filter({ hasText: "$0.16" });
 
-      // Cost hover shows the cache share of the day's spend.
+      // Total Tokens includes the additive cache buckets; hover splits them out
+      // in the same value-then-label rows the access-log table uses.
+      await expect(dayRow.getByText("66,510")).toBeVisible();
+      await dayRow.getByText("66,510").hover();
+      await expect(tooltip(page)).toContainText(/20\s*input/);
+      await expect(tooltip(page)).toContainText(/2,272\s*output/);
+      await expect(tooltip(page)).toContainText(/32,109\s*cache read/);
+      await expect(tooltip(page)).toContainText(/32,109\s*cache write/);
+      await expect(tooltip(page)).toContainText(/66,510\s*total/);
+
+      // Cost hover breaks the day into the same four billed buckets.
       await closeTooltip(page);
-      await page.getByText("$0.16", { exact: true }).hover();
-      await expect(tooltip(page)).toContainText("cache: $0.13");
+      await dayRow.getByText("$0.16", { exact: true }).hover();
+      await expect(tooltip(page)).toContainText(/\$0\.0001\s*input/);
+      await expect(tooltip(page)).toContainText(/\$0\.0341\s*output/);
+      await expect(tooltip(page)).toContainText(/\$0\.0096\s*cache read/);
+      await expect(tooltip(page)).toContainText(/\$0\.1204\s*cache write/);
+      await expect(tooltip(page)).toContainText(/\$0\.1642\s*total/);
     } finally {
       await close();
     }

--- a/e2e/tests/agent-network-cache-accounting.spec.ts
+++ b/e2e/tests/agent-network-cache-accounting.spec.ts
@@ -126,8 +126,9 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       await expect(tooltip(page)).toContainText("cache");
 
       // The follow-up request reads the cache back: read bucket, no write row.
+      // No exact match: the output count renders behind an sr-only "Output:" prefix.
       const readRow = page.getByRole("row").filter({ hasText: "$0.0217" });
-      await readRow.getByText("800", { exact: true }).hover();
+      await readRow.getByText("800").hover();
       await expect(tooltip(page)).toContainText("cache read");
       await expect(tooltip(page)).toContainText("32,919");
       await expect(tooltip(page)).not.toContainText("cache write");

--- a/e2e/tests/agent-network-cache-accounting.spec.ts
+++ b/e2e/tests/agent-network-cache-accounting.spec.ts
@@ -3,9 +3,10 @@
  *
  * Drives the Usage & Logs page against mocked agent-network endpoints whose
  * rows carry the cache fields (cached_input_tokens / cache_creation_tokens /
- * cache_cost_usd) and verifies the hover breakdowns: the access-log Tokens
- * tooltip gains cache read/write rows and a cache-aware total, the Cost
- * tooltip splits out the cache share, and the usage overview's daily table
+ * cache_cost_usd) plus the per-bucket cost breakdown, and verifies the hover
+ * breakdowns: the access-log Tokens tooltip gains cache read/write rows and a
+ * cache-aware total, the Cost tooltip lists one line per billed bucket, and
+ * the usage overview's daily table
  * surfaces the day's cache buckets. Route mocks keep the spec hermetic, so it
  * passes against management builds that predate the cache fields.
  */
@@ -29,6 +30,10 @@ const writeEntry = {
   cache_creation_tokens: 32109,
   cost_usd: 0.142519,
   cache_cost_usd: 0.120409,
+  input_cost_usd: 0.00003,
+  cached_input_cost_usd: 0,
+  cache_creation_cost_usd: 0.120409,
+  output_cost_usd: 0.02208,
   provider: "bedrock",
   model: "anthropic.claude-sonnet-4-5",
   session_id: "sess-cache-write",
@@ -45,6 +50,10 @@ const readEntry = {
   cache_creation_tokens: 0,
   cost_usd: 0.021663,
   cache_cost_usd: 0.009633,
+  input_cost_usd: 0.00003,
+  cached_input_cost_usd: 0.009633,
+  cache_creation_cost_usd: 0,
+  output_cost_usd: 0.012,
   session_id: "sess-cache-read",
 };
 
@@ -57,6 +66,10 @@ const todayBucket = {
   cache_creation_tokens: 32109,
   cost_usd: 0.164182,
   cache_cost_usd: 0.130042,
+  input_cost_usd: 0.00006,
+  cached_input_cost_usd: 0.009633,
+  cache_creation_cost_usd: 0.120409,
+  output_cost_usd: 0.03408,
 };
 
 async function mockCacheUsage(page: Page) {
@@ -119,19 +132,27 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       await expect(tooltip(page)).toContainText("cache write");
       await expect(tooltip(page)).toContainText("33,591");
 
-      // Cost tooltip: base vs cache vs total split.
+      // Cost tooltip: all four buckets are listed plus the total, including
+      // buckets that cost nothing — this request wrote the cache but never read
+      // it, so "cache read" is present with a $0.0000 amount.
       await writeRow.getByText("$0.1425").hover();
-      await expect(tooltip(page)).toContainText("$0.0221");
+      await expect(tooltip(page)).toContainText("input");
+      await expect(tooltip(page)).toContainText("cache read");
+      await expect(tooltip(page)).toContainText("cache write");
+      await expect(tooltip(page)).toContainText("output");
       await expect(tooltip(page)).toContainText("$0.1204");
-      await expect(tooltip(page)).toContainText("cache");
+      await expect(tooltip(page)).toContainText("$0.0221");
+      await expect(tooltip(page)).toContainText("$0.0000");
+      await expect(tooltip(page)).toContainText("total");
 
-      // The follow-up request reads the cache back: read bucket, no write row.
+      // The follow-up request reads the cache back: read bucket filled, write
+      // bucket still listed as a zero row.
       // No exact match: the output count renders behind an sr-only "Output:" prefix.
       const readRow = page.getByRole("row").filter({ hasText: "$0.0217" });
       await readRow.getByText("800").hover();
       await expect(tooltip(page)).toContainText("cache read");
       await expect(tooltip(page)).toContainText("32,919");
-      await expect(tooltip(page)).not.toContainText("cache write");
+      await expect(tooltip(page)).toContainText(/0\s*cache write/);
     } finally {
       await close();
     }

--- a/e2e/tests/agent-network-cache-accounting.spec.ts
+++ b/e2e/tests/agent-network-cache-accounting.spec.ts
@@ -11,7 +11,7 @@
  * passes against management builds that predate the cache fields.
  */
 import { test, expect, type Browser, type Page } from "@playwright/test";
-import { loginToApp } from "../helpers/auth";
+import { loginToApp, navigateTo } from "../helpers/auth";
 
 const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
 
@@ -115,13 +115,22 @@ function tooltip(page: Page) {
   return page.getByRole("tooltip");
 }
 
+// Radix keeps a tooltip mounted until the pointer leaves its trigger, and
+// hovering straight from one cell to the next in the same row can leave both
+// open — which makes tooltip() match two elements. Park the pointer off the
+// table and wait for the open one to unmount before the next hover.
+async function hoverAway(page: Page) {
+  await page.mouse.move(0, 0);
+  await expect(tooltip(page)).toHaveCount(0);
+}
+
 test.describe.serial("Agent Network cache accounting @agent-network", () => {
   test("access-log hover breaks out prompt-cache tokens and cost", async ({
     browser,
   }) => {
     const { page, close } = await newUsagePage(browser);
     try {
-      await page.goto("/agent-network/usage?tab=access-logs");
+      await navigateTo(page, "/agent-network/usage?tab=access-logs");
 
       const writeRow = page.getByRole("row").filter({ hasText: "$0.1425" });
       await expect(writeRow).toBeVisible();
@@ -135,6 +144,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       // Cost tooltip: all four buckets are listed plus the total, including
       // buckets that cost nothing — this request wrote the cache but never read
       // it, so "cache read" is present with a $0.0000 amount.
+      await hoverAway(page);
       await writeRow.getByText("$0.1425").hover();
       await expect(tooltip(page)).toContainText("input");
       await expect(tooltip(page)).toContainText("cache read");
@@ -149,6 +159,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       // bucket still listed as a zero row.
       // No exact match: the output count renders behind an sr-only "Output:" prefix.
       const readRow = page.getByRole("row").filter({ hasText: "$0.0217" });
+      await hoverAway(page);
       await readRow.getByText("800").hover();
       await expect(tooltip(page)).toContainText("cache read");
       await expect(tooltip(page)).toContainText("32,919");
@@ -163,7 +174,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
   }) => {
     const { page, close } = await newUsagePage(browser);
     try {
-      await page.goto("/agent-network/usage");
+      await navigateTo(page, "/agent-network/usage");
 
       // Total Tokens includes the additive cache buckets; hover splits them.
       await expect(page.getByText("66,510")).toBeVisible();
@@ -172,6 +183,7 @@ test.describe.serial("Agent Network cache accounting @agent-network", () => {
       await expect(tooltip(page)).toContainText("cache write: 32,109");
 
       // Cost hover shows the cache share of the day's spend.
+      await hoverAway(page);
       await page.getByText("$0.16", { exact: true }).hover();
       await expect(tooltip(page)).toContainText("cache: $0.13");
     } finally {

--- a/e2e/tests/setup-keys.spec.ts
+++ b/e2e/tests/setup-keys.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "../helpers/fixtures";
 import { navigateTo } from "../helpers/auth";
-import { generateRandomName } from "../helpers/utils";
+import { clearScrollLock, generateRandomName } from "../helpers/utils";
 import { deleteGroupsByPrefix, deleteSetupKeysByPrefix } from "../helpers/api";
 
 let setupKeys: string[] = [];
@@ -118,19 +118,34 @@ async function createSetupKey(
   await expect(page.getByText(opts.name)).toBeVisible();
 }
 
-async function revokeSetupKey(
+// openRowActions opens a row's action dropdown. A confirmation dialog closed
+// moments earlier can still leave Radix's scroll-lock artifacts on <body>
+// (`pointer-events: none`, a stale overlay), and those swallow the click even
+// with force — the menu then silently never opens and the item lookup times
+// out. Clear them before clicking.
+async function openRowActions(
   page: import("@playwright/test").Page,
   name: string,
 ) {
-  // Row actions are now behind a dropdown menu.
+  await clearScrollLock(page);
   await page
     .locator("tr")
     .filter({ hasText: name })
     .getByTestId("setup-key-actions")
     .click({ force: true });
-  await page
-    .locator('[data-testid="revoke-setup-key"]:not([data-disabled])')
-    .click({ force: true });
+}
+
+async function revokeSetupKey(
+  page: import("@playwright/test").Page,
+  name: string,
+) {
+  // Row actions are now behind a dropdown menu.
+  await openRowActions(page, name);
+  const revokeItem = page.locator(
+    '[data-testid="revoke-setup-key"]:not([data-disabled])',
+  );
+  await expect(revokeItem).toBeVisible();
+  await revokeItem.click({ force: true });
   const responsePromise = page.waitForResponse(
     (resp) => resp.url().includes("/api/setup-keys/") && resp.request().method() === "PUT",
     { timeout: 10_000 },
@@ -151,13 +166,23 @@ async function deleteSetupKey(
   name: string,
 ) {
   // Row actions are now behind a dropdown menu.
-  await page
-    .locator("tr")
-    .filter({ hasText: name })
-    .getByTestId("setup-key-actions")
-    .click({ force: true });
-  await page.getByTestId("delete-setup-key").click({ force: true });
+  await openRowActions(page, name);
+  const deleteItem = page.locator(
+    '[data-testid="delete-setup-key"]:not([data-disabled])',
+  );
+  await expect(deleteItem).toBeVisible();
+  await deleteItem.click({ force: true });
+  // Await the DELETE like revoke awaits its PUT: the handler refetches
+  // /setup-keys afterwards, which re-renders every row — returning before that
+  // settles means the next key's trigger click can land on a replaced node.
+  const responsePromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/setup-keys/") &&
+      resp.request().method() === "DELETE",
+    { timeout: 10_000 },
+  );
   await page.getByTestId("confirmation.confirm").click();
+  await responsePromise;
   await expect(page.locator("tr").filter({ hasText: name })).not.toBeVisible();
   await expect(page.getByRole("dialog")).not.toBeVisible();
 }

--- a/src/modules/agent-network/AgentAccessLogExpandedRow.tsx
+++ b/src/modules/agent-network/AgentAccessLogExpandedRow.tsx
@@ -46,6 +46,19 @@ export default function AgentAccessLogExpandedRow({ entry }: Readonly<Props>) {
     metadata["plg.llm.cache_creation_tokens"] = String(cacheWrite);
     metadata["plg.cost.usd_cache"] = (entry.cacheCostUsd ?? 0).toFixed(6);
   }
+  // Per-bucket cost keys mirror the proxy's cost.usd_* metadata. Emitted only
+  // when the server sent the breakdown, so a row from an older management
+  // server shows no misleading zeros.
+  if (entry.inputCostUsd !== undefined || entry.outputCostUsd !== undefined) {
+    metadata["plg.cost.usd_input"] = (entry.inputCostUsd ?? 0).toFixed(6);
+    metadata["plg.cost.usd_cached_input"] = (
+      entry.cachedInputCostUsd ?? 0
+    ).toFixed(6);
+    metadata["plg.cost.usd_cache_creation"] = (
+      entry.cacheCreationCostUsd ?? 0
+    ).toFixed(6);
+    metadata["plg.cost.usd_output"] = (entry.outputCostUsd ?? 0).toFixed(6);
+  }
   if (isDeny) {
     metadata["plg.llm_policy.decision"] = "deny";
     metadata["plg.llm_policy.reason"] = entry.denyReason ?? "unknown";

--- a/src/modules/agent-network/AgentAccessLogExpandedRow.tsx
+++ b/src/modules/agent-network/AgentAccessLogExpandedRow.tsx
@@ -26,17 +26,26 @@ export default function AgentAccessLogExpandedRow({ entry }: Readonly<Props>) {
   const hasBody = hasPrompt || hasCompletion;
   const denyReason = formatDenyReason(entry.denyReason);
 
+  const cacheRead = entry.cachedInputTokens ?? 0;
+  const cacheWrite = entry.cacheCreationTokens ?? 0;
   const metadata: Record<string, string> = {
     "plg.llm.provider": entry.providerId,
     "plg.llm.model": entry.model,
     "plg.llm.input_tokens": String(entry.inputTokens),
     "plg.llm.output_tokens": String(entry.outputTokens),
-    "plg.llm.total_tokens": String(entry.inputTokens + entry.outputTokens),
+    "plg.llm.total_tokens": String(
+      entry.inputTokens + entry.outputTokens + cacheRead + cacheWrite,
+    ),
     "plg.llm.cost_usd": entry.costUsd.toFixed(6),
     "plg.llm.stream": entry.stream ? "true" : "false",
     "plg.agentnetwork.policy_name": entry.policyName,
     "plg.agentnetwork.user_groups": (entry.userGroups ?? []).join(", "),
   };
+  if (cacheRead > 0 || cacheWrite > 0) {
+    metadata["plg.llm.cached_input_tokens"] = String(cacheRead);
+    metadata["plg.llm.cache_creation_tokens"] = String(cacheWrite);
+    metadata["plg.cost.usd_cache"] = (entry.cacheCostUsd ?? 0).toFixed(6);
+  }
   if (isDeny) {
     metadata["plg.llm_policy.decision"] = "deny";
     metadata["plg.llm_policy.reason"] = entry.denyReason ?? "unknown";

--- a/src/modules/agent-network/AgentAccessLogTable.tsx
+++ b/src/modules/agent-network/AgentAccessLogTable.tsx
@@ -40,6 +40,8 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   ChevronRight,
+  DatabaseIcon,
+  DatabaseZapIcon,
   ExternalLinkIcon,
   ShieldCheckIcon,
 } from "lucide-react";
@@ -261,13 +263,10 @@ export default function AgentAccessLogTable({
           </DataTableHeader>
         ),
         cell: ({ row }) => (
-          <span
-            className={
-              "text-nb-gray-300 text-[0.82rem] px-3 py-2 font-mono whitespace-nowrap"
-            }
-          >
-            ${row.original.costUsd.toFixed(4)}
-          </span>
+          <CostCell
+            costUsd={row.original.costUsd}
+            cacheCostUsd={row.original.cacheCostUsd}
+          />
         ),
       },
       {
@@ -409,6 +408,8 @@ export default function AgentAccessLogTable({
               {
                 inputTokens: row.original.inputTokens,
                 outputTokens: row.original.outputTokens,
+                cachedInputTokens: row.original.cachedInputTokens,
+                cacheCreationTokens: row.original.cacheCreationTokens,
               } as AIAccessLogEntry
             }
           />
@@ -423,13 +424,10 @@ export default function AgentAccessLogTable({
           </DataTableHeader>
         ),
         cell: ({ row }) => (
-          <span
-            className={
-              "text-nb-gray-300 text-[0.82rem] px-3 py-2 font-mono whitespace-nowrap"
-            }
-          >
-            ${row.original.costUsd.toFixed(4)}
-          </span>
+          <CostCell
+            costUsd={row.original.costUsd}
+            cacheCostUsd={row.original.cacheCostUsd}
+          />
         ),
       },
       {
@@ -999,7 +997,14 @@ function TokensCell({ entry }: { entry: AIAccessLogEntry }) {
   ) {
     return <EmptyRow />;
   }
-  const total = (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0);
+  const cacheRead = entry.cachedInputTokens ?? 0;
+  const cacheWrite = entry.cacheCreationTokens ?? 0;
+  // Anthropic-shape cache buckets are additive to input tokens, so they count toward the total.
+  const total =
+    (entry.inputTokens ?? 0) +
+    (entry.outputTokens ?? 0) +
+    cacheRead +
+    cacheWrite;
   return (
     <FullTooltip
       content={
@@ -1018,6 +1023,27 @@ function TokensCell({ entry }: { entry: AIAccessLogEntry }) {
             </span>
             <span className={"text-nb-gray-400"}>output</span>
           </div>
+          {cacheRead > 0 && (
+            <div className={"flex items-center gap-2 whitespace-nowrap"}>
+              <DatabaseIcon size={12} className={"text-amber-400 shrink-0"} />
+              <span className={"font-medium"}>
+                {cacheRead.toLocaleString()}
+              </span>
+              <span className={"text-nb-gray-400"}>cache read</span>
+            </div>
+          )}
+          {cacheWrite > 0 && (
+            <div className={"flex items-center gap-2 whitespace-nowrap"}>
+              <DatabaseZapIcon
+                size={12}
+                className={"text-amber-400 shrink-0"}
+              />
+              <span className={"font-medium"}>
+                {cacheWrite.toLocaleString()}
+              </span>
+              <span className={"text-nb-gray-400"}>cache write</span>
+            </div>
+          )}
           <div
             className={
               "border-t border-nb-gray-800 mt-0.5 pt-1 flex items-center gap-2 text-nb-gray-400 whitespace-nowrap"
@@ -1046,6 +1072,58 @@ function TokensCell({ entry }: { entry: AIAccessLogEntry }) {
           {entry.outputTokens.toLocaleString()}
         </div>
       </div>
+    </FullTooltip>
+  );
+}
+
+// CostCell renders the metered USD cost with a hover breakdown of how much of
+// it was billed for prompt-cache usage (cache read + write buckets).
+function CostCell({
+  costUsd,
+  cacheCostUsd,
+}: {
+  costUsd: number;
+  cacheCostUsd?: number;
+}) {
+  const cache = cacheCostUsd ?? 0;
+  const display = (
+    <span
+      className={
+        "text-nb-gray-300 text-[0.82rem] px-3 py-2 font-mono whitespace-nowrap"
+      }
+    >
+      ${costUsd.toFixed(4)}
+    </span>
+  );
+  if (cache <= 0) return display;
+  return (
+    <FullTooltip
+      content={
+        <div className={"text-xs flex flex-col gap-1 font-mono"}>
+          <div className={"flex items-center gap-2 whitespace-nowrap"}>
+            <span className={"font-medium"}>
+              ${(costUsd - cache).toFixed(4)}
+            </span>
+            <span className={"text-nb-gray-400 font-sans"}>input + output</span>
+          </div>
+          <div className={"flex items-center gap-2 whitespace-nowrap"}>
+            <span className={"font-medium"}>${cache.toFixed(4)}</span>
+            <span className={"text-nb-gray-400 font-sans"}>cache</span>
+          </div>
+          <div
+            className={
+              "border-t border-nb-gray-800 mt-0.5 pt-1 flex items-center gap-2 text-nb-gray-400 whitespace-nowrap"
+            }
+          >
+            <span className={"font-medium text-nb-gray-200"}>
+              ${costUsd.toFixed(4)}
+            </span>
+            <span className={"font-sans"}>total</span>
+          </div>
+        </div>
+      }
+    >
+      {display}
     </FullTooltip>
   );
 }

--- a/src/modules/agent-network/AgentAccessLogTable.tsx
+++ b/src/modules/agent-network/AgentAccessLogTable.tsx
@@ -40,8 +40,6 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   ChevronRight,
-  DatabaseIcon,
-  DatabaseZapIcon,
   ExternalLinkIcon,
   ShieldCheckIcon,
 } from "lucide-react";
@@ -266,6 +264,10 @@ export default function AgentAccessLogTable({
           <CostCell
             costUsd={row.original.costUsd}
             cacheCostUsd={row.original.cacheCostUsd}
+            inputCostUsd={row.original.inputCostUsd}
+            cachedInputCostUsd={row.original.cachedInputCostUsd}
+            cacheCreationCostUsd={row.original.cacheCreationCostUsd}
+            outputCostUsd={row.original.outputCostUsd}
           />
         ),
       },
@@ -427,6 +429,10 @@ export default function AgentAccessLogTable({
           <CostCell
             costUsd={row.original.costUsd}
             cacheCostUsd={row.original.cacheCostUsd}
+            inputCostUsd={row.original.inputCostUsd}
+            cachedInputCostUsd={row.original.cachedInputCostUsd}
+            cacheCreationCostUsd={row.original.cacheCreationCostUsd}
+            outputCostUsd={row.original.outputCostUsd}
           />
         ),
       },
@@ -1010,46 +1016,30 @@ function TokensCell({ entry }: { entry: AIAccessLogEntry }) {
       content={
         <div className={"text-xs flex flex-col gap-1"}>
           <div className={"flex items-center gap-2 whitespace-nowrap"}>
-            <ArrowUpIcon size={12} className={"text-sky-400 shrink-0"} />
             <span className={"font-medium"}>
               {entry.inputTokens.toLocaleString()}
             </span>
             <span className={"text-nb-gray-400"}>input</span>
           </div>
           <div className={"flex items-center gap-2 whitespace-nowrap"}>
-            <ArrowDownIcon size={12} className={"text-netbird shrink-0"} />
             <span className={"font-medium"}>
               {entry.outputTokens.toLocaleString()}
             </span>
             <span className={"text-nb-gray-400"}>output</span>
           </div>
-          {cacheRead > 0 && (
-            <div className={"flex items-center gap-2 whitespace-nowrap"}>
-              <DatabaseIcon size={12} className={"text-amber-400 shrink-0"} />
-              <span className={"font-medium"}>
-                {cacheRead.toLocaleString()}
-              </span>
-              <span className={"text-nb-gray-400"}>cache read</span>
-            </div>
-          )}
-          {cacheWrite > 0 && (
-            <div className={"flex items-center gap-2 whitespace-nowrap"}>
-              <DatabaseZapIcon
-                size={12}
-                className={"text-amber-400 shrink-0"}
-              />
-              <span className={"font-medium"}>
-                {cacheWrite.toLocaleString()}
-              </span>
-              <span className={"text-nb-gray-400"}>cache write</span>
-            </div>
-          )}
+          <div className={"flex items-center gap-2 whitespace-nowrap"}>
+            <span className={"font-medium"}>{cacheRead.toLocaleString()}</span>
+            <span className={"text-nb-gray-400"}>cache read</span>
+          </div>
+          <div className={"flex items-center gap-2 whitespace-nowrap"}>
+            <span className={"font-medium"}>{cacheWrite.toLocaleString()}</span>
+            <span className={"text-nb-gray-400"}>cache write</span>
+          </div>
           <div
             className={
               "border-t border-nb-gray-800 mt-0.5 pt-1 flex items-center gap-2 text-nb-gray-400 whitespace-nowrap"
             }
           >
-            <span className={"w-3 shrink-0"} aria-hidden={true} />
             <span className={"font-medium text-nb-gray-200"}>
               {total.toLocaleString()}
             </span>
@@ -1076,16 +1066,57 @@ function TokensCell({ entry }: { entry: AIAccessLogEntry }) {
   );
 }
 
-// CostCell renders the metered USD cost with a hover breakdown of how much of
-// it was billed for prompt-cache usage (cache read + write buckets).
+// CostRow is one line of the Cost hover breakdown: an amount plus its label.
+function CostRow({ amount, label }: { amount: number; label: string }) {
+  return (
+    <div className={"flex items-center gap-2 whitespace-nowrap"}>
+      <span className={"font-medium"}>${amount.toFixed(4)}</span>
+      <span className={"text-nb-gray-400 font-sans"}>{label}</span>
+    </div>
+  );
+}
+
+// CostCell renders the metered USD cost with a hover breakdown of the buckets
+// it was billed from.
+//
+// Servers that send the per-bucket breakdown get one line per bucket the
+// provider bills separately (input / output / cache read / cache write). Older
+// servers send only the two aggregates, so the hover falls back to the coarse
+// "input + output" vs "cache" split derivable from those — the two shapes are
+// distinguished by whether inputCostUsd is defined, not by whether it is zero.
 function CostCell({
   costUsd,
   cacheCostUsd,
+  inputCostUsd,
+  cachedInputCostUsd,
+  cacheCreationCostUsd,
+  outputCostUsd,
 }: {
   costUsd: number;
   cacheCostUsd?: number;
+  inputCostUsd?: number;
+  cachedInputCostUsd?: number;
+  cacheCreationCostUsd?: number;
+  outputCostUsd?: number;
 }) {
   const cache = cacheCostUsd ?? 0;
+  const hasBreakdown =
+    inputCostUsd !== undefined || outputCostUsd !== undefined;
+
+  // Nothing was metered: the request never reached a provider (denied before
+  // routing), or ran on a model the proxy deliberately doesn't price. A dash
+  // reads as "not metered" — matching TokensCell — where "$0.0000" plus a
+  // tooltip of zeros would imply a priced request that happened to be free.
+  const buckets = [
+    inputCostUsd ?? 0,
+    cachedInputCostUsd ?? 0,
+    cacheCreationCostUsd ?? 0,
+    outputCostUsd ?? 0,
+  ];
+  if (costUsd === 0 && cache === 0 && buckets.every((b) => b === 0)) {
+    return <EmptyRow />;
+  }
+
   const display = (
     <span
       className={
@@ -1095,21 +1126,31 @@ function CostCell({
       ${costUsd.toFixed(4)}
     </span>
   );
-  if (cache <= 0) return display;
+  // Nothing to break out: no cache spend and no per-bucket split to show.
+  if (cache <= 0 && !hasBreakdown) return display;
+
+  const cacheRead = cachedInputCostUsd ?? 0;
+  const cacheWrite = cacheCreationCostUsd ?? 0;
   return (
     <FullTooltip
       content={
         <div className={"text-xs flex flex-col gap-1 font-mono"}>
-          <div className={"flex items-center gap-2 whitespace-nowrap"}>
-            <span className={"font-medium"}>
-              ${(costUsd - cache).toFixed(4)}
-            </span>
-            <span className={"text-nb-gray-400 font-sans"}>input + output</span>
-          </div>
-          <div className={"flex items-center gap-2 whitespace-nowrap"}>
-            <span className={"font-medium"}>${cache.toFixed(4)}</span>
-            <span className={"text-nb-gray-400 font-sans"}>cache</span>
-          </div>
+          {hasBreakdown ? (
+            <>
+              {/* All four buckets, including zeros: a zero cache-read line is
+                  information (the request missed the cache), and a fixed set of
+                  rows keeps the hover comparable between requests. */}
+              <CostRow amount={inputCostUsd ?? 0} label={"input"} />
+              <CostRow amount={outputCostUsd ?? 0} label={"output"} />
+              <CostRow amount={cacheRead} label={"cache read"} />
+              <CostRow amount={cacheWrite} label={"cache write"} />
+            </>
+          ) : (
+            <>
+              <CostRow amount={costUsd - cache} label={"input + output"} />
+              <CostRow amount={cache} label={"cache"} />
+            </>
+          )}
           <div
             className={
               "border-t border-nb-gray-800 mt-0.5 pt-1 flex items-center gap-2 text-nb-gray-400 whitespace-nowrap"

--- a/src/modules/agent-network/AgentOverviewPanel.tsx
+++ b/src/modules/agent-network/AgentOverviewPanel.tsx
@@ -380,15 +380,23 @@ function ConsumptionByDayChart({
                       ctx.parsed.y,
                     ).toLocaleString()}`,
               // Surface the day's prompt-cache share on hover without adding chart series.
+              // Gate on the figure this metric actually shows: a day with cache
+              // tokens but no cache spend (unpriced model) would otherwise
+              // render "Cache: $0.00", implying a priced-but-free day.
               afterBody: (items) => {
                 const d = daily[items[0]?.dataIndex ?? -1];
-                if (!d || d.cacheRead + d.cacheWrite <= 0) return [];
-                return metric === "cost"
-                  ? [`Cache: $${d.cacheCost.toFixed(2)}`]
-                  : [
+                if (!d) return [];
+                if (metric === "cost") {
+                  return d.cacheCost > 0
+                    ? [`Cache: $${d.cacheCost.toFixed(2)}`]
+                    : [];
+                }
+                return d.cacheRead + d.cacheWrite > 0
+                  ? [
                       `Cache read: ${d.cacheRead.toLocaleString()}`,
                       `Cache write: ${d.cacheWrite.toLocaleString()}`,
-                    ];
+                    ]
+                  : [];
               },
             },
           },

--- a/src/modules/agent-network/AgentOverviewPanel.tsx
+++ b/src/modules/agent-network/AgentOverviewPanel.tsx
@@ -17,6 +17,7 @@ import {
   Tooltip,
 } from "chart.js";
 import useFetchApi from "@utils/api";
+import { cn } from "@utils/helpers";
 import dayjs from "dayjs";
 import { ActivityIcon, ExternalLinkIcon } from "lucide-react";
 import * as React from "react";
@@ -47,6 +48,14 @@ type DayBucket = {
   cacheRead: number;
   cacheWrite: number;
   cacheCost: number;
+  // Per-bucket cost split, so the Cost hover can break the day down the same
+  // way the access log breaks down a request. Undefined on older management
+  // servers that send only the two cost aggregates — undefined and zero mean
+  // different things here, so these stay optional.
+  inputCost?: number;
+  outputCost?: number;
+  cacheReadCost?: number;
+  cacheWriteCost?: number;
 };
 
 // AgentOverviewPanel shows account consumption over time as a per-day bar
@@ -220,14 +229,27 @@ function DailyBreakdownTable({ daily }: { daily: DayBucket[] }) {
         cell: ({ row }) => {
           const d = row.original;
           const total = d.input + d.output + d.cacheRead + d.cacheWrite;
-          if (d.cacheRead + d.cacheWrite <= 0)
-            return <NumberCell value={total} />;
           return (
             <FullTooltip
               content={
-                <div className={"text-xs flex flex-col gap-1 font-mono"}>
-                  <span>{`cache read: ${d.cacheRead.toLocaleString()}`}</span>
-                  <span>{`cache write: ${d.cacheWrite.toLocaleString()}`}</span>
+                <div className={"text-xs flex flex-col gap-1"}>
+                  <BreakdownRow
+                    value={d.input.toLocaleString()}
+                    label={"input"}
+                  />
+                  <BreakdownRow
+                    value={d.output.toLocaleString()}
+                    label={"output"}
+                  />
+                  <BreakdownRow
+                    value={d.cacheRead.toLocaleString()}
+                    label={"cache read"}
+                  />
+                  <BreakdownRow
+                    value={d.cacheWrite.toLocaleString()}
+                    label={"cache write"}
+                  />
+                  <BreakdownTotal value={total.toLocaleString()} />
                 </div>
               }
             >
@@ -242,8 +264,14 @@ function DailyBreakdownTable({ daily }: { daily: DayBucket[] }) {
         header: ({ column }) => (
           <DataTableHeader column={column}>Cost</DataTableHeader>
         ),
+        // Mirrors the access log's Cost hover: one row per bucket the provider
+        // bills separately when the server sends the split, otherwise the coarse
+        // cache-vs-rest split derivable from the two aggregates. The shapes are
+        // told apart by whether inputCost is defined, not by whether it is zero.
         cell: ({ row }) => {
           const d = row.original;
+          const hasBreakdown =
+            d.inputCost !== undefined || d.outputCost !== undefined;
           const display = (
             <span
               className={
@@ -253,13 +281,51 @@ function DailyBreakdownTable({ daily }: { daily: DayBucket[] }) {
               ${d.cost.toFixed(2)}
             </span>
           );
-          if (d.cacheCost <= 0) return display;
+          // Nothing to break out: no cache spend and no per-bucket split.
+          if (d.cacheCost <= 0 && !hasBreakdown) return display;
           return (
             <FullTooltip
               content={
-                <span className={"text-xs font-mono"}>
-                  {`cache: $${d.cacheCost.toFixed(2)}`}
-                </span>
+                <div className={"text-xs flex flex-col gap-1 font-mono"}>
+                  {hasBreakdown ? (
+                    <>
+                      <BreakdownRow
+                        mono={true}
+                        value={usd(d.inputCost ?? 0)}
+                        label={"input"}
+                      />
+                      <BreakdownRow
+                        mono={true}
+                        value={usd(d.outputCost ?? 0)}
+                        label={"output"}
+                      />
+                      <BreakdownRow
+                        mono={true}
+                        value={usd(d.cacheReadCost ?? 0)}
+                        label={"cache read"}
+                      />
+                      <BreakdownRow
+                        mono={true}
+                        value={usd(d.cacheWriteCost ?? 0)}
+                        label={"cache write"}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <BreakdownRow
+                        mono={true}
+                        value={usd(d.cost - d.cacheCost)}
+                        label={"input + output"}
+                      />
+                      <BreakdownRow
+                        mono={true}
+                        value={usd(d.cacheCost)}
+                        label={"cache"}
+                      />
+                    </>
+                  )}
+                  <BreakdownTotal mono={true} value={usd(d.cost)} />
+                </div>
               }
             >
               {display}
@@ -316,6 +382,59 @@ function NumberCell({ value }: { value: number }) {
     <span className={"text-nb-gray-300 px-3 py-2 font-mono whitespace-nowrap"}>
       {value.toLocaleString()}
     </span>
+  );
+}
+
+// The two hover breakdowns below follow the access-log table's Tokens and Cost
+// hovers: one "<value> <label>" row per bucket, then the day's aggregate on a
+// separated total row. Buckets are listed even when zero — a zero cache-read
+// line says the day never hit the cache, and a fixed set of rows keeps the
+// hover comparable between days.
+
+// usd renders a breakdown amount at the precision the router meters at. The
+// Cost column rounds a whole day to cents, but the hover is there for the
+// detail — prompt-cache reads in particular are routinely sub-cent.
+function usd(amount: number): string {
+  return `$${amount.toFixed(4)}`;
+}
+
+// mono keeps cost figures aligned digit-for-digit; labels stay in the body face
+// so they don't read as data.
+function BreakdownRow({
+  value,
+  label,
+  mono = false,
+}: {
+  value: string;
+  label: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className={"flex items-center gap-2 whitespace-nowrap"}>
+      <span className={"font-medium"}>{value}</span>
+      <span className={cn("text-nb-gray-400", mono && "font-sans")}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function BreakdownTotal({
+  value,
+  mono = false,
+}: {
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div
+      className={
+        "border-t border-nb-gray-800 mt-0.5 pt-1 flex items-center gap-2 text-nb-gray-400 whitespace-nowrap"
+      }
+    >
+      <span className={"font-medium text-nb-gray-200"}>{value}</span>
+      <span className={cn(mono && "font-sans")}>total</span>
+    </div>
   );
 }
 
@@ -455,6 +574,10 @@ function toDailyBuckets(buckets: APIAgentNetworkUsageBucket[]): DayBucket[] {
       cacheRead: b.cached_input_tokens ?? 0,
       cacheWrite: b.cache_creation_tokens ?? 0,
       cacheCost: b.cache_cost_usd ?? 0,
+      inputCost: b.input_cost_usd,
+      outputCost: b.output_cost_usd,
+      cacheReadCost: b.cached_input_cost_usd,
+      cacheWriteCost: b.cache_creation_cost_usd,
     });
   }
 

--- a/src/modules/agent-network/AgentOverviewPanel.tsx
+++ b/src/modules/agent-network/AgentOverviewPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ButtonGroup from "@components/ButtonGroup";
+import FullTooltip from "@components/FullTooltip";
 import InlineLink from "@components/InlineLink";
 import SquareIcon from "@components/SquareIcon";
 import { DataTable } from "@components/table/DataTable";
@@ -42,6 +43,10 @@ type DayBucket = {
   input: number;
   output: number;
   cost: number;
+  // Prompt-cache accounting: read/write token buckets and the cache share of cost.
+  cacheRead: number;
+  cacheWrite: number;
+  cacheCost: number;
 };
 
 // AgentOverviewPanel shows account consumption over time as a per-day bar
@@ -206,13 +211,30 @@ function DailyBreakdownTable({ daily }: { daily: DayBucket[] }) {
       },
       {
         id: "total",
-        accessorFn: (row) => row.input + row.output,
+        accessorFn: (row) =>
+          row.input + row.output + row.cacheRead + row.cacheWrite,
         header: ({ column }) => (
           <DataTableHeader column={column}>Total Tokens</DataTableHeader>
         ),
-        cell: ({ row }) => (
-          <NumberCell value={row.original.input + row.original.output} />
-        ),
+        // Total includes the additive prompt-cache buckets; hover breaks them out.
+        cell: ({ row }) => {
+          const d = row.original;
+          const total = d.input + d.output + d.cacheRead + d.cacheWrite;
+          if (d.cacheRead + d.cacheWrite <= 0)
+            return <NumberCell value={total} />;
+          return (
+            <FullTooltip
+              content={
+                <div className={"text-xs flex flex-col gap-1 font-mono"}>
+                  <span>{`cache read: ${d.cacheRead.toLocaleString()}`}</span>
+                  <span>{`cache write: ${d.cacheWrite.toLocaleString()}`}</span>
+                </div>
+              }
+            >
+              <NumberCell value={total} />
+            </FullTooltip>
+          );
+        },
       },
       {
         id: "cost",
@@ -220,13 +242,30 @@ function DailyBreakdownTable({ daily }: { daily: DayBucket[] }) {
         header: ({ column }) => (
           <DataTableHeader column={column}>Cost</DataTableHeader>
         ),
-        cell: ({ row }) => (
-          <span
-            className={"text-nb-gray-300 px-3 py-2 font-mono whitespace-nowrap"}
-          >
-            ${row.original.cost.toFixed(2)}
-          </span>
-        ),
+        cell: ({ row }) => {
+          const d = row.original;
+          const display = (
+            <span
+              className={
+                "text-nb-gray-300 px-3 py-2 font-mono whitespace-nowrap"
+              }
+            >
+              ${d.cost.toFixed(2)}
+            </span>
+          );
+          if (d.cacheCost <= 0) return display;
+          return (
+            <FullTooltip
+              content={
+                <span className={"text-xs font-mono"}>
+                  {`cache: $${d.cacheCost.toFixed(2)}`}
+                </span>
+              }
+            >
+              {display}
+            </FullTooltip>
+          );
+        },
       },
     ],
     [],
@@ -340,6 +379,17 @@ function ConsumptionByDayChart({
                   : `${ctx.dataset.label}: ${Number(
                       ctx.parsed.y,
                     ).toLocaleString()}`,
+              // Surface the day's prompt-cache share on hover without adding chart series.
+              afterBody: (items) => {
+                const d = daily[items[0]?.dataIndex ?? -1];
+                if (!d || d.cacheRead + d.cacheWrite <= 0) return [];
+                return metric === "cost"
+                  ? [`Cache: $${d.cacheCost.toFixed(2)}`]
+                  : [
+                      `Cache read: ${d.cacheRead.toLocaleString()}`,
+                      `Cache write: ${d.cacheWrite.toLocaleString()}`,
+                    ];
+              },
             },
           },
         },
@@ -394,6 +444,9 @@ function toDailyBuckets(buckets: APIAgentNetworkUsageBucket[]): DayBucket[] {
       input: b.input_tokens ?? 0,
       output: b.output_tokens ?? 0,
       cost: b.cost_usd ?? 0,
+      cacheRead: b.cached_input_tokens ?? 0,
+      cacheWrite: b.cache_creation_tokens ?? 0,
+      cacheCost: b.cache_cost_usd ?? 0,
     });
   }
 
@@ -406,7 +459,17 @@ function toDailyBuckets(buckets: APIAgentNetworkUsageBucket[]): DayBucket[] {
   // Cap at a year of days as a defensive bound against a bad range.
   for (let i = 0; i < 366 && !cur.isAfter(end); i++) {
     const key = cur.format("YYYY-MM-DD");
-    out.push(map.get(key) ?? { key, input: 0, output: 0, cost: 0 });
+    out.push(
+      map.get(key) ?? {
+        key,
+        input: 0,
+        output: 0,
+        cost: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cacheCost: 0,
+      },
+    );
     cur = cur.add(1, "day");
   }
   return out;

--- a/src/modules/agent-network/agentAccessLogApi.ts
+++ b/src/modules/agent-network/agentAccessLogApi.ts
@@ -28,6 +28,13 @@ export type APIAgentNetworkAccessLog = {
   cached_input_tokens?: number;
   cache_creation_tokens?: number;
   cache_cost_usd?: number;
+  // Per-bucket cost breakdown — the base of the cost fields; cost_usd is their
+  // sum and cache_cost_usd the cache pair. Optional — absent on older
+  // management servers, where only the two aggregates are available.
+  input_cost_usd?: number;
+  cached_input_cost_usd?: number;
+  cache_creation_cost_usd?: number;
+  output_cost_usd?: number;
   user_id?: string;
   source_ip?: string;
   method?: string;
@@ -70,6 +77,13 @@ export type APIAgentNetworkAccessLogSession = {
   cached_input_tokens?: number;
   cache_creation_tokens?: number;
   cache_cost_usd?: number;
+  // Per-bucket cost breakdown — the base of the cost fields; cost_usd is their
+  // sum and cache_cost_usd the cache pair. Optional — absent on older
+  // management servers, where only the two aggregates are available.
+  input_cost_usd?: number;
+  cached_input_cost_usd?: number;
+  cache_creation_cost_usd?: number;
+  output_cost_usd?: number;
   providers?: string[];
   models?: string[];
   decision: string;
@@ -87,6 +101,13 @@ export type APIAgentNetworkUsageBucket = {
   cached_input_tokens?: number;
   cache_creation_tokens?: number;
   cache_cost_usd?: number;
+  // Per-bucket cost breakdown — the base of the cost fields; cost_usd is their
+  // sum and cache_cost_usd the cache pair. Optional — absent on older
+  // management servers, where only the two aggregates are available.
+  input_cost_usd?: number;
+  cached_input_cost_usd?: number;
+  cache_creation_cost_usd?: number;
+  output_cost_usd?: number;
 };
 
 export type UsageGranularity = "day" | "week" | "month";
@@ -199,6 +220,10 @@ export function accessLogFromAgentAPI(
     cacheCreationTokens: entry.cache_creation_tokens ?? 0,
     costUsd: entry.cost_usd ?? 0,
     cacheCostUsd: entry.cache_cost_usd ?? 0,
+    inputCostUsd: entry.input_cost_usd,
+    cachedInputCostUsd: entry.cached_input_cost_usd,
+    cacheCreationCostUsd: entry.cache_creation_cost_usd,
+    outputCostUsd: entry.output_cost_usd,
     durationMs: entry.duration_ms,
     decision,
     denyReason: decision === "deny" ? entry.deny_reason : undefined,
@@ -245,6 +270,10 @@ export function accessLogSessionFromAgentAPI(
     cacheCreationTokens: session.cache_creation_tokens ?? 0,
     costUsd: session.cost_usd ?? 0,
     cacheCostUsd: session.cache_cost_usd ?? 0,
+    inputCostUsd: session.input_cost_usd,
+    cachedInputCostUsd: session.cached_input_cost_usd,
+    cacheCreationCostUsd: session.cache_creation_cost_usd,
+    outputCostUsd: session.output_cost_usd,
     providers: session.providers ?? [],
     models: session.models ?? [],
     decision,

--- a/src/modules/agent-network/agentAccessLogApi.ts
+++ b/src/modules/agent-network/agentAccessLogApi.ts
@@ -24,6 +24,10 @@ export type APIAgentNetworkAccessLog = {
   output_tokens: number;
   total_tokens: number;
   cost_usd: number;
+  // Prompt-cache accounting. Optional — absent on older management servers.
+  cached_input_tokens?: number;
+  cache_creation_tokens?: number;
+  cache_cost_usd?: number;
   user_id?: string;
   source_ip?: string;
   method?: string;
@@ -63,6 +67,9 @@ export type APIAgentNetworkAccessLogSession = {
   output_tokens: number;
   total_tokens: number;
   cost_usd: number;
+  cached_input_tokens?: number;
+  cache_creation_tokens?: number;
+  cache_cost_usd?: number;
   providers?: string[];
   models?: string[];
   decision: string;
@@ -77,6 +84,9 @@ export type APIAgentNetworkUsageBucket = {
   output_tokens: number;
   total_tokens: number;
   cost_usd: number;
+  cached_input_tokens?: number;
+  cache_creation_tokens?: number;
+  cache_cost_usd?: number;
 };
 
 export type UsageGranularity = "day" | "week" | "month";
@@ -185,7 +195,10 @@ export function accessLogFromAgentAPI(
     model: entry.model ?? "",
     inputTokens: entry.input_tokens ?? 0,
     outputTokens: entry.output_tokens ?? 0,
+    cachedInputTokens: entry.cached_input_tokens ?? 0,
+    cacheCreationTokens: entry.cache_creation_tokens ?? 0,
     costUsd: entry.cost_usd ?? 0,
+    cacheCostUsd: entry.cache_cost_usd ?? 0,
     durationMs: entry.duration_ms,
     decision,
     denyReason: decision === "deny" ? entry.deny_reason : undefined,
@@ -228,7 +241,10 @@ export function accessLogSessionFromAgentAPI(
     inputTokens: session.input_tokens ?? 0,
     outputTokens: session.output_tokens ?? 0,
     totalTokens: session.total_tokens ?? 0,
+    cachedInputTokens: session.cached_input_tokens ?? 0,
+    cacheCreationTokens: session.cache_creation_tokens ?? 0,
     costUsd: session.cost_usd ?? 0,
+    cacheCostUsd: session.cache_cost_usd ?? 0,
     providers: session.providers ?? [],
     models: session.models ?? [],
     decision,

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -175,7 +175,11 @@ export type AIAccessLogEntry = {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  // Prompt-cache buckets: read/write token counts and the cache share of costUsd. Optional — absent on older management servers.
+  cachedInputTokens?: number;
+  cacheCreationTokens?: number;
   costUsd: number;
+  cacheCostUsd?: number;
   durationMs: number;
   decision: AIAccessLogDecision;
   denyReason?: string;
@@ -213,7 +217,10 @@ export type AIAccessLogSession = {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+  cachedInputTokens?: number;
+  cacheCreationTokens?: number;
   costUsd: number;
+  cacheCostUsd?: number;
   providers: string[]; // distinct vendor ids seen in the session
   models: string[]; // distinct models seen in the session
   decision: AIAccessLogDecision;

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -180,6 +180,12 @@ export type AIAccessLogEntry = {
   cacheCreationTokens?: number;
   costUsd: number;
   cacheCostUsd?: number;
+  // Per-bucket cost breakdown. Undefined (not 0) when the server predates the
+  // breakdown, so the UI can tell "no split available" from "split is zero".
+  inputCostUsd?: number;
+  cachedInputCostUsd?: number;
+  cacheCreationCostUsd?: number;
+  outputCostUsd?: number;
   durationMs: number;
   decision: AIAccessLogDecision;
   denyReason?: string;
@@ -221,6 +227,12 @@ export type AIAccessLogSession = {
   cacheCreationTokens?: number;
   costUsd: number;
   cacheCostUsd?: number;
+  // Per-bucket cost breakdown. Undefined (not 0) when the server predates the
+  // breakdown, so the UI can tell "no split available" from "split is zero".
+  inputCostUsd?: number;
+  cachedInputCostUsd?: number;
+  cacheCreationCostUsd?: number;
+  outputCostUsd?: number;
   providers: string[]; // distinct vendor ids seen in the session
   models: string[]; // distinct models seen in the session
   decision: AIAccessLogDecision;


### PR DESCRIPTION
Hovering the access-log Tokens cell now breaks out prompt-cache read/write tokens (and a cache-aware total), the Cost cells show the cache share of the metered cost, and the usage overview chart and daily table surface the day's cache tokens and cache cost the same way. Backed by the new `cached_input_tokens` / `cache_creation_tokens` / `cache_cost_usd` fields from netbirdio/netbird#6900; entries from older management servers render unchanged.

## Issue ticket number and link

N/A — pairs with netbirdio/netbird#6900

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/886

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prompt-cache token and cost breakdowns across Agent Network access logs, session views, and the daily usage chart/tables.
  * Token and cost calculations now include cache read/write and expose cache details via improved hover tooltips (including per-bucket cost lines when available).
* **Bug Fixes**
  * Cache metrics now gracefully default when missing, ensuring totals and tooltips remain accurate.
* **Tests**
  * Added end-to-end coverage for cache-aware totals and tooltip breakdowns on access logs and the usage overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->