### PR TITLE
Add openSUSE zypper instructions with GPG key import to the Linux tab

### DIFF
--- a/e2e/tests/setup-modal-linux.spec.ts
+++ b/e2e/tests/setup-modal-linux.spec.ts
@@ -69,6 +69,25 @@ test.describe("Setup modal Linux distro instructions", () => {
     );
   });
 
+  test("imports the repository GPG key on openSUSE", async ({ page }) => {
+    await openLinuxManualInstall(page);
+    const modal = page.getByTestId("setup-netbird-modal");
+
+    await selectDistro(page, "openSUSE (Zypper)");
+    await expect(modal).toContainText(
+      "sudo zypper --non-interactive addrepo -f -g https://pkgs.netbird.io/yum/ netbird",
+    );
+    await expect(modal).toContainText(
+      "sudo zypper --gpg-auto-import-keys refresh netbird",
+    );
+    await expect(modal).toContainText("sudo zypper install netbird");
+    await expect(modal).toContainText(
+      "sudo zypper install netbird-ui libgtk-4-1 libwebkitgtk-6_0-4 xdg-utils",
+    );
+    // Zypper ignores gpgkey= in a .repo file, so that snippet must not appear
+    await expect(modal).not.toContainText("/etc/yum.repos.d/netbird.repo");
+  });
+
   test("offers CLI only on Amazon Linux", async ({ page }) => {
     await openLinuxManualInstall(page);
     const modal = page.getByTestId("setup-netbird-modal");

--- a/src/modules/setup-netbird-modal/LinuxTab.tsx
+++ b/src/modules/setup-netbird-modal/LinuxTab.tsx
@@ -96,6 +96,21 @@ const DISTROS: Distro[] = [
     note: "The desktop app needs version 10 or newer with EPEL enabled, which provides WebKitGTK 6.0. On version 9 install the CLI only.",
   },
   {
+    label: "openSUSE (Zypper)",
+    value: "opensuse",
+    // Zypper does not read gpgkey= from a .repo file, so the repository key is
+    // imported by an explicit refresh instead of the YUM_REPOSITORY snippet.
+    repository: [
+      "sudo zypper --non-interactive addrepo -f -g https://pkgs.netbird.io/yum/ netbird",
+      "sudo zypper --gpg-auto-import-keys refresh netbird",
+    ],
+    cli: "sudo zypper install netbird",
+    desktopApp: [
+      "sudo zypper install netbird-ui libgtk-4-1 libwebkitgtk-6_0-4 xdg-utils",
+    ],
+    note: "The desktop app needs Tumbleweed or Leap 15.6 and newer. On earlier releases install the CLI only.",
+  },
+  {
     label: "Amazon Linux (YUM)",
     value: "amazon",
     repository: YUM_REPOSITORY,


### PR DESCRIPTION
Zypper ignores the gpgkey= entry of a .repo file, so the yum snippet would leave the repository key uninstalled on openSUSE. The new distro entry adds the repository with GPG checking enabled and imports the key on refresh.
<img width="1100" height="939" alt="localhost_3000_peers" src="https://github.com/user-attachments/assets/4c518ffb-ab9e-4879-8ffc-0799f725e67c" />

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/dashboard/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787832998&installation_model_id=427504&pr_number=735&repository=netbirdio%2Fdashboard&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fdashboard%2Fpull%2F735&signature=41b3547091431fb2895130d8aad72331ff64c783498536a3e720c8534fd90f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added openSUSE (Zypper) as a Linux distribution option in the setup modal.
  * Displays tailored commands for configuring the repository and installing NetBird and its desktop dependencies.

* **Tests**
  * Added coverage verifying the openSUSE installation commands and repository instructions shown in the modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->