### PR TITLE
Show SSH enable commands with the privileges the daemon requires

### DIFF
--- a/src/modules/peer/PeerSSHInstructions.tsx
+++ b/src/modules/peer/PeerSSHInstructions.tsx
@@ -22,6 +22,8 @@ import { SegmentedTabs } from "@components/SegmentedTabs";
 import NetBirdIcon from "@/assets/icons/NetBirdIcon";
 import { Peer } from "@/interfaces/Peer";
 import { PeerSSHPolicyModal } from "@/modules/peer/PeerSSHPolicyModal";
+import { getOperatingSystem } from "@hooks/useOperatingSystem";
+import { OperatingSystem } from "@/interfaces/OperatingSystem";
 
 type Props = {
   open?: boolean;
@@ -38,6 +40,12 @@ export const PeerSSHInstructions = ({
 }: Props) => {
   const [client, setClient] = useState("cli");
   const [policyModal, setPolicyModal] = useState(false);
+
+  // Enabling the SSH server and root login require root, or an administrator on
+  // Windows, since they decide who may obtain a shell on that machine.
+  const isWindows =
+    !!peer?.os && getOperatingSystem(peer.os) === OperatingSystem.WINDOWS;
+  const prefix = isWindows ? "" : "sudo ";
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
@@ -75,13 +83,19 @@ export const PeerSSHInstructions = ({
               <Steps.Step step={1}>
                 <p className={"font-normal"}>
                   If you are using NetBird via CLI, you can enable SSH by
-                  running
+                  running{" "}
+                  {isWindows
+                    ? "these commands in an elevated prompt"
+                    : "these commands as root"}
+                  . Run the first one only if NetBird is already running. On a
+                  machine where you do not have those rights, an administrator
+                  has to run them.
                 </p>
-                <Code codeToCopy={"netbird down"}>
-                  <Code.Line>{`netbird down # if NetBird is already running`}</Code.Line>
+                <Code codeToCopy={`${prefix}netbird down`}>
+                  <Code.Line>{`${prefix}netbird down`}</Code.Line>
                 </Code>
                 <Code>
-                  <Code.Line>{`netbird up --allow-server-ssh --enable-ssh-root`}</Code.Line>
+                  <Code.Line>{`${prefix}netbird up --allow-server-ssh --enable-ssh-root`}</Code.Line>
                 </Code>
               </Steps.Step>
             ) : (


### PR DESCRIPTION
The daemon now requires root, or an administrator on Windows, to enable the SSH server and root login (netbird client v0.76.0), so the instructions in this modal no longer work as printed.

- Prefix the CLI commands with `sudo` on Linux and macOS peers, and copy the prefixed form to the clipboard rather than a command that fails
- Show the Windows form without `sudo`, telling the user to run it from an elevated prompt, based on the peer's reported OS
- Say that an administrator has to run the commands on a machine where the user has no such rights, which is the normal case for a managed workstation

## Issue ticket number and link

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/894

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated SSH setup instructions with operating-system-specific commands.
  * Added guidance for elevated prompts on Windows and root access on other systems.
  * Clarified when administrator assistance may be required during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
