### PR TITLE
Make peer inactivity expiration duration configurable in the UI

### DIFF
--- a/src/modules/settings/AuthenticationTab.tsx
+++ b/src/modules/settings/AuthenticationTab.tsx
@@ -105,7 +105,9 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
     peerInactivityExpirationEnabled,
     setPeerInactivityExpirationEnabled,
     peerInactivityExpiresIn,
+    setPeerInactivityExpiresIn,
     peerInactivityExpireInterval,
+    setPeerInactivityExpireInterval,
   ] = useExpirationState({
     enabled: account.settings.peer_inactivity_expiration_enabled,
     expirationInSeconds: account.settings.peer_inactivity_expiration || 600,
@@ -131,6 +133,10 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
 
   const saveChanges = async () => {
     const expiration = convertToSeconds(expiresIn, expireInterval);
+    const inactivityExpiration = convertToSeconds(
+      peerInactivityExpiresIn,
+      peerInactivityExpireInterval,
+    );
 
     notify({
       title: "Save Authentication Settings",
@@ -145,7 +151,9 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
             peer_inactivity_expiration_enabled: loginExpiration
               ? peerInactivityExpirationEnabled
               : false,
-            peer_inactivity_expiration: 600,
+            peer_inactivity_expiration: peerInactivityExpirationEnabled
+              ? inactivityExpiration
+              : account.settings.peer_inactivity_expiration || 600,
             extra: {
               ...account.settings?.extra,
               peer_approval_enabled: isAnyIntegrationEnabled
@@ -412,10 +420,76 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
                 helpText={
                   <>
                     Enable to require authentication after users disconnect from
-                    management for 10 minutes.
+                    management for the configured period of time.
                   </>
                 }
               />
+              <div
+                className={cn(
+                  "flex justify-between gap-10",
+                  !peerInactivityExpirationEnabled &&
+                    "opacity-50 pointer-events-none",
+                )}
+              >
+                <div className={"w-full"}>
+                  <Label>Inactivity Expiration</Label>
+                  <HelpText>
+                    Time a peer can stay disconnected from management before
+                    re-authentication is required.
+                  </HelpText>
+                </div>
+                <div className={"w-full flex gap-3"}>
+                  <Input
+                    placeholder={"10"}
+                    maxWidthClass={"min-w-[100px]"}
+                    min={1}
+                    disabled={
+                      !loginExpiration ||
+                      !peerInactivityExpirationEnabled ||
+                      !permission.settings.update
+                    }
+                    data-testid={"peer-inactivity-expiration-input"}
+                    className={"w-full"}
+                    value={peerInactivityExpiresIn}
+                    type={"number"}
+                    onChange={(e) => setPeerInactivityExpiresIn(e.target.value)}
+                  />
+                  <Select
+                    disabled={
+                      !loginExpiration ||
+                      !peerInactivityExpirationEnabled ||
+                      !permission.settings.update
+                    }
+                    value={peerInactivityExpireInterval}
+                    onValueChange={(v) => setPeerInactivityExpireInterval(v)}
+                  >
+                    <SelectTrigger
+                      className="w-full"
+                      data-testid={"peer-inactivity-expiration-select"}
+                    >
+                      <div className={"flex items-center gap-3"}>
+                        <CalendarClock
+                          size={15}
+                          className={"text-nb-gray-300"}
+                        />
+                        <SelectValue
+                          placeholder="Select interval..."
+                          data-testid={
+                            "peer-inactivity-expiration-select-value"
+                          }
+                        />
+                      </div>
+                    </SelectTrigger>
+                    <SelectContent
+                      data-testid={"peer-inactivity-expiration-select-content"}
+                    >
+                      <SelectItem value="days">Days</SelectItem>
+                      <SelectItem value="hours">Hours</SelectItem>
+                      <SelectItem value="minutes">Minutes</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/modules/settings/AuthenticationTab.tsx
+++ b/src/modules/settings/AuthenticationTab.tsx
@@ -110,7 +110,7 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
     setPeerInactivityExpireInterval,
   ] = useExpirationState({
     enabled: account.settings.peer_inactivity_expiration_enabled,
-    expirationInSeconds: account.settings.peer_inactivity_expiration || 600,
+    expirationInSeconds: account.settings.peer_inactivity_expiration ?? 600,
     timeRange: ["minutes", "hours", "days"],
   });
 
@@ -131,12 +131,20 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
     isLocalMFAEnabled,
   ]);
 
+  // An empty/cleared input converts to NaN; block saving until it's a
+  // positive number so the API never receives an invalid duration.
+  const inactivityExpirationSeconds = convertToSeconds(
+    peerInactivityExpiresIn,
+    peerInactivityExpireInterval,
+  );
+  const isInactivityExpirationInvalid =
+    loginExpiration &&
+    peerInactivityExpirationEnabled &&
+    (!Number.isFinite(inactivityExpirationSeconds) ||
+      inactivityExpirationSeconds <= 0);
+
   const saveChanges = async () => {
     const expiration = convertToSeconds(expiresIn, expireInterval);
-    const inactivityExpiration = convertToSeconds(
-      peerInactivityExpiresIn,
-      peerInactivityExpireInterval,
-    );
 
     notify({
       title: "Save Authentication Settings",
@@ -152,8 +160,8 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
               ? peerInactivityExpirationEnabled
               : false,
             peer_inactivity_expiration: peerInactivityExpirationEnabled
-              ? inactivityExpiration
-              : account.settings.peer_inactivity_expiration || 600,
+              ? inactivityExpirationSeconds
+              : account.settings.peer_inactivity_expiration ?? 600,
             extra: {
               ...account.settings?.extra,
               peer_approval_enabled: isAnyIntegrationEnabled
@@ -227,7 +235,11 @@ export default function AuthenticationTab({ account }: Readonly<Props>) {
 
           <Button
             variant={"primary"}
-            disabled={!hasChanges || !permission.settings.update}
+            disabled={
+              !hasChanges ||
+              !permission.settings.update ||
+              isInactivityExpirationInvalid
+            }
             onClick={saveChanges}
             data-testid={"save-authentication-settings"}
           >


### PR DESCRIPTION
## Issue ticket number and link

No dedicated issue. Context: the inactivity expiration feature was added backend-side in netbirdio/netbird#2326 with `peer_inactivity_expiration` (seconds) fully supported by the accounts API — but the dashboard never exposed the duration and instead hardcodes `600` on every save of the Authentication page.

This has two consequences for self-hosted admins:

- The inactivity duration can only be set via the API.
- Worse: any value set via the API is **silently reset to 10 minutes** the next time an admin saves the Authentication settings page (`peer_inactivity_expiration: 600` was sent unconditionally).

## What this PR does

- Adds an **"Inactivity Expiration"** input (minutes/hours/days) below the *Require login after disconnect* toggle, mirroring the existing *Session Expiration* input row.
- On save, sends the configured duration instead of the hardcoded `600`. When the toggle is off, the stored account value is preserved instead of being overwritten.
- Updates the toggle help text ("for 10 minutes" → "for the configured period of time").
- Fixes the `useExpirationState` destructuring for the inactivity state (position 3 is `setExpiresIn`, but it was named `peerInactivityExpireInterval`).

Verified: `next build` passes, no new type errors, Prettier clean.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This exposes an existing, already-documented API setting (`peer_inactivity_expiration`) in the UI. Happy to follow up with a docs PR updating the screenshots/description on the periodic-authentication page if desired.

### Docs PR URL (required if "docs added" is checked)

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expanded peer inactivity expiration section with a numeric duration input and an interval selector.
  * Updated the UI guidance and help text for configuring the inactivity period.
* **Bug Fixes**
  * Improved validation for inactivity expiration settings before saving, preventing non-positive or invalid computed values.
  * Adjusted persistence to store the derived inactivity expiration only when the feature is enabled; otherwise it falls back to a safe default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshot

Toggle enabled with the new duration input (mirrors the Session Expiration row):

![Inactivity Expiration field](https://raw.githubusercontent.com/paul-hph/dashboard/569f8053933c5b752b3073cc19dc5f14cac7a62c/assets/inactivity-expiration-field.png)
