### PR TITLE
Bootstrap Agent Network settings via the explicit POST

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -483,3 +483,28 @@ export async function deleteAgentNetworkProvidersByPrefix(
     }
   }
 }
+
+/**
+ * Whether the management build under test bootstraps the Agent Network
+ * settings row through the explicit POST /agent-network/settings.
+ *
+ * Builds that predate it seed the row as a side effect of the first provider
+ * create and describe the endpoint identity as cluster + subdomain; builds
+ * that have it expose proxy_address instead. The settings GET carries the
+ * field either way — including before the account is bootstrapped, where it
+ * answers with the defaults and an empty proxy_address — so the shape of that
+ * response is a side-effect-free probe for the endpoint's existence.
+ */
+export async function supportsAgentNetworkSettingsBootstrap(
+  page: Page,
+): Promise<boolean> {
+  const { token, origin } = await getApiContext(page);
+  const resp = await page.request.get(`${origin}/api/agent-network/settings`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok()) return false;
+  const settings = await resp.json().catch(() => null);
+  return (
+    !!settings && typeof settings === "object" && "proxy_address" in settings
+  );
+}

--- a/e2e/tests/agent-network-kimi-provider.spec.ts
+++ b/e2e/tests/agent-network-kimi-provider.spec.ts
@@ -123,12 +123,16 @@ test.describe.serial("Agent Network Kimi provider @agent-network", () => {
       // first and only creates the provider once that succeeds. A rejected
       // bootstrap therefore means no provider POST ever happens, which on its
       // own surfaces only as the whole test timing out — race it so the real
-      // status is reported instead.
+      // status is reported instead. 409 is not a rejection: it means a
+      // concurrent bootstrap won and the row exists, which the wizard treats as
+      // success and follows with the provider create, so matching it here would
+      // fail a run that is about to succeed.
       const bootstrapRejected: Promise<never> = page
         .waitForResponse(
           (resp) =>
             resp.url().includes("/agent-network/settings") &&
             resp.request().method() === "POST" &&
+            resp.status() !== 409 &&
             !resp.ok(),
           { timeout: 30_000 },
         )

--- a/e2e/tests/agent-network-kimi-provider.spec.ts
+++ b/e2e/tests/agent-network-kimi-provider.spec.ts
@@ -10,7 +10,10 @@
  * The kimi_api catalog entry ships with newer management builds. When the
  * backend under test predates it, the whole suite skips instead of failing —
  * same trade-off as the provider matrix in netbird's agent-network e2e
- * harness, which skips per-provider on missing credentials.
+ * harness, which skips per-provider on missing credentials. The same applies
+ * to the explicit settings bootstrap: connecting the first provider of an
+ * account POSTs /agent-network/settings first, so on a build without that
+ * endpoint the wizard cannot get as far as creating a provider.
  *
  * The Agent Network menu is deployment-gated; the test build honors the
  * localStorage override (see testAgentNetworkOverride in utils/netbird.ts),
@@ -22,6 +25,7 @@ import { generateRandomName } from "../helpers/utils";
 import {
   deleteAgentNetworkProvidersByPrefix,
   listAgentNetworkCatalog,
+  supportsAgentNetworkSettingsBootstrap,
 } from "../helpers/api";
 
 const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
@@ -61,6 +65,11 @@ test.describe.serial("Agent Network Kimi provider @agent-network", () => {
       test.skip(
         !catalog.some((c) => c.id === KIMI_CATALOG_ID),
         `management catalog has no ${KIMI_CATALOG_ID} entry`,
+      );
+      test.skip(
+        !(await supportsAgentNetworkSettingsBootstrap(page)),
+        "management build has no POST /agent-network/settings, so the " +
+          "wizard cannot bootstrap the account before the first create",
       );
 
       await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
@@ -110,11 +119,36 @@ test.describe.serial("Agent Network Kimi provider @agent-network", () => {
           resp.request().method() === "POST",
         { timeout: 30_000 },
       );
+      // On the account's first provider the wizard bootstraps the settings row
+      // first and only creates the provider once that succeeds. A rejected
+      // bootstrap therefore means no provider POST ever happens, which on its
+      // own surfaces only as the whole test timing out — race it so the real
+      // status is reported instead.
+      const bootstrapRejected: Promise<never> = page
+        .waitForResponse(
+          (resp) =>
+            resp.url().includes("/agent-network/settings") &&
+            resp.request().method() === "POST" &&
+            !resp.ok(),
+          { timeout: 30_000 },
+        )
+        .then(
+          (resp) => {
+            throw new Error(
+              `Agent Network settings bootstrap POST returned ${resp.status()}; ` +
+                "the provider was never created",
+            );
+          },
+          // Nothing matched: the bootstrap succeeded or wasn't needed. Never
+          // settle, leaving the race to the provider create.
+          () => new Promise<never>(() => {}),
+        );
       await page
         .getByRole("button", { name: "Connect Provider" })
         .last()
         .click({ force: true });
-      expect([200, 201]).toContain((await createResponse).status());
+      const created = await Promise.race([createResponse, bootstrapRejected]);
+      expect([200, 201]).toContain(created.status());
 
       // Row lands in the providers table.
       await expect(page.getByText(providerName).first()).toBeVisible();

--- a/e2e/tests/agent-network-settings-shapes.spec.ts
+++ b/e2e/tests/agent-network-settings-shapes.spec.ts
@@ -22,9 +22,10 @@ const EMPTY_STATE_TEXT =
 
 const BOOTSTRAPPED_ENDPOINT = "violet.eu.proxy.netbird.io";
 
-// The defaults object current servers return before the account is
-// bootstrapped: values present, endpoint/proxy_address empty, no timestamps
-// (no row has been persisted yet).
+// The defaults object current servers return for an account that has not been
+// bootstrapped yet: the mutable settings carry their default values, the
+// endpoint/proxy_address identity is empty, and there are no timestamps because
+// no row has been persisted.
 const UNBOOTSTRAPPED_DEFAULTS = {
   endpoint: "",
   proxy_address: "",

--- a/e2e/tests/agent-network-settings-shapes.spec.ts
+++ b/e2e/tests/agent-network-settings-shapes.spec.ts
@@ -3,8 +3,8 @@
  *
  * The management API signals "account not bootstrapped" differently by
  * generation: current servers answer GET /agent-network/settings with the
- * defaults object carrying an empty cluster/subdomain/endpoint, older ones
- * with 200 + a JSON null body, and the oldest with a 404.
+ * defaults object carrying an empty endpoint/proxy_address, older ones with
+ * 200 + a JSON null body, and the oldest with a 404.
  * useAgentNetworkSettings normalizes all three to the same null-settings
  * signal, and this spec pins that: the providers page must render the
  * connect-first endpoint placeholder for every unbootstrapped shape, and the
@@ -23,12 +23,12 @@ const EMPTY_STATE_TEXT =
 const BOOTSTRAPPED_ENDPOINT = "violet.eu.proxy.netbird.io";
 
 // The defaults object current servers return before the account is
-// bootstrapped: values present, cluster/subdomain/endpoint empty, no
-// timestamps (no row has been persisted yet).
+// bootstrapped: values present, endpoint/proxy_address empty, no timestamps
+// (no row has been persisted yet).
 const UNBOOTSTRAPPED_DEFAULTS = {
-  cluster: "",
-  subdomain: "",
   endpoint: "",
+  proxy_address: "",
+  dedicated: false,
   enable_log_collection: true,
   enable_prompt_collection: false,
   redact_pii: false,
@@ -36,9 +36,9 @@ const UNBOOTSTRAPPED_DEFAULTS = {
 };
 
 const BOOTSTRAPPED_SETTINGS = {
-  cluster: "eu.proxy.netbird.io",
-  subdomain: "violet",
   endpoint: BOOTSTRAPPED_ENDPOINT,
+  proxy_address: "eu.proxy.netbird.io",
+  dedicated: false,
   enable_log_collection: true,
   enable_prompt_collection: false,
   redact_pii: false,

--- a/e2e/tests/team-service-users.spec.ts
+++ b/e2e/tests/team-service-users.spec.ts
@@ -99,7 +99,10 @@ async function openServiceUserList(page: Page) {
 // the client-side navigation is still in flight, so anything that follows can
 // otherwise be computed against the page being left behind.
 async function returnToServiceUserList(page: Page) {
-  await page.getByRole("link", { name: "Service Users" }).click();
+  await page
+    .getByTestId("breadcrumb-item")
+    .filter({ hasText: "Service Users" })
+    .click();
   await page.waitForURL(/\/team\/service-users/, { timeout: 15_000 });
   await expectServiceUserList(page);
 }

--- a/e2e/tests/team-service-users.spec.ts
+++ b/e2e/tests/team-service-users.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "../helpers/fixtures";
 import { navigateTo } from "../helpers/auth";
 import { generateRandomName } from "../helpers/utils";
@@ -20,17 +21,9 @@ test.describe.serial("Team - Service Users @team", () => {
   });
 
   test("Should update role and manage access tokens", async ({ dashboardAsOwner: page }) => {
-    await page.locator("tr").getByText(regularUser).click();
+    await openServiceUser(page, regularUser);
     await changeRoleTo(page, "Admin");
-    // Await the PUT so the role change is persisted before the next serial
-    // test asserts it — clicking save alone returns before the request lands.
-    const saveResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/users/") && resp.request().method() === "PUT",
-      { timeout: 30_000 },
-    );
-    await page.getByTestId("save-changes").click();
-    await saveResponse;
+    await saveUserChanges(page);
 
     // Create and delete access token
     const tokenName = generateRandomName("tkn_");
@@ -45,23 +38,18 @@ test.describe.serial("Team - Service Users @team", () => {
     await tokenRow.getByTestId("access-token-delete").click();
     await page.getByTestId("confirmation.confirm").click();
     await expect(tokenRow).not.toBeVisible();
-
-    await page.getByText("Service Users").first().click();
   });
 
   test("Should update admin user role and verify all changes persisted", async ({
     dashboardAsOwner: page,
   }) => {
-    await page.locator("tr").getByText(adminServiceUser).click();
+    await openServiceUser(page, adminServiceUser);
     await changeRoleTo(page, "User");
-    const saveResponse = page.waitForResponse(
-      (resp) => resp.url().includes("/api/users/") && resp.request().method() === "PUT",
-      { timeout: 30_000 },
-    );
-    await page.getByTestId("save-changes").click();
-    await saveResponse;
+    await saveUserChanges(page);
 
-    await page.getByText("Service Users").first().click();
+    // Go back the way a user would, so this also covers the save refreshing
+    // the cached users list rather than only what the server persisted.
+    await returnToServiceUserList(page);
     await checkServiceUserRow(page, regularUser, "Admin");
     await checkServiceUserRow(page, adminServiceUser, "User");
 
@@ -72,6 +60,7 @@ test.describe.serial("Team - Service Users @team", () => {
   });
 
   test("Should delete service users", async ({ dashboardAsOwner: page }) => {
+    await openServiceUserList(page);
     for (const name of [regularUser, adminServiceUser]) {
       const row = page.locator("tr").filter({ hasText: name });
       // Row actions are now behind a dropdown menu; open it, then delete.
@@ -83,11 +72,7 @@ test.describe.serial("Team - Service Users @team", () => {
   });
 });
 
-async function createServiceUser(
-  page: import("@playwright/test").Page,
-  name: string,
-  role: string,
-) {
+async function createServiceUser(page: Page, name: string, role: string) {
   await page.getByTestId("open-service-user-modal").click();
   await expect(page.getByTestId("service-user-name")).toBeVisible({ timeout: 5_000 });
   await page.getByTestId("service-user-name").fill(name);
@@ -101,23 +86,83 @@ async function createServiceUser(
   await expect(page.getByTestId("service-user-name")).not.toBeVisible({ timeout: 5_000 });
 }
 
-async function checkServiceUserRow(
-  page: import("@playwright/test").Page,
-  name: string,
-  role: string,
-) {
+// openServiceUserList lands on the service users table and waits for it to
+// settle.
+async function openServiceUserList(page: Page) {
+  await navigateTo(page, "/team/service-users");
+  await expectServiceUserList(page);
+}
+
+// returnToServiceUserList goes back to the list from a user's page the way a
+// user would, via the breadcrumb. Unlike a plain click on the nav entry, it
+// waits for the navigation to actually land: the click itself resolves while
+// the client-side navigation is still in flight, so anything that follows can
+// otherwise be computed against the page being left behind.
+async function returnToServiceUserList(page: Page) {
+  await page.getByRole("link", { name: "Service Users" }).click();
+  await page.waitForURL(/\/team\/service-users/, { timeout: 15_000 });
+  await expectServiceUserList(page);
+}
+
+async function expectServiceUserList(page: Page) {
+  await expect(page.getByRole("heading", { name: /Service Users/ })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+// openServiceUser opens one service user's page from the list and only returns
+// once that page really belongs to `name`. The row click is a client-side
+// navigation and the table re-renders as the users fetch revalidates, so
+// clicking a row without confirming where we landed can silently leave us on a
+// different user — and every later edit then targets that other user.
+async function openServiceUser(page: Page, name: string) {
+  await openServiceUserList(page);
+
+  const row = page.locator("tr").filter({ hasText: name });
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await row.click();
+
+  await page.waitForURL(/\/team\/user\?/, { timeout: 15_000 });
+  await expect(page.getByRole("heading", { name, exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function checkServiceUserRow(page: Page, name: string, role: string) {
   const row = page.locator("tr").filter({ hasText: name });
   await expect(row).toBeVisible({ timeout: 10_000 });
   await expect(row.getByText(role, { exact: true }).first()).toBeVisible({ timeout: 10_000 });
 }
 
-async function changeRoleTo(
-  page: import("@playwright/test").Page,
-  role: string,
-) {
+async function changeRoleTo(page: Page, role: string) {
   await page.getByTestId("user-role-selector").click();
   await page
     .getByTestId("user-role-selector-item")
     .getByText(role, { exact: true })
     .click();
+  // Confirm the pick landed. A missed dropdown click leaves the role
+  // unchanged, which disables "Save Changes" and turns the save below into an
+  // unexplained 30s wait for a PUT that is never sent.
+  await expect(
+    page.getByTestId("user-role-selector").getByText(role, { exact: true }),
+  ).toBeVisible({ timeout: 5_000 });
+}
+
+// saveUserChanges saves the open user page and awaits the PUT, so the change is
+// persisted before the next serial test asserts it — clicking save alone
+// returns before the request lands. The PUT is pinned to the user currently
+// open and its status checked: a PUT for some other user, or a rejected one,
+// otherwise leaves the account in a state later assertions blame on the UI.
+async function saveUserChanges(page: Page) {
+  const userId = new URL(page.url()).searchParams.get("id");
+  expect(userId, "expected a user page with an id parameter").toBeTruthy();
+
+  const saveResponse = page.waitForResponse(
+    (resp) =>
+      resp.url().includes(`/api/users/${userId}`) &&
+      resp.request().method() === "PUT",
+    { timeout: 30_000 },
+  );
+  await page.getByTestId("save-changes").click();
+  expect((await saveResponse).status()).toBe(200);
 }

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -170,18 +170,22 @@ export default function AIProviderModal({
   onOpenChange,
   provider,
 }: Readonly<Props>) {
-  const { addProvider, updateProvider, settings } = useAIProviders();
+  const {
+    addProvider,
+    updateProvider,
+    settings,
+    bootstrapAgentNetworkSettings,
+  } = useAIProviders();
   const { data: domains, isLoading: domainsLoading } = useFetchApi<
     ReverseProxyDomain[]
   >("/reverse-proxies/domains");
   const { catalog: catalogList, getById } = useProviderCatalog();
 
   const isEdit = !!provider;
-  // Cluster is no longer a per-provider concern: the backend pins it on
-  // the account-level Settings row, seeded by the first provider create.
-  // We auto-pick from the live /domains response and ship it as
-  // bootstrap_cluster on the create payload — the backend ignores it on
-  // subsequent creates and updates.
+  // The endpoint lives on the account-level Settings row, bootstrapped once
+  // via an explicit POST. We auto-pick a proxy cluster from the live /domains
+  // response and, when the account isn't bootstrapped yet, POST it as the
+  // settings proxy_address right before the first provider create.
   const settingsBootstrapped = !!settings;
 
   const [tab, setTab] = useState<string>("provider");
@@ -309,7 +313,7 @@ export default function AIProviderModal({
 
   // Auto-pick the first validated cluster on first render once the
   // /domains response lands. Only matters for the first-create flow —
-  // once settings is bootstrapped the bootstrap hint is ignored.
+  // once settings is bootstrapped no further bootstrap happens.
   React.useEffect(() => {
     if (settingsBootstrapped) return;
     if (bootstrapCluster) return;
@@ -393,8 +397,8 @@ export default function AIProviderModal({
     name.trim().length > 0 &&
     /^https?:\/\/[^\s]+$/i.test(upstreamUrl.trim()) &&
     apiKey.trim().length >= 4 &&
-    // First-create requires a cluster pick; once settings is bootstrapped
-    // the bootstrap hint is ignored so we don't need to gate on it.
+    // First-create bootstraps the settings row and needs a cluster pick;
+    // once settings is bootstrapped no cluster is involved.
     (settingsBootstrapped || bootstrapCluster.trim().length > 0);
 
   // Restrict extraValues to keys the current catalog entry declares.
@@ -453,11 +457,20 @@ export default function AIProviderModal({
       handleClose();
       return;
     }
+    // First create: bootstrap the account's endpoint before the provider
+    // exists, as an explicit settings POST. A failure keeps the wizard open
+    // (the provider isn't created either) so the operator sees the error and
+    // can retry — this used to be a silent backend side effect.
+    if (!settingsBootstrapped) {
+      const bootstrapped = await bootstrapAgentNetworkSettings(
+        bootstrapCluster.trim(),
+      );
+      if (!bootstrapped) return;
+    }
     await addProvider({
       providerId,
       name,
       upstreamUrl,
-      bootstrapCluster: settingsBootstrapped ? undefined : bootstrapCluster,
       apiKey,
       extraValues: sanitizedExtraValues,
       ...identityOverrides,

--- a/src/modules/agent-network/AIProvidersProvider.tsx
+++ b/src/modules/agent-network/AIProvidersProvider.tsx
@@ -69,9 +69,6 @@ export type APIProviderRequest = {
   provider_id: string;
   name: string;
   upstream_url: string;
-  // bootstrap_cluster is only honoured on the first provider create
-  // for the account; subsequent creates and all updates ignore it.
-  bootstrap_cluster?: string;
   api_key?: string;
   extra_values?: Record<string, string>;
   identity_header_user_id?: string;
@@ -86,9 +83,6 @@ export type ProviderConnectInput = {
   providerId: AIProviderId;
   name: string;
   upstreamUrl: string;
-  // bootstrapCluster is only used on first-create to seed the
-  // account-level Settings row; ignored after that.
-  bootstrapCluster?: string;
   apiKey: string;
   extraValues?: Record<string, string>;
   identityHeaderUserId?: string;
@@ -116,9 +110,13 @@ export type ProviderUpdateInput = {
 };
 
 export type APIAgentNetworkSettings = {
-  cluster: string;
-  subdomain: string;
+  // Bare hostname agents call for this account. Empty until bootstrapped.
   endpoint: string;
+  // Declared cluster address of the proxy serving the endpoint: equal to
+  // endpoint when a dedicated proxy serves the account, otherwise the shared
+  // cluster the endpoint hangs one label beneath.
+  proxy_address: string;
+  dedicated: boolean;
   attribution_mode?: AttributionMode;
   default_user_monthly_budget?: number;
   enable_log_collection: boolean;
@@ -131,9 +129,20 @@ export type APIAgentNetworkSettings = {
   updated_at?: string;
 };
 
+// APIAgentNetworkSettingsCreateRequest matches the POST /agent-network/settings
+// bootstrap body. Exactly one of proxy_address (labeled endpoint — the server
+// allocates the label beneath it) and endpoint (self-addressed dedicated
+// endpoint, claimed verbatim) must be set. The dashboard only uses the
+// labeled shape; the dedicated shape is API/BYOP-facing.
+export type APIAgentNetworkSettingsCreateRequest = {
+  proxy_address?: string;
+  endpoint?: string;
+};
+
 // APIAgentNetworkSettingsRequest matches the PUT /agent-network/settings
-// body. Read-only fields (cluster, subdomain, endpoint, timestamps) are
-// stamped by the backend and never sent from the dashboard.
+// body. The identity fields (endpoint, proxy_address) are assigned at
+// bootstrap (POST) and are not part of the update schema; timestamps are
+// stamped by the backend.
 export type APIAgentNetworkSettingsRequest = {
   enable_log_collection: boolean;
   enable_prompt_collection: boolean;
@@ -142,9 +151,9 @@ export type APIAgentNetworkSettingsRequest = {
 };
 
 export type AgentNetworkSettings = {
-  cluster: string;
-  subdomain: string;
   endpoint: string;
+  proxyAddress: string;
+  dedicated: boolean;
   attributionMode: AttributionMode;
   defaultUserMonthlyBudget: number;
   enableLogCollection: boolean;
@@ -221,7 +230,6 @@ function toCreateRequest(input: ProviderConnectInput): APIProviderRequest {
     provider_id: input.providerId,
     name: input.name,
     upstream_url: input.upstreamUrl,
-    bootstrap_cluster: input.bootstrapCluster,
     api_key: input.apiKey,
     extra_values: input.extraValues,
     identity_header_user_id: input.identityHeaderUserId,
@@ -235,9 +243,9 @@ function toCreateRequest(input: ProviderConnectInput): APIProviderRequest {
 
 function settingsFromAPI(s: APIAgentNetworkSettings): AgentNetworkSettings {
   return {
-    cluster: s.cluster,
-    subdomain: s.subdomain,
     endpoint: s.endpoint,
+    proxyAddress: s.proxy_address,
+    dedicated: s.dedicated ?? false,
     attributionMode: s.attribution_mode ?? "priority",
     defaultUserMonthlyBudget: s.default_user_monthly_budget ?? 0,
     enableLogCollection: s.enable_log_collection ?? false,
@@ -510,6 +518,12 @@ type AIProvidersContextValue = {
   updateAgentNetworkSettings: (
     updates: AgentNetworkSettingsUpdate,
   ) => Promise<boolean>;
+  // Bootstraps the account's settings row, assigning the endpoint as a
+  // server-allocated label beneath the given proxy cluster address. One-time
+  // per account; resolves to true once the row exists (a lost race against a
+  // concurrent bootstrap counts — the row is there), false on failure (errors
+  // are notified internally).
+  bootstrapAgentNetworkSettings: (proxyAddress: string) => Promise<boolean>;
 };
 
 const AIProvidersContext = createContext<AIProvidersContextValue | null>(null);
@@ -523,12 +537,12 @@ export function useAIProviders() {
 }
 
 // useAgentNetworkSettings fetches the account-level agent-network settings.
-// Returns null until the account is bootstrapped (first provider create, or
-// a settings update carrying a cluster). Backends signal the unbootstrapped
-// state differently by age: current ones respond 200 with the defaults and
-// an empty cluster/subdomain/endpoint, older ones 200 + JSON null, and the
-// oldest 404 — tolerated via ignoreError so old deploys don't surface a
-// spurious error in the empty state. All three normalize to null here.
+// Returns null until the account is bootstrapped via the explicit settings
+// POST. Backends signal the unbootstrapped state differently by age: current
+// ones respond 200 with the defaults and an empty endpoint/proxy_address,
+// older ones 200 + JSON null, and the oldest 404 — tolerated via ignoreError
+// so old deploys don't surface a spurious error in the empty state. All
+// three normalize to null here.
 export function useAgentNetworkSettings() {
   const { enabled: agentNetworkEnabled } = useAgentNetworkMode();
   const { data, error, isLoading, mutate } =
@@ -607,6 +621,13 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
   const settingsApi = useApiCall<APIAgentNetworkSettings>(
     "/agent-network/settings",
   );
+  // Separate call with ignoreError: the bootstrap treats a 409 (a concurrent
+  // bootstrap won) as success, so the global error surface must not fire
+  // before we get to classify the failure.
+  const settingsBootstrapApi = useApiCall<APIAgentNetworkSettings>(
+    "/agent-network/settings",
+    true,
+  );
 
   const providers = useMemo<AIProvider[]>(
     () => (apiProviders ?? []).map(fromAPI),
@@ -638,10 +659,6 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
       try {
         const created = await providersApi.post(toCreateRequest(input));
         await mutate();
-        // First-create bootstraps account-level settings on the
-        // backend; refresh so the page header flips out of the empty
-        // state without a manual reload.
-        await mutateSettings();
         notify({
           title: "AI provider connected",
           description: `${created.name} is now available on your agent network endpoint.`,
@@ -655,7 +672,7 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
         return undefined;
       }
     },
-    [providersApi, mutate, mutateSettings],
+    [providersApi, mutate],
   );
 
   const updateProvider = useCallback(
@@ -966,6 +983,31 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
     [budgetRulesApi, mutateBudgetRules],
   );
 
+  const bootstrapAgentNetworkSettings = useCallback(
+    async (proxyAddress: string) => {
+      const body: APIAgentNetworkSettingsCreateRequest = {
+        proxy_address: proxyAddress,
+      };
+      try {
+        await settingsBootstrapApi.post(body);
+      } catch (err) {
+        const code = (err as { code?: number })?.code;
+        if (code !== 409) {
+          notify({
+            title: "Failed to set up the agent network endpoint",
+            description: err instanceof Error ? err.message : String(err),
+          });
+          return false;
+        }
+        // 409: a concurrent bootstrap won. The row exists, which is what
+        // the caller wanted — fall through to the refresh.
+      }
+      await mutateSettings();
+      return true;
+    },
+    [settingsBootstrapApi, mutateSettings],
+  );
+
   const updateAgentNetworkSettings = useCallback(
     async (updates: AgentNetworkSettingsUpdate) => {
       try {
@@ -1016,6 +1058,7 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
       toggleBudgetRule,
       deleteBudgetRule,
       updateAgentNetworkSettings,
+      bootstrapAgentNetworkSettings,
     }),
     [
       providers,
@@ -1045,6 +1088,7 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
       toggleBudgetRule,
       deleteBudgetRule,
       updateAgentNetworkSettings,
+      bootstrapAgentNetworkSettings,
     ],
   );
 

--- a/src/modules/agent-network/AIProvidersProvider.tsx
+++ b/src/modules/agent-network/AIProvidersProvider.tsx
@@ -140,10 +140,14 @@ export type APIAgentNetworkSettingsCreateRequest = {
 };
 
 // APIAgentNetworkSettingsRequest matches the PUT /agent-network/settings
-// body. The identity fields (endpoint, proxy_address) are assigned at
-// bootstrap (POST) and are not part of the update schema; timestamps are
-// stamped by the backend.
+// body. Every field is required — the PUT is a full replace, like the rest of
+// the REST API. The identity fields (endpoint, proxy_address) are assigned at
+// bootstrap (POST) and immutable: the request must echo the stored values
+// unchanged, and the backend rejects a mismatch (422) without applying
+// anything. Timestamps are stamped by the backend.
 export type APIAgentNetworkSettingsRequest = {
+  endpoint: string;
+  proxy_address: string;
   enable_log_collection: boolean;
   enable_prompt_collection: boolean;
   redact_pii: boolean;
@@ -257,8 +261,13 @@ function settingsFromAPI(s: APIAgentNetworkSettings): AgentNetworkSettings {
 
 function settingsToRequest(
   s: AgentNetworkSettingsUpdate,
+  identity: Pick<AgentNetworkSettings, "endpoint" | "proxyAddress">,
 ): APIAgentNetworkSettingsRequest {
   return {
+    // Required echo of the immutable identity — always the stored values,
+    // never user input, so the backend's mismatch rejection can't trigger.
+    endpoint: identity.endpoint,
+    proxy_address: identity.proxyAddress,
     enable_log_collection: s.enableLogCollection,
     enable_prompt_collection: s.enablePromptCollection,
     redact_pii: s.redactPii,
@@ -1010,8 +1019,19 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
 
   const updateAgentNetworkSettings = useCallback(
     async (updates: AgentNetworkSettingsUpdate) => {
+      // The PUT must echo the immutable identity fields (endpoint,
+      // proxy_address) alongside the mutable ones. Without a loaded settings
+      // row there is nothing to echo — and no row to update; the backend
+      // would 404 the PUT anyway.
+      if (!settings) {
+        notify({
+          title: "Failed to update account controls",
+          description: "Agent Network has not been set up yet.",
+        });
+        return false;
+      }
       try {
-        await settingsApi.put(settingsToRequest(updates));
+        await settingsApi.put(settingsToRequest(updates, settings));
         await mutateSettings();
         notify({
           title: "Account controls updated",
@@ -1026,7 +1046,7 @@ export default function AIProvidersProvider({ children }: Readonly<Props>) {
         return false;
       }
     },
-    [settingsApi, mutateSettings],
+    [settings, settingsApi, mutateSettings],
   );
 
   const value = useMemo<AIProvidersContextValue>(


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on netbirdio/netbird#7085** (management: rework Agent Network endpoint identity and settings bootstrap). Draft until that merges — against a management build without it, the settings POST this introduces does not exist.

Adopts the new Agent Network settings contract:

- The management API replaced the implicit settings bootstrap — a `bootstrap_cluster` hint on the first provider create — with an explicit `POST /agent-network/settings` carrying the proxy cluster address. The settings response now carries `endpoint` + `proxy_address` + `dedicated` instead of `cluster` + `subdomain`.
- The provider wizard keeps its UX (auto-picking a validated cluster, gating the first create on having one) but now bootstraps the settings row with the explicit POST right before the first provider create. A bootstrap failure keeps the wizard open and surfaces the error — previously a failed bootstrap was swallowed server-side and the account silently ended up with a provider but no endpoint. A `409` (concurrent bootstrap won) is treated as success, since the row exists either way.
- Types updated accordingly; `bootstrapAgentNetworkSettings` is exposed on the providers context. The onboarding provider step reuses the same wizard, so it is covered by the same change.

Without this, the dashboard against a new management silently stops bootstrapping accounts: provider create succeeds (the old hint is an ignored unknown field), but no endpoint is ever assigned.

Verified manually end to end against a local management running netbirdio/netbird#7085 (labeled bootstrap through the wizard, endpoint rendered, second create skips the bootstrap, failure path keeps the wizard open).

## Issue ticket number and link

Internal (NetBird team) change; ticket to be linked alongside the management PR before this leaves draft.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Docs for the changed settings API are being handled with the management PR (netbirdio/netbird#7085); nothing dashboard-specific beyond that.

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

> Note: the agent-network e2e flow cannot pass against `main` images until netbirdio/netbird#7085 merges and images are rebuilt — the settings POST doesn't exist there yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit Agent Network setup before creating the first AI provider.
  * The selected proxy address is applied during setup.
  * Settings can be refreshed and retried when setup is incomplete.

* **Bug Fixes**
  * Provider creation now stops safely if setup fails.
  * Concurrent setup requests are handled without blocking creation.
  * Uninitialized settings are handled consistently across empty and unavailable responses.
  * Service-user updates now reliably save changes and refresh displayed lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->