### PR TITLE
Fix icon alignment in collapsed navigation and network tab Add buttons

### DIFF
--- a/src/layouts/Navigation.tsx
+++ b/src/layouts/Navigation.tsx
@@ -53,7 +53,7 @@ export default function Navigation({
           ? "w-auto max-w-[22rem]"
           : "w-[15rem] max-w-[15rem] min-w-[15rem] overflow-y-auto",
         isNavigationCollapsed &&
-          "md:w-[70px] md:min-w-[70px] md:fixed md:overflow-hidden md:hover:w-[15rem] md:hover:max-w-[15rem] md:hover:min-w-[15rem] md:z-50",
+          "md:w-[64px] md:min-w-[64px] md:fixed md:overflow-hidden md:hover:w-[15rem] md:hover:max-w-[15rem] md:hover:min-w-[15rem] md:z-50",
       )}
       style={{
         height: `calc(100vh - ${headerHeight + bannerHeight}px)`,
@@ -71,7 +71,7 @@ export default function Navigation({
             className={cn(
               "flex flex-col pt-3 justify-between w-[15rem] max-w-[15rem] min-w-[15rem] transition-all",
               isNavigationCollapsed &&
-                "md:w-[70px] md:min-w-[70px] md:group-hover/navigation:w-[15rem] md:group-hover/navigation:max-w-[15rem] md:group-hover/navigation:min-w-[15rem] md:overflow-x-clip",
+                "md:w-[64px] md:min-w-[64px] md:group-hover/navigation:w-[15rem] md:group-hover/navigation:max-w-[15rem] md:group-hover/navigation:min-w-[15rem] md:overflow-x-clip",
             )}
             style={{
               height: !fullWidth

--- a/src/layouts/PageContainer.tsx
+++ b/src/layouts/PageContainer.tsx
@@ -16,7 +16,7 @@ export default function PageContainer({
       className={cn(
         className,
         "relative flex-auto overflow-auto bg-nb-gray z-1 focus:outline-none",
-        isNavigationCollapsed && "md:pl-[70px]",
+        isNavigationCollapsed && "md:pl-[64px]",
       )}
     >
       {children}

--- a/src/modules/networks/resources/ResourcesTable.tsx
+++ b/src/modules/networks/resources/ResourcesTable.tsx
@@ -18,10 +18,9 @@ import {
   TableFiltersButton,
 } from "@components/table/TableFilters";
 import NoResults from "@components/ui/NoResults";
-import { IconCirclePlus } from "@tabler/icons-react";
 import { ColumnDef, SortingState } from "@tanstack/react-table";
 import { removeAllSpaces } from "@utils/helpers";
-import { ArrowUpRightIcon, Layers3Icon } from "lucide-react";
+import { ArrowUpRightIcon, Layers3Icon, PlusCircle } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import * as React from "react";
 import { useMemo, useState } from "react";
@@ -338,7 +337,7 @@ export default function ResourcesTable({
                 disabled={!permission.networks.update}
                 data-testid={"add-resource"}
               >
-                <IconCirclePlus size={16} />
+                <PlusCircle size={16} />
                 Add
               </Button>
             )

--- a/src/modules/networks/routing-peers/NetworkRoutingPeersTable.tsx
+++ b/src/modules/networks/routing-peers/NetworkRoutingPeersTable.tsx
@@ -14,8 +14,8 @@ import {
   TableFiltersButton,
 } from "@components/table/TableFilters";
 import NoResults from "@components/ui/NoResults";
-import { IconCirclePlus } from "@tabler/icons-react";
 import { ColumnDef, SortingState } from "@tanstack/react-table";
+import { PlusCircle } from "lucide-react";
 import * as React from "react";
 import { useMemo, useState } from "react";
 import PeerIcon from "@/assets/icons/PeerIcon";
@@ -167,7 +167,7 @@ export default function NetworkRoutingPeersTable({
           onClick={() => network && openAddRoutingPeerModal(network)}
           disabled={!permission.networks.update}
         >
-          <IconCirclePlus size={16} />
+          <PlusCircle size={16} />
           Add
         </Button>
       )}


### PR DESCRIPTION
## Issue ticket number and link

N/A — visual polish reported directly.

## Description

Two small icon-alignment fixes.

**1. Collapsed navigation icons were not centered**

Nav items carry 24px of left padding (`px-3` on the `<li>` plus `px-3` on the button), so with 16px icons the icon center lands at 32px — but the 70px rail centered at 35px, leaving icons 3px to the left. Narrowing the rail to 64px makes the rail center and the icon center coincide.

- `src/layouts/Navigation.tsx` — collapsed width 70px → 64px on the outer container and the inner flex column
- `src/layouts/PageContainer.tsx` — `md:pl-[70px]` → `md:pl-[64px]` to match the new offset

Note: this assumes sidebar icons render at 16px. A few (e.g. `<PeerIcon />`) are used without an explicit `size`; if any default to another size they will still sit slightly off-center.

**2. Network tab Add buttons used two different icon sets**

The Resources and Routing Peers Add buttons used `IconCirclePlus` from `@tabler/icons-react`, while the Services tab used `PlusCircle` from `lucide-react`. Both were `size={16}`, but the two sets draw the glyph at different inner scales and stroke widths, so they read as different sizes. Standardized on lucide.

- `src/modules/networks/resources/ResourcesTable.tsx`
- `src/modules/networks/routing-peers/NetworkRoutingPeersTable.tsx`

`ResourceGroupCell.tsx` still uses the tabler icon — it is an inline cell chip rather than a tab Add button, so it is out of scope here.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

CSS-only visual alignment fix — no user-facing behavior, API, or configuration changes to document.

### Docs PR URL (required if "docs added" is checked)

N/A

## E2E tests

management-cloud-tag: main
reverse-proxy-tag: main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the width of the collapsed navigation for a more compact layout.
  * Updated page spacing to align with the narrower collapsed navigation.
  * Preserved existing expanded navigation hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
