### PR TITLE
Add bulk deletion for Access Control groups

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -39,6 +39,7 @@ const Checkbox = React.forwardRef<
         "peer h-5 w-5 shrink-0 rounded-[4px] border",
         "ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2",
         "disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-neutral-900 data-[state=checked]:text-neutral-50 ",
+        "disabled:data-[state=unchecked]:border-dashed dark:disabled:data-[state=unchecked]:border-nb-gray-700",
         "data-[state=indeterminate]:bg-neutral-900 data-[state=indeterminate]:text-neutral-50",
         className,
       )}

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -3,7 +3,7 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { cn } from "@utils/helpers";
 import { cva, VariantProps } from "class-variance-authority";
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 import * as React from "react";
 
 type CheckboxVariants = VariantProps<typeof variants>;
@@ -42,9 +42,16 @@ const Checkbox = React.forwardRef<
       {...props}
     >
       <CheckboxPrimitive.Indicator
-        className={"flex items-center justify-center"}
+        className={"group flex items-center justify-center"}
       >
-        <Check size={14} />
+        <Check
+          size={14}
+          className={"group-data-[state=indeterminate]:hidden"}
+        />
+        <Minus
+          size={14}
+          className={"hidden group-data-[state=indeterminate]:block"}
+        />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   </div>

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -14,10 +14,12 @@ const variants = cva([], {
       default: [
         "dark:data-[state=unchecked]:bg-nb-gray-950 dark:border-nb-gray-900 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 ",
         "dark:data-[state=checked]:bg-netbird dark:data-[state=checked]:text-neutral-50",
+        "dark:data-[state=indeterminate]:bg-netbird dark:data-[state=indeterminate]:text-neutral-50",
       ],
       tableCell: [
         "dark:data-[state=unchecked]:bg-nb-gray-920 dark:border-nb-gray-800 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 ",
         "dark:data-[state=checked]:bg-netbird dark:data-[state=checked]:text-neutral-50",
+        "dark:data-[state=indeterminate]:bg-netbird dark:data-[state=indeterminate]:text-neutral-50",
       ],
     },
   },
@@ -37,6 +39,7 @@ const Checkbox = React.forwardRef<
         "peer h-5 w-5 shrink-0 rounded-[4px] border",
         "ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2",
         "disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-neutral-900 data-[state=checked]:text-neutral-50 ",
+        "data-[state=indeterminate]:bg-neutral-900 data-[state=indeterminate]:text-neutral-50",
         className,
       )}
       {...props}

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -127,6 +127,21 @@ const checkboxSort: SortingFn<any> = (rowA, rowB, columnId) => {
   return 0;
 };
 
+/**
+ * Rows are not required to carry an `id`, and some carry a nullable one, so
+ * read it defensively rather than asserting it exists. Rows without a usable id
+ * fall back to `fallbackRowId` — previously they silently got `undefined` as the
+ * row key under `useRowId`, which breaks row selection.
+ */
+function readRowId(row: unknown): string | undefined {
+  if (typeof row !== "object" || row === null || !("id" in row)) return;
+  const id = (row as { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+/** Namespaced so an id-less row cannot collide with a real id like "1". */
+const fallbackRowId = (index: number) => `row-${index}`;
+
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[] | undefined;
@@ -162,6 +177,7 @@ interface DataTableProps<TData, TValue> {
   showHeader?: boolean;
   rowSelection?: RowSelectionState;
   setRowSelection?: React.Dispatch<React.SetStateAction<RowSelectionState>>;
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
   useRowId?: boolean;
   headingTarget?: HTMLHeadingElement | null;
   showResetFilterButton?: boolean;
@@ -177,6 +193,7 @@ interface DataTableProps<TData, TValue> {
   initialPageSize?: number;
   uniqueKey?: string;
   resetRowSelectionOnSearch?: boolean;
+  resetRowSelectionOnFilter?: boolean;
   pageCount?: number;
   pagination?: { pageIndex: number; pageSize: number };
   onPaginationChange?: (pagination: {
@@ -226,6 +243,7 @@ export function DataTable<TData, TValue>({
   showHeader = true,
   rowSelection,
   setRowSelection,
+  enableRowSelection,
   useRowId,
   headingTarget,
   showResetFilterButton = true,
@@ -241,6 +259,7 @@ export function DataTable<TData, TValue>({
   initialPageSize = 10,
   uniqueKey,
   resetRowSelectionOnSearch = true,
+  resetRowSelectionOnFilter = false,
   pageCount,
   pagination,
   onPaginationChange,
@@ -340,7 +359,10 @@ export function DataTable<TData, TValue>({
       checkbox: checkboxSort,
       datetime: datetimeSort,
     },
-    getRowId: useRowId ? (row) => row.id : undefined,
+    getRowId: useRowId
+      ? (row, index) => readRowId(row) ?? fallbackRowId(index)
+      : undefined,
+    enableRowSelection,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onPaginationChange: (updater) => {
@@ -365,6 +387,9 @@ export function DataTable<TData, TValue>({
       } else {
         setLocalColumnFilters(filters as ColumnFiltersState);
       }
+      // Rows hidden by a filter stay in the selection map, so tables whose bulk
+      // actions are destructive opt into clearing it whenever filters change.
+      if (resetRowSelectionOnFilter) setRowSelection?.({});
     },
     onGlobalFilterChange: (value) => {
       if (manualFiltering) {
@@ -536,7 +561,7 @@ export function DataTable<TData, TValue>({
                 {table.getRowModel().rows?.length ? (
                   table.getRowModel().rows.map((row) => {
                     const expandedRow = renderExpandedRow?.(row.original);
-                    const rowId = row.original.id ?? row.id;
+                    const rowId = readRowId(row.original) ?? row.id;
                     const isExpanded = accordion?.includes(rowId);
                     const rowContent = (
                       <React.Fragment key={row.id}>

--- a/src/components/table/DataTableMultiSelectPopup.tsx
+++ b/src/components/table/DataTableMultiSelectPopup.tsx
@@ -11,6 +11,7 @@ type Props<T> = {
   label?: string;
   onCanceled?: () => void;
   rightSide?: React.ReactNode;
+  icon?: React.ReactNode;
 };
 
 export function DataTableMultiSelectPopup<T>({
@@ -18,6 +19,7 @@ export function DataTableMultiSelectPopup<T>({
   label = "Peer(s) selected",
   selectedItems,
   rightSide,
+  icon,
 }: Props<T>) {
   const count = selectedItems?.length || 0;
   return (
@@ -54,7 +56,9 @@ export function DataTableMultiSelectPopup<T>({
                     }
                   >
                     <div className={"flex gap-2 items-center"}>
-                      <MonitorSmartphoneIcon size={16} className={""} />
+                      {icon ?? (
+                        <MonitorSmartphoneIcon size={16} className={""} />
+                      )}
                       <span>
                         <span className={"font-medium text-white"}>
                           {count}

--- a/src/interfaces/Group.ts
+++ b/src/interfaces/Group.ts
@@ -34,6 +34,7 @@ export const GROUP_TOOLTIP_TEXT = {
   },
   DELETE: {
     INTEGRATION: "This group is issued by an IdP and cannot be deleted.",
+    ALL: "The 'All' group is required and cannot be deleted.",
   },
   IN_USE: "Remove dependencies to this group to delete it.",
 };

--- a/src/modules/groups/GroupsMultiSelect.tsx
+++ b/src/modules/groups/GroupsMultiSelect.tsx
@@ -1,0 +1,114 @@
+import Button from "@components/Button";
+import FullTooltip from "@components/FullTooltip";
+import { notify } from "@components/Notification";
+import { DataTableMultiSelectPopup } from "@components/table/DataTableMultiSelectPopup";
+import { ErrorResponse, useApiCall } from "@utils/api";
+import { FolderGit2, Trash2 } from "lucide-react";
+import { useSWRConfig } from "swr";
+import { useDialog } from "@/contexts/DialogProvider";
+import { useGroups } from "@/contexts/GroupsProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { Group } from "@/interfaces/Group";
+import { GroupUsage } from "@/modules/groups/useGroupsUsage";
+
+type Props = {
+  selectedGroups?: GroupUsage[];
+  onCanceled?: () => void;
+};
+
+export const GroupsMultiSelect = ({
+  selectedGroups = [],
+  onCanceled,
+}: Readonly<Props>) => {
+  const { mutate } = useSWRConfig();
+  const { confirm } = useDialog();
+  const { deleteGroupDropdownOption } = useGroups();
+  const { permission } = usePermissions();
+  const groupCall = useApiCall<Group>("/groups", true);
+  const groupCount = selectedGroups.length;
+
+  const deleteAllGroups = async () => {
+    if (!permission.groups.delete || groupCount === 0) return;
+
+    const choice = await confirm({
+      title: `Delete ${groupCount} ${groupCount > 1 ? "groups" : "group"}?`,
+      description: `Are you sure you want to delete ${
+        groupCount > 1 ? "these groups" : "this group"
+      }? This action cannot be undone.`,
+      confirmText: "Delete All",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+
+    // Take the batch and drop the selection now rather than when the requests
+    // land, so a slow batch cannot wipe a selection the user made in the
+    // meantime, and the popup acknowledges the confirmation immediately.
+    const groupsToDelete = selectedGroups;
+    onCanceled?.();
+
+    // allSettled, not all: the in-use counts driving the checkboxes come from a
+    // client-side snapshot, so the server can still reject an individual group.
+    // The table has to refresh for the ones that did get deleted either way.
+    const promise = Promise.allSettled(
+      groupsToDelete.map((group) => groupCall.del({}, `/${group.id}`)),
+    ).then((results) => {
+      results.forEach((result, index) => {
+        if (result.status === "fulfilled") {
+          deleteGroupDropdownOption(groupsToDelete[index].name);
+        }
+      });
+      mutate("/groups");
+
+      const failures = results.filter((r) => r.status === "rejected");
+      if (failures.length === 0) return;
+
+      const firstError = failures[0].reason as ErrorResponse | undefined;
+      const failureMessage = firstError?.message ?? "Something went wrong...";
+      return Promise.reject({
+        code: firstError?.code ?? 418,
+        requestId: firstError?.requestId,
+        message:
+          failures.length === groupCount
+            ? failureMessage
+            : `${failures.length} of ${groupCount} groups could not be deleted. ${failureMessage}`,
+      } satisfies ErrorResponse);
+    });
+
+    notify({
+      title: "Delete Groups",
+      description:
+        groupCount > 1
+          ? "Groups were successfully deleted"
+          : "Group was successfully deleted",
+      promise,
+      loadingMessage:
+        groupCount > 1
+          ? "Deleting the selected groups..."
+          : "Deleting the selected group...",
+    });
+  };
+
+  return (
+    <DataTableMultiSelectPopup
+      selectedItems={selectedGroups}
+      label={groupCount === 1 ? "Group selected" : "Groups selected"}
+      onCanceled={onCanceled}
+      icon={<FolderGit2 size={16} />}
+      rightSide={
+        <FullTooltip content={<span className={"text-xs"}>Delete All</span>}>
+          <Button
+            variant={"danger-outline"}
+            size={"xs"}
+            className={"!h-9 !w-9"}
+            onClick={deleteAllGroups}
+            disabled={!permission.groups.delete}
+            aria-label={"Delete selected groups"}
+          >
+            <Trash2 size={16} className={"shrink-0"} />
+          </Button>
+        </FullTooltip>
+      }
+    />
+  );
+};

--- a/src/modules/groups/table/GroupsTable.tsx
+++ b/src/modules/groups/table/GroupsTable.tsx
@@ -50,7 +50,13 @@ export const GroupsTableColumns: ColumnDef<GroupUsage>[] = [
     header: ({ table }) => (
       <div className={"min-w-[20px] max-w-[20px]"}>
         <Checkbox
-          checked={table.getIsAllPageRowsSelected()}
+          checked={
+            table.getIsAllPageRowsSelected()
+              ? true
+              : table.getIsSomePageRowsSelected()
+              ? "indeterminate"
+              : false
+          }
           onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
           disabled={!table.getRowModel().rows.some((row) => row.getCanSelect())}
           aria-label="Select all groups on this page"
@@ -415,7 +421,7 @@ export default function GroupsTable({ headingTarget }: Readonly<Props>) {
           <TableFilterChips table={table} filters={filterDefs} />
         )}
         columnVisibility={{
-          select: permission.groups.delete,
+          select: !!permission.groups.delete,
           in_use: false,
           search: false,
         }}

--- a/src/modules/groups/table/GroupsTable.tsx
+++ b/src/modules/groups/table/GroupsTable.tsx
@@ -1,3 +1,5 @@
+import { Checkbox } from "@components/Checkbox";
+import FullTooltip from "@components/FullTooltip";
 import { DataTable } from "@components/table/DataTable";
 import DataTableHeader from "@components/table/DataTableHeader";
 import DataTableResetFilterButton from "@components/table/DataTableResetFilterButton";
@@ -11,27 +13,74 @@ import {
   TableFilterDef,
   TableFiltersButton,
 } from "@components/table/TableFilters";
-import { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+  ColumnDef,
+  RowSelectionState,
+  SortingState,
+} from "@tanstack/react-table";
 import { removeAllSpaces } from "@utils/helpers";
 import { Layers3Icon } from "lucide-react";
 import { usePathname } from "next/navigation";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import AccessControlIcon from "@/assets/icons/AccessControlIcon";
 import DNSIcon from "@/assets/icons/DNSIcon";
+import DNSZoneIcon from "@/assets/icons/DNSZoneIcon";
 import NetworkRoutesIcon from "@/assets/icons/NetworkRoutesIcon";
 import PeerIcon from "@/assets/icons/PeerIcon";
 import SetupKeysIcon from "@/assets/icons/SetupKeysIcon";
 import TeamIcon from "@/assets/icons/TeamIcon";
 import { AddGroupButton } from "@/components/ui/AddGroupButton";
 import { GroupProvider } from "@/contexts/GroupProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { GroupsMultiSelect } from "@/modules/groups/GroupsMultiSelect";
 import GroupsActionCell from "@/modules/groups/table/GroupsActionCell";
 import GroupsCountCell from "@/modules/groups/table/GroupsCountCell";
 import GroupsNameCell from "@/modules/groups/table/GroupsNameCell";
-import useGroupsUsage, { GroupUsage } from "@/modules/groups/useGroupsUsage";
-import DNSZoneIcon from "@/assets/icons/DNSZoneIcon";
+import useGroupsUsage, {
+  canDeleteGroup,
+  groupDeleteDisabledReason,
+  GroupUsage,
+  isGroupInUse,
+} from "@/modules/groups/useGroupsUsage";
 
 export const GroupsTableColumns: ColumnDef<GroupUsage>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <div className={"min-w-[20px] max-w-[20px]"}>
+        <Checkbox
+          checked={table.getIsAllPageRowsSelected()}
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          disabled={!table.getRowModel().rows.some((row) => row.getCanSelect())}
+          aria-label="Select all groups on this page"
+        />
+      </div>
+    ),
+    cell: ({ row }) => {
+      const canSelect = row.getCanSelect();
+      const disabledReason = groupDeleteDisabledReason(row.original);
+      return (
+        <div className={"min-w-[20px] max-w-[20px]"}>
+          <FullTooltip
+            content={<div className={"text-xs max-w-xs"}>{disabledReason}</div>}
+            interactive={false}
+            disabled={canSelect || !disabledReason}
+          >
+            <Checkbox
+              checked={row.getIsSelected() && canSelect}
+              variant={"tableCell"}
+              onCheckedChange={(value) => row.toggleSelected(!!value)}
+              disabled={!canSelect}
+              aria-label={`Select ${row.original.name}`}
+            />
+          </FullTooltip>
+        </div>
+      );
+    },
+    enableSorting: false,
+    enableHiding: false,
+  },
   {
     accessorKey: "name",
     header: ({ column }) => {
@@ -240,18 +289,7 @@ export const GroupsTableColumns: ColumnDef<GroupUsage>[] = [
       return <DataTableHeader column={column}>In Use</DataTableHeader>;
     },
     sortingFn: "basic",
-    accessorFn: (row) => {
-      return (
-        row.peers_count > 0 ||
-        row.nameservers_count > 0 ||
-        row.policies_count > 0 ||
-        row.routes_count > 0 ||
-        row.setup_keys_count > 0 ||
-        row.users_count > 0 ||
-        row.resources_count > 0 ||
-        row.zones_count > 0
-      );
-    },
+    accessorFn: isGroupInUse,
   },
   {
     accessorKey: "id",
@@ -275,7 +313,34 @@ type Props = {
 
 export default function GroupsTable({ headingTarget }: Readonly<Props>) {
   const { data: groups, isLoading } = useGroupsUsage();
+  const { permission } = usePermissions();
   const path = usePathname();
+  const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
+
+  const selectedGroups = useMemo(
+    () =>
+      groups?.filter(
+        (group) => canDeleteGroup(group) && group.id && selectedRows[group.id],
+      ) ?? [],
+    [groups, selectedRows],
+  );
+
+  // Drop selections whose group has been deleted or has picked up a dependency
+  // since it was checked, so a group can never silently re-enter the batch when
+  // it becomes deletable again. Returning `prev` untouched matters: `groups` is
+  // recomputed from seven endpoints, so this runs on every revalidation.
+  useEffect(() => {
+    setSelectedRows((prev) => {
+      const selectedIds = Object.keys(prev);
+      if (selectedIds.length === 0) return prev;
+      const deletableIds = new Set(
+        groups?.filter(canDeleteGroup).map((group) => group.id),
+      );
+      const remaining = selectedIds.filter((id) => deletableIds.has(id));
+      if (remaining.length === selectedIds.length) return prev;
+      return Object.fromEntries(remaining.map((id) => [id, prev[id]]));
+    });
+  }, [groups]);
 
   // Default sorting state of the table
   const [sorting, setSorting] = useLocalStorage<SortingState>(
@@ -322,43 +387,58 @@ export default function GroupsTable({ headingTarget }: Readonly<Props>) {
   );
 
   return (
-    <DataTable
-      headingTarget={headingTarget}
-      text={"Groups"}
-      sorting={sorting}
-      isLoading={isLoading}
-      setSorting={setSorting}
-      columns={GroupsTableColumns}
-      data={groups}
-      initialPageSize={25}
-      showResetFilterButton={false}
-      searchPlaceholder={"Search group by name..."}
-      rightSide={() => <AddGroupButton />}
-      aboveTable={(table) => (
-        <TableFilterChips table={table} filters={filterDefs} />
-      )}
-      columnVisibility={{
-        in_use: false,
-        search: false,
-      }}
-    >
-      {(table) => (
-        <>
-          <TableFiltersButton
-            table={table}
-            filters={filterDefs}
-            disabled={groups?.length == 0}
-          />
-          <DataTableResetFilterButton
-            table={table}
-            onClick={() => {
-              table.setPageIndex(0);
-              table.resetColumnFilters();
-              table.resetGlobalFilter();
-            }}
-          />
-        </>
-      )}
-    </DataTable>
+    <>
+      <GroupsMultiSelect
+        selectedGroups={selectedGroups}
+        onCanceled={() => setSelectedRows({})}
+      />
+      <DataTable
+        headingTarget={headingTarget}
+        rowSelection={selectedRows}
+        setRowSelection={setSelectedRows}
+        enableRowSelection={(row) =>
+          !!permission.groups.delete && canDeleteGroup(row.original)
+        }
+        useRowId={true}
+        resetRowSelectionOnFilter={true}
+        text={"Groups"}
+        sorting={sorting}
+        isLoading={isLoading}
+        setSorting={setSorting}
+        columns={GroupsTableColumns}
+        data={groups}
+        initialPageSize={25}
+        showResetFilterButton={false}
+        searchPlaceholder={"Search group by name..."}
+        rightSide={() => <AddGroupButton />}
+        aboveTable={(table) => (
+          <TableFilterChips table={table} filters={filterDefs} />
+        )}
+        columnVisibility={{
+          select: permission.groups.delete,
+          in_use: false,
+          search: false,
+        }}
+      >
+        {(table) => (
+          <>
+            <TableFiltersButton
+              table={table}
+              filters={filterDefs}
+              disabled={groups?.length == 0}
+            />
+            <DataTableResetFilterButton
+              table={table}
+              onClick={() => {
+                table.setPageIndex(0);
+                table.resetColumnFilters();
+                table.resetGlobalFilter();
+                setSelectedRows({});
+              }}
+            />
+          </>
+        )}
+      </DataTable>
+    </>
   );
 }

--- a/src/modules/groups/useGroupsUsage.tsx
+++ b/src/modules/groups/useGroupsUsage.tsx
@@ -1,7 +1,7 @@
 import useFetchApi from "@utils/api";
 import { useMemo } from "react";
 import { DNSZone } from "@/interfaces/DNS";
-import { Group } from "@/interfaces/Group";
+import { GROUP_TOOLTIP_TEXT, Group, GroupIssued } from "@/interfaces/Group";
 import { NameserverGroup } from "@/interfaces/Nameserver";
 import { Policy } from "@/interfaces/Policy";
 import { Route } from "@/interfaces/Route";
@@ -18,6 +18,32 @@ export interface GroupUsage extends Group {
   users_count: number;
   resources_count: number;
 }
+
+export const isGroupInUse = (group: GroupUsage) =>
+  group.peers_count > 0 ||
+  group.nameservers_count > 0 ||
+  group.policies_count > 0 ||
+  group.routes_count > 0 ||
+  group.setup_keys_count > 0 ||
+  group.users_count > 0 ||
+  group.resources_count > 0 ||
+  group.zones_count > 0;
+
+/**
+ * Why the group cannot be deleted, or undefined when it can be. Mirrors the
+ * rules the single-group action cell applies, so the bulk-select checkboxes and
+ * the row menu can never disagree about what is deletable.
+ */
+export const groupDeleteDisabledReason = (group: GroupUsage) => {
+  if (group.name === "All") return GROUP_TOOLTIP_TEXT.DELETE.ALL;
+  if (group.issued === GroupIssued.INTEGRATION)
+    return GROUP_TOOLTIP_TEXT.DELETE.INTEGRATION;
+  if (isGroupInUse(group)) return GROUP_TOOLTIP_TEXT.IN_USE;
+  return undefined;
+};
+
+export const canDeleteGroup = (group: GroupUsage) =>
+  !!group.id && !groupDeleteDisabledReason(group);
 
 export default function useGroupsUsage() {
   const { data: groups, isLoading: isGroupsLoading } =


### PR DESCRIPTION
## Description

Adds page-scoped group selection and bulk deletion to the Access Control Groups page, following the existing Peers page interaction pattern.

<img width="1501" height="677" alt="Screenshot 2026-08-10 at 9 00 38 PM" src="https://github.com/user-attachments/assets/08a81767-1d7c-4608-93b2-033e75bd0fcd" />

## Changes

- Add row checkboxes and current-page select-all behavior.
- Restrict selection to groups that can be deleted and explain disabled rows.
- Add a confirmation dialog, deletion notifications, and partial-failure handling.
- Refresh group data and clear selection after batch operations.
- Clear selected groups when search or table filters change.
- Extend the shared table and multi-select popup for row eligibility and custom icons.
- Improve fallback row ID handling for records without string IDs.


## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [X] Documentation is **not needed** for this change (explain why)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select group deletion with confirmation and success or partial-failure notifications.
  * Added group-row selection with permission and usage-based safeguards.
  * Added configurable row selection and selection reset behavior to data tables.
  * Added support for custom icons in multi-select popups.

* **Bug Fixes**
  * Improved handling of missing or invalid row identifiers.
  * Clarified why groups cannot be deleted, including the required “All” group.
  * Improved indeterminate checkbox visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->