### PR TITLE
Bump default wasm client to v0.76.3

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -82,7 +82,7 @@ const loadConfig = (): Config => {
     googleTagManagerID: configJson?.googleTagManagerID || undefined,
     authServiceUrl: configJson?.authServiceUrl ?? undefined,
     wasmPath:
-      configJson?.wasmPath || "https://pkgs.netbird.io/wasm/client/v0.74.2",
+      configJson?.wasmPath || "https://pkgs.netbird.io/wasm/client/v0.76.3",
     licensed: configJson?.licensed === "true",
     cloud: configJson?.cloud === "true",
     agentNetworkOnly: configJson?.agentNetworkOnly === "true",


### PR DESCRIPTION
Update the default embedded client wasm to the latest NetBird release.

- Bump the default wasm client path to v0.76.3

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (version bump only, no behavior or user-facing changes)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default WebAssembly client URL to use version `v0.76.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->