### PR TITLE
Upgrade base image to Alpine 3.24

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.24
 
 RUN apk add --no-cache bash curl less ca-certificates git tzdata zip gettext \
     nginx curl supervisor certbot-nginx && \


### PR DESCRIPTION
Alpine 3.14 reached end of life in May 2023 and has received no security fixes for roughly three years. nginx is installed from the Alpine repos rather than pinned, so the base bump also moves nginx 1.20.2 -> 1.30.4, certbot 1.16.0 -> 5.6.0 and supervisor 4.2.2 -> 4.3.0.

Alpine 3.24 carries security support until June 2028.

Verified by building and running this Dockerfile on 3.14, 3.23 and 3.24 and comparing: the served index.html is byte-identical across all three, the CSP response header hashes identically, `nginx -t` passes on the existing config, and supervisord reaches the same state. /etc/crontabs/root and /etc/nginx/http.d/ still exist on 3.24, so the `rm /etc/crontabs/root` step and the config COPY paths are unaffected. Every certbot flag used by init_cert.sh is still accepted by certbot 5.x.

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base image to Alpine Linux 3.24 for improved platform support and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->