### PR TITLE
fix(agent-network): show real provider name in access log

### DIFF
--- a/src/modules/agent-network/AIProviderLogo.tsx
+++ b/src/modules/agent-network/AIProviderLogo.tsx
@@ -6,7 +6,10 @@ import { AIProviderId } from "@/modules/agent-network/data/mockData";
 import { useProviderCatalog } from "@/modules/agent-network/useProviderCatalog";
 
 type Props = {
-  providerId: AIProviderId;
+  // Catalog provider id to badge. Undefined renders the neutral "?" badge —
+  // for requests NetBird can't attribute to any provider (e.g. rejected
+  // before the router picked one).
+  providerId?: AIProviderId;
   size?: number;
   className?: string;
 };
@@ -17,7 +20,7 @@ export default function AIProviderLogo({
   className,
 }: Readonly<Props>) {
   const { getById } = useProviderCatalog();
-  const entry = getById(providerId);
+  const entry = providerId ? getById(providerId) : undefined;
   const initial = entry ? entry.name.charAt(0) : "?";
   const bg = entry?.brand_color ?? "#6B7280";
 

--- a/src/modules/agent-network/AgentAccessLogExpandedRow.tsx
+++ b/src/modules/agent-network/AgentAccessLogExpandedRow.tsx
@@ -29,7 +29,10 @@ export default function AgentAccessLogExpandedRow({ entry }: Readonly<Props>) {
   const cacheRead = entry.cachedInputTokens ?? 0;
   const cacheWrite = entry.cacheCreationTokens ?? 0;
   const metadata: Record<string, string> = {
-    "plg.llm.provider": entry.providerId,
+    // The vendor label the proxy actually stamped, not the dashboard's
+    // normalised catalog id — this block mirrors the wire metadata, and a
+    // request rejected before it was parsed as an LLM call carries no vendor.
+    "plg.llm.provider": entry.providerVendor ?? entry.providerId,
     "plg.llm.model": entry.model,
     "plg.llm.input_tokens": String(entry.inputTokens),
     "plg.llm.output_tokens": String(entry.outputTokens),

--- a/src/modules/agent-network/AgentAccessLogTable.tsx
+++ b/src/modules/agent-network/AgentAccessLogTable.tsx
@@ -45,7 +45,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import * as React from "react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { DateRange } from "react-day-picker";
 import AgentNetworkIcon from "@/assets/icons/AgentNetworkIcon";
 import { useGroups } from "@/contexts/GroupsProvider";
@@ -69,6 +69,7 @@ import {
 } from "@/modules/agent-network/agentAccessLogApi";
 import { useAIProviders } from "@/modules/agent-network/AIProvidersProvider";
 import AIProviderLogo from "@/modules/agent-network/AIProviderLogo";
+import { useProviderCatalog } from "@/modules/agent-network/useProviderCatalog";
 import AgentAccessLogExpandedRow from "@/modules/agent-network/AgentAccessLogExpandedRow";
 import EmptyRow from "@/modules/common-table-rows/EmptyRow";
 import TextWithTooltip from "@components/ui/TextWithTooltip";
@@ -94,6 +95,7 @@ export default function AgentAccessLogTable({
   onGroupedChange,
 }: Readonly<Props>) {
   const { providers } = useAIProviders();
+  const { catalog } = useProviderCatalog();
   const { users } = useUsers();
   const { peers } = usePeers();
   const { groups } = useGroups();
@@ -178,10 +180,19 @@ export default function AgentAccessLogTable({
     return map;
   }, [providers]);
 
-  const resolveProvider = (entry: AIAccessLogEntry) =>
-    entry.resolvedProviderId
-      ? providerByConfigId.get(entry.resolvedProviderId)
-      : undefined;
+  // Catalog display names, for requests that carry a vendor but no resolved
+  // provider — so the column can say "OpenAI API" instead of "openai_api".
+  const catalogNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    catalog.forEach((p) => map.set(p.id, p.name));
+    return map;
+  }, [catalog]);
+
+  const providerDisplay = useCallback(
+    (entry: AIAccessLogEntry): ProviderDisplay =>
+      resolveProviderDisplay(entry, providerByConfigId, catalogNameById),
+    [providerByConfigId, catalogNameById],
+  );
 
   const columns = useMemo<ColumnDef<AIAccessLogEntry>[]>(
     () => [
@@ -222,14 +233,13 @@ export default function AgentAccessLogTable({
       },
       {
         id: "provider",
-        accessorFn: (row) => {
-          const resolved = resolveProvider(row);
-          // Include the resolved name, the raw vendor id, and the model so the
-          // search matches whether the operator types "OpenAI API" or "openai".
-          return `${resolved?.name ?? ""} ${row.providerId} ${
+        accessorFn: (row) =>
+          // Include the displayed name, the raw vendor label, and the model so
+          // the search matches whether the operator types "OpenAI API" or
+          // "openai".
+          `${providerDisplay(row).name} ${row.providerVendor ?? ""} ${
             row.model
-          }`.trim();
-        },
+          }`.trim(),
         header: ({ column }) => (
           <DataTableHeader column={column} name="provider" sorting={false}>
             Provider
@@ -238,7 +248,7 @@ export default function AgentAccessLogTable({
         cell: ({ row }) => (
           <ProviderCell
             entry={row.original}
-            resolved={resolveProvider(row.original)}
+            display={providerDisplay(row.original)}
           />
         ),
       },
@@ -316,7 +326,7 @@ export default function AgentAccessLogTable({
         enableGlobalFilter: false,
       },
     ],
-    [providerByConfigId, principalSearchById],
+    [providerDisplay, principalSearchById],
   );
 
   // Session-grouped columns. Filter ids (timestamp / user / group / provider /
@@ -371,7 +381,11 @@ export default function AgentAccessLogTable({
       },
       {
         id: "provider",
-        accessorFn: (row) => row.models.join(" "),
+        accessorFn: (row) =>
+          [
+            ...row.models,
+            ...row.entries.map((e) => providerDisplay(e).name),
+          ].join(" "),
         header: ({ column }) => (
           <DataTableHeader column={column} sorting={false}>
             Provider
@@ -380,7 +394,7 @@ export default function AgentAccessLogTable({
         cell: ({ row }) => (
           <SessionProviderCell
             session={row.original}
-            resolveProvider={resolveProvider}
+            providerDisplay={providerDisplay}
           />
         ),
       },
@@ -472,7 +486,7 @@ export default function AgentAccessLogTable({
         enableGlobalFilter: false,
       },
     ],
-    [providerByConfigId, principalSearchById],
+    [providerDisplay, principalSearchById],
   );
 
   const [sorting, setSorting] = useState<SortingState>([
@@ -970,27 +984,95 @@ function UserCell({ entry }: { entry: AIAccessLogEntry }) {
   );
 }
 
+// ProviderDisplay is what the Provider column shows for one request: the badge
+// id, the label, and whether the label names the provider that actually served
+// the request (resolved) or is only the API shape the client called.
+type ProviderDisplay = {
+  // Stable identity for deduping a session's providers: the config-row id when
+  // resolved, so two records of the same vendor stay distinct.
+  key: string;
+  logoId?: AIProviderId;
+  name: string;
+  resolved: boolean;
+  // Why the label isn't a configured provider — shown on hover. Unset when
+  // resolved.
+  hint?: string;
+};
+
+// resolveProviderDisplay maps a request to its Provider column content.
+//
+// A request the router matched carries resolved_provider_id — the config-row id
+// of the provider that served it, and the only unambiguous attribution (one
+// synth service fronts every provider, so serviceId can't disambiguate).
+//
+// A request rejected before routing carries no resolved id: a 403
+// (model_not_routable / no_authorised_provider) still has the parser's vendor,
+// so it's labelled with that vendor's catalog name; a 404 on an unrecognised
+// path has no vendor at all and reads as "Unknown". Neither may render the raw
+// catalog id, which used to surface in the column as "custom" or "openai_api".
+function resolveProviderDisplay(
+  entry: AIAccessLogEntry,
+  providerByConfigId: Map<string, AIProvider>,
+  catalogNameById: Map<string, string>,
+): ProviderDisplay {
+  const resolved = entry.resolvedProviderId
+    ? providerByConfigId.get(entry.resolvedProviderId)
+    : undefined;
+  if (resolved) {
+    return {
+      key: resolved.id,
+      logoId: resolved.providerId,
+      name: resolved.name,
+      resolved: true,
+    };
+  }
+
+  if (!entry.providerVendor) {
+    return {
+      key: "unknown",
+      name: "Unknown",
+      resolved: false,
+      hint: "Not attributed to a provider — the request was rejected before NetBird recognised it as an LLM call.",
+    };
+  }
+
+  return {
+    key: `vendor:${entry.providerId}`,
+    logoId: entry.providerId,
+    name: catalogNameById.get(entry.providerId) ?? entry.providerVendor,
+    resolved: false,
+    hint: "Not attributed to a configured provider — this is the API shape the client called. Requests denied before routing never reach a provider.",
+  };
+}
+
 function ProviderCell({
   entry,
-  resolved,
+  display,
 }: {
   entry: AIAccessLogEntry;
-  resolved?: AIProvider;
+  display: ProviderDisplay;
 }) {
-  // Logo uses the catalog id of the resolved provider when available,
-  // falling back to the parser-level vendor (entry.providerId) for
-  // legacy entries the router didn't stamp.
-  const logoId = resolved?.providerId ?? entry.providerId;
-  const displayName = resolved?.name ?? entry.providerId;
+  const name = (
+    <span
+      className={cn(
+        "text-sm truncate",
+        display.resolved ? "text-nb-gray-200" : "text-nb-gray-400",
+      )}
+    >
+      {display.name}
+    </span>
+  );
   return (
     <div className={"flex items-center gap-2 py-2 px-3 whitespace-nowrap"}>
-      <AIProviderLogo providerId={logoId} size={20} />
+      <AIProviderLogo providerId={display.logoId} size={20} />
       <div className={"flex flex-col min-w-0"}>
-        <span className={"text-sm text-nb-gray-200 truncate"}>
-          {displayName}
-        </span>
+        {display.hint ? (
+          <FullTooltip content={display.hint}>{name}</FullTooltip>
+        ) : (
+          name
+        )}
         <code className={"text-[11px] text-nb-gray-400 font-mono truncate"}>
-          {entry.model}
+          {entry.model || "—"}
         </code>
       </div>
     </div>
@@ -1201,10 +1283,9 @@ function CostCell(fields: CostFields) {
   );
 }
 
-// resolveProviderFn resolves a request's configured provider (by the router's
-// stamped resolved_provider_id) — shared by the session cells so they reuse the
-// flat row's provider resolution.
-type ResolveProviderFn = (entry: AIAccessLogEntry) => AIProvider | undefined;
+// ProviderDisplayFn maps a request to its Provider column content — shared by
+// the session cells so they label providers exactly like the flat rows.
+type ProviderDisplayFn = (entry: AIAccessLogEntry) => ProviderDisplay;
 
 // SessionActivityCell shows the session's last-activity date and its first→last
 // time-of-day span. The elapsed duration moves to the Requests column.
@@ -1229,33 +1310,55 @@ function SessionActivityCell({ session }: { session: AIAccessLogSession }) {
 // session's entries, resolved the same way as the flat Provider column.
 function SessionProviderCell({
   session,
-  resolveProvider,
+  providerDisplay,
 }: {
   session: AIAccessLogSession;
-  resolveProvider: ResolveProviderFn;
+  providerDisplay: ProviderDisplayFn;
 }) {
   const items = useMemo(() => {
-    const seen = new Map<string, { logoId: AIProviderId; name: string }>();
-    session.entries.forEach((e) => {
-      const resolved = resolveProvider(e);
-      const logoId = resolved?.providerId ?? e.providerId;
-      const name = resolved?.name ?? e.providerId;
-      if (!seen.has(logoId)) seen.set(logoId, { logoId, name });
-    });
-    return Array.from(seen.values());
-  }, [session.entries, resolveProvider]);
+    const collect = (predicate: (d: ProviderDisplay) => boolean) => {
+      const seen = new Map<string, ProviderDisplay>();
+      session.entries.forEach((e) => {
+        const display = providerDisplay(e);
+        if (!predicate(display) || seen.has(display.key)) return;
+        seen.set(display.key, display);
+      });
+      return Array.from(seen.values());
+    };
+    // Only count providers a request was actually routed to. Sessions commonly
+    // open with a request that never reached one (an unroutable model, or a
+    // probe on an unknown path the client then retried), and since entries run
+    // oldest-first that unattributed request would otherwise become the
+    // session's primary provider and inflate the "+N" count.
+    const resolved = collect((d) => d.resolved);
+    // Nothing was routed anywhere — a wholly denied session. Fall back to the
+    // vendor labels so the row still says what was attempted.
+    return resolved.length > 0 ? resolved : collect(() => true);
+  }, [session.entries, providerDisplay]);
 
   if (items.length === 0) return <EmptyRow />;
   const [primary] = items;
   const extra = items.length - 1;
+  const name = (
+    <span
+      className={cn(
+        "text-sm truncate",
+        primary.resolved ? "text-nb-gray-200" : "text-nb-gray-400",
+      )}
+    >
+      {primary.name}
+      {extra > 0 ? ` +${extra}` : ""}
+    </span>
+  );
   return (
     <div className={"flex items-center gap-2 py-2 px-3 whitespace-nowrap"}>
       <AIProviderLogo providerId={primary.logoId} size={20} />
       <div className={"flex flex-col min-w-0"}>
-        <span className={"text-sm text-nb-gray-200 truncate"}>
-          {primary.name}
-          {extra > 0 ? ` +${extra}` : ""}
-        </span>
+        {primary.hint ? (
+          <FullTooltip content={primary.hint}>{name}</FullTooltip>
+        ) : (
+          name
+        )}
         {session.models.length > 1 ? (
           <FullTooltip
             content={

--- a/src/modules/agent-network/AgentAccessLogTable.tsx
+++ b/src/modules/agent-network/AgentAccessLogTable.tsx
@@ -1036,10 +1036,20 @@ function resolveProviderDisplay(
     };
   }
 
+  // A vendor the dashboard has no catalog id for normalises to "custom" — itself
+  // a real catalog entry (the OpenAI-compatible catch-all). Resolving its name
+  // would label every unrecognised vendor with that one generic name, and keying
+  // on the id would collapse distinct vendors into a single item in the session
+  // column. Key and label those by the raw vendor label instead.
+  const unmappedVendor = entry.providerId === "custom";
   return {
-    key: `vendor:${entry.providerId}`,
+    key: unmappedVendor
+      ? `vendor:${entry.providerVendor}`
+      : `vendor:${entry.providerId}`,
     logoId: entry.providerId,
-    name: catalogNameById.get(entry.providerId) ?? entry.providerVendor,
+    name: unmappedVendor
+      ? entry.providerVendor
+      : (catalogNameById.get(entry.providerId) ?? entry.providerVendor),
     resolved: false,
     hint: "Not attributed to a configured provider. This is the API shape the client called. Requests denied before routing never reach a provider.",
   };

--- a/src/modules/agent-network/AgentAccessLogTable.tsx
+++ b/src/modules/agent-network/AgentAccessLogTable.tsx
@@ -1032,7 +1032,7 @@ function resolveProviderDisplay(
       key: "unknown",
       name: "Unknown",
       resolved: false,
-      hint: "Not attributed to a provider — the request was rejected before NetBird recognised it as an LLM call.",
+      hint: "Not attributed to a provider. The request was rejected before NetBird recognised it as an LLM call.",
     };
   }
 
@@ -1041,7 +1041,7 @@ function resolveProviderDisplay(
     logoId: entry.providerId,
     name: catalogNameById.get(entry.providerId) ?? entry.providerVendor,
     resolved: false,
-    hint: "Not attributed to a configured provider — this is the API shape the client called. Requests denied before routing never reach a provider.",
+    hint: "Not attributed to a configured provider. This is the API shape the client called. Requests denied before routing never reach a provider.",
   };
 }
 

--- a/src/modules/agent-network/agentAccessLogApi.ts
+++ b/src/modules/agent-network/agentAccessLogApi.ts
@@ -205,6 +205,7 @@ export function accessLogFromAgentAPI(
     id: entry.id,
     serviceId: entry.service_id,
     providerId: normalizeProviderId(entry.provider),
+    providerVendor: entry.provider ?? "",
     resolvedProviderId: entry.resolved_provider_id ?? "",
     sessionId: entry.session_id ?? "",
     timestamp: entry.timestamp,

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -169,6 +169,11 @@ export type AIAccessLogEntry = {
   id: string;
   serviceId: string;
   providerId: AIProviderId;
+  // Raw vendor label the request parser stamped ("openai", "anthropic"),
+  // before it was normalised into a catalog id. Empty when the request never
+  // got far enough to be recognised as an LLM call — providerId collapses that
+  // case into "custom", so only this field can tell the two apart.
+  providerVendor?: string;
   // Config-row id of the provider the router actually selected
   // (llm.resolved_provider_id metadata). Empty for legacy entries
   // and non-agent-network requests where the router didn't run.


### PR DESCRIPTION
## Issue ticket number and link

Requests the router rejected before picking a provider (403
  model_not_routable, 404 unknown path) carry no resolved_provider_id, and
  the Provider column rendered the raw catalog id as the name ("custom",
  "openai_api"). In the Sessions view the leading unresolved request also
  became the session's primary provider and inflated the "+N" count, since
  entries are ordered oldest-first.

  Label unresolved requests with the vendor's catalog display name (or a
  muted "Unknown" when no vendor was stamped) plus a hover explaining it
  isn't an attribution, and build a session's provider list from resolved
  entries only.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved provider attribution in access logs using configured provider names and vendor labels.
  * Added clearer handling for unknown or unresolved providers, including neutral logos and “Unknown” labels.
  * Provider details now appear more accurately in session summaries, table columns, tooltips, and metadata.
  * Routed providers and fallback vendor labels are displayed separately to reduce ambiguity.
  * Access log entries now better distinguish recognized providers, custom providers, and requests without provider information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->