### PR TITLE
fix: use --restart=unless-stopped instead of --rm in Docker install command

### DIFF
--- a/src/modules/setup-netbird-modal/DockerTab.tsx
+++ b/src/modules/setup-netbird-modal/DockerTab.tsx
@@ -59,7 +59,7 @@ export default function DockerTab({
               {showSetupKeyInfo && <RoutingPeerSetupKeyInfo />}
             </p>
             <Code>
-              <Code.Line>docker run --rm -d \</Code.Line>
+              <Code.Line>docker run -d --restart=unless-stopped \</Code.Line>
               <Code.Line> --cap-add=NET_ADMIN \</Code.Line>
               <Code.Line>
                 {" "}


### PR DESCRIPTION
The generated Docker command used --rm, which removes the container on stop. Combined with -d, the NetBird client would not survive a host reboot despite the persistent netbird-client volume. Replace with --restart=unless-stopped so the client reconnects automatically.

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why): this only corrects the command string rendered in the dashboard's install modal; no dashboard-side documentation describes this command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Docker run command to preserve the container after stopping and automatically restart it unless explicitly stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->