### PR TITLE
fix(setup): match the v0.75 client UI in the management URL step

### DIFF
--- a/src/modules/setup-netbird-modal/MacOSTab.tsx
+++ b/src/modules/setup-netbird-modal/MacOSTab.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import React from "react";
 import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import {
+  ManagementUrlStep,
   NetBirdUpCommand,
   RoutingPeerSetupKeyInfo,
 } from "@/modules/setup-netbird-modal/SetupModal";
@@ -75,12 +76,7 @@ export default function MacOSTab({
 
           {GRPC_API_ORIGIN && (
             <Steps.Step step={baseMgmtStep}>
-              <p>
-                {`Click on "Settings" then "Advanced Settings" from the NetBird icon in your system tray and enter the following "Management URL"`}
-              </p>
-              <Code>
-                <Code.Line>{GRPC_API_ORIGIN}</Code.Line>
-              </Code>
+              <ManagementUrlStep trayName={"menu bar"} />
             </Steps.Step>
           )}
 
@@ -106,7 +102,7 @@ export default function MacOSTab({
               <Steps.Step step={runStep}>
                 <p>
                   {/* eslint-disable-next-line react/no-unescaped-entities */}
-                  Click on "Connect" from the NetBird icon in your system tray
+                  Click on "Connect" from the NetBird icon in your menu bar
                 </p>
               </Steps.Step>
               <Steps.Step step={runStep + 1} line={false}>

--- a/src/modules/setup-netbird-modal/SetupModal.tsx
+++ b/src/modules/setup-netbird-modal/SetupModal.tsx
@@ -9,10 +9,11 @@ import { notify } from "@components/Notification";
 import Paragraph from "@components/Paragraph";
 import SmallParagraph from "@components/SmallParagraph";
 import { Tabs, TabsList, TabsTrigger } from "@components/Tabs";
+import { Mark } from "@components/ui/Mark";
 import { IconInfoCircle } from "@tabler/icons-react";
 import { useApiCall } from "@utils/api";
 import { cn } from "@utils/helpers";
-import { getNetBirdUpCommand } from "@utils/netbird";
+import { getNetBirdUpCommand, GRPC_API_ORIGIN } from "@utils/netbird";
 import {
   CopyIcon,
   ExternalLinkIcon,
@@ -430,6 +431,38 @@ export const NetBirdUpCommand = ({
         </Code.Line>
       )}
     </Code>
+  );
+};
+
+type ManagementUrlStepProps = {
+  // The desktop client calls it the system tray on Windows and the menu bar
+  // on macOS; use the platform's own term so the step matches what the user
+  // is looking at.
+  trayName: string;
+};
+
+// ManagementUrlStep tells a desktop-client user where to point the client at
+// this self-hosted management server. The client reworked its UI in v0.75: it
+// now asks for the management server in the first-run "Set up NetBird" screen
+// and keeps the field in Settings > General, so the old
+// "Settings > Advanced Settings" path no longer exists.
+export const ManagementUrlStep = ({ trayName }: ManagementUrlStepProps) => {
+  return (
+    <>
+      <p>
+        On first launch, NetBird asks where to connect. Select{" "}
+        <Mark>Self-hosted</Mark> and enter the following{" "}
+        <Mark>Management server URL</Mark>
+      </p>
+      <Code>
+        <Code.Line>{GRPC_API_ORIGIN}</Code.Line>
+      </Code>
+      <p className={"mt-2 text-xs text-nb-gray-300 font-normal"}>
+        Already past that screen? Click the NetBird icon in your {trayName},
+        open <Mark>Settings</Mark> and set <Mark>Management Server</Mark> to{" "}
+        <Mark>Self-hosted</Mark> under <Mark>General</Mark>.
+      </p>
+    </>
   );
 };
 

--- a/src/modules/setup-netbird-modal/SetupModal.tsx
+++ b/src/modules/setup-netbird-modal/SetupModal.tsx
@@ -442,10 +442,8 @@ type ManagementUrlStepProps = {
 };
 
 // ManagementUrlStep tells a desktop-client user where to point the client at
-// this self-hosted management server. The client reworked its UI in v0.75: it
-// now asks for the management server in the first-run "Set up NetBird" screen
-// and keeps the field in Settings > General, so the old
-// "Settings > Advanced Settings" path no longer exists.
+// this self-hosted management server: the first-run "Set up NetBird" screen,
+// or Settings > General once the client is past it.
 export const ManagementUrlStep = ({ trayName }: ManagementUrlStepProps) => {
   return (
     <>

--- a/src/modules/setup-netbird-modal/WindowsTab.tsx
+++ b/src/modules/setup-netbird-modal/WindowsTab.tsx
@@ -1,5 +1,4 @@
 import Button from "@components/Button";
-import Code from "@components/Code";
 import { SelectDropdown } from "@components/select/SelectDropdown";
 import Steps from "@components/Steps";
 import TabsContentPadding, { TabsContent } from "@components/Tabs";
@@ -9,6 +8,7 @@ import Link from "next/link";
 import React, { useState } from "react";
 import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import {
+  ManagementUrlStep,
   NetBirdUpCommand,
   RoutingPeerSetupKeyInfo,
 } from "@/modules/setup-netbird-modal/SetupModal";
@@ -88,12 +88,7 @@ export default function WindowsTab({
 
           {GRPC_API_ORIGIN && (
             <Steps.Step step={baseMgmtStep}>
-              <p>
-                {`Click on "Settings" then "Advanced Settings" from the NetBird icon in your system tray and enter the following "Management URL"`}
-              </p>
-              <Code>
-                <Code.Line>{GRPC_API_ORIGIN}</Code.Line>
-              </Code>
+              <ManagementUrlStep trayName={"system tray"} />
             </Steps.Step>
           )}
 


### PR DESCRIPTION
  The desktop client reworked its UI in v0.75: the management server is now
  asked for on the first-run "Set up NetBird" screen and lives under
  Settings > General, so the "Settings > Advanced Settings" path the Windows
  and macOS tabs described no longer exists. Move the copy into a shared
  ManagementUrlStep, cover the already-installed case, and say "menu bar"
  instead of "system tray" on macOS.

  Screenshots: https://github.com/netbirdio/dashboard/issues/732#issuecomment-5326178738

  Fixes #732

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear setup instructions for connecting desktop clients to a self-hosted management server.
  * Displayed the management server URL during Windows and macOS setup.
  * Updated macOS instructions to use the platform-appropriate “menu bar” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->