### PR TITLE
Load a provider's models from the vendor in the provider modal

### DIFF
--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -471,9 +471,8 @@ export default function AIProviderModal({
             ? "Save with 1 unpriced model?"
             : `Save with ${unpriced.length} unpriced models?`,
         description:
-          "Usage for models without input and output rates is tracked at $0 " +
-          "and won't count toward budget limits. You can set the rates now, " +
-          "or save and update them later.",
+          "Models without rates are tracked at $0 and don’t count toward " +
+          "budget limits. Set rates now or later.",
         confirmText: "Save anyway",
         cancelText: "Set rates first",
         type: "warning",

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -177,11 +177,6 @@ const withModelKey = (m: ProviderModel): EditableModel => ({
 // configuration, while zero on both is the shape an unpriced model arrives in.
 const hasNoPrice = (m: ProviderModel) => !m.inputPer1k && !m.outputPer1k;
 
-// MAX_LISTED_UNPRICED bounds the ids named in the save confirmation. A vendor
-// list can run to dozens; past a handful the names stop informing the decision
-// and the dialog just gets taller than the screen.
-const MAX_LISTED_UNPRICED = 5;
-
 // sortUnpricedFirst floats the rows needing a rate to the top, keeping the
 // relative order within each half so the vendor's own ordering survives.
 const sortUnpricedFirst = <T extends ProviderModel>(rows: T[]): T[] =>
@@ -471,17 +466,14 @@ export default function AIProviderModal({
     const unpriced = submittedModels.filter(hasNoPrice);
     if (unpriced.length > 0) {
       const proceed = await confirm({
-        title: `Save with ${unpriced.length} unpriced ${
-          unpriced.length === 1 ? "model" : "models"
-        }?`,
-        description: `${unpriced
-          .slice(0, MAX_LISTED_UNPRICED)
-          .map((m) => m.id)
-          .join(", ")}${
-          unpriced.length > MAX_LISTED_UNPRICED
-            ? ` and ${unpriced.length - MAX_LISTED_UNPRICED} more`
-            : ""
-        } have no input or output rate. Requests to them are charged $0 and their spend will not appear in usage or count against budgets.`,
+        title:
+          unpriced.length === 1
+            ? "Save with 1 unpriced model?"
+            : `Save with ${unpriced.length} unpriced models?`,
+        description:
+          "Usage for models without input and output rates is tracked at $0 " +
+          "and won't count toward budget limits. You can set the rates now, " +
+          "or save and update them later.",
         confirmText: "Save anyway",
         cancelText: "Set rates first",
         type: "warning",

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -798,7 +798,7 @@ export default function AIProviderModal({
 
               <FormRow
                 label={"Provider"}
-                helpText={"API provider to expose through NetBird."}
+                helpText={"AI provider and upstream URL to expose through NetBird."}
               >
                 <SelectDropdown
                   value={providerId}
@@ -853,30 +853,11 @@ export default function AIProviderModal({
                   placeholder={"Select provider..."}
                 />
               </FormRow>
-
-              <FormRow
-                label={
-                  providerId === "kimi_api" ? (
-                    <>
-                      Upstream URL
-                      <HelpTooltip
-                        content={
-                          "Moonshot AI's international platform endpoint. Keep the bare host. Moonshot serves both API shapes with the same key: the path an agent calls rides through to Moonshot, so its base URL picks the shape (Claude Code appends /anthropic; Kimi CLI and OpenAI shaped callers use the bare endpoint). Mainland China accounts use api.moonshot.cn instead."
-                        }
-                      />
-                    </>
-                  ) : (
-                    "Upstream URL"
-                  )
-                }
-                helpText={upstreamUrlHelpText(providerId)}
-              >
-                <Input
-                  value={upstreamUrl}
-                  onChange={(e) => setUpstreamUrl(e.target.value)}
-                  placeholder={upstreamUrlPlaceholder(providerId)}
-                />
-              </FormRow>
+              <Input
+                value={upstreamUrl}
+                onChange={(e) => setUpstreamUrl(e.target.value)}
+                placeholder={upstreamUrlPlaceholder(providerId)}
+              />
 
               {isCustomKind && (
                 <FancyToggleSwitch

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import AgentNetworkIcon from "@/assets/icons/AgentNetworkIcon";
+import { useDialog } from "@/contexts/DialogProvider";
 import {
   ReverseProxyDomain,
   ReverseProxyDomainType,
@@ -171,6 +172,28 @@ const withModelKey = (m: ProviderModel): EditableModel => ({
   _key: `model-${modelKeySeq++}`,
 });
 
+// hasNoPrice reports a row that would meter every request against it as free.
+// Both rates, not either: a model priced on input alone is a deliberate
+// configuration, while zero on both is the shape an unpriced model arrives in.
+const hasNoPrice = (m: ProviderModel) => !m.inputPer1k && !m.outputPer1k;
+
+// MAX_LISTED_UNPRICED bounds the ids named in the save confirmation. A vendor
+// list can run to dozens; past a handful the names stop informing the decision
+// and the dialog just gets taller than the screen.
+const MAX_LISTED_UNPRICED = 5;
+
+// sortUnpricedFirst floats the rows needing a rate to the top, keeping the
+// relative order within each half so the vendor's own ordering survives.
+const sortUnpricedFirst = <T extends ProviderModel>(rows: T[]): T[] =>
+  rows
+    .map((row, index) => ({ row, index }))
+    .sort(
+      (a, b) =>
+        Number(hasNoPrice(b.row)) - Number(hasNoPrice(a.row)) ||
+        a.index - b.index,
+    )
+    .map(({ row }) => row);
+
 export default function AIProviderModal({
   open,
   onOpenChange,
@@ -186,6 +209,7 @@ export default function AIProviderModal({
     ReverseProxyDomain[]
   >("/reverse-proxies/domains");
   const { catalog: catalogList, getById } = useProviderCatalog();
+  const { confirm } = useDialog();
 
   const isEdit = !!provider;
   // The endpoint lives on the account-level Settings row, bootstrapped once
@@ -439,6 +463,31 @@ export default function AIProviderModal({
         seenModelIds.add(m.id);
         return true;
       });
+
+    // Saving an unpriced model is silent and irreversible in effect: every
+    // request against it records $0, and the usage that was already spent
+    // cannot be re-priced afterwards. The inline warning is easy to scroll
+    // past on a long vendor list, so confirm at the point of no return.
+    const unpriced = submittedModels.filter(hasNoPrice);
+    if (unpriced.length > 0) {
+      const proceed = await confirm({
+        title: `Save with ${unpriced.length} unpriced ${
+          unpriced.length === 1 ? "model" : "models"
+        }?`,
+        description: `${unpriced
+          .slice(0, MAX_LISTED_UNPRICED)
+          .map((m) => m.id)
+          .join(", ")}${
+          unpriced.length > MAX_LISTED_UNPRICED
+            ? ` and ${unpriced.length - MAX_LISTED_UNPRICED} more`
+            : ""
+        } have no input or output rate. Requests to them are charged $0 and their spend will not appear in usage or count against budgets.`,
+        confirmText: "Save anyway",
+        cancelText: "Set rates first",
+        type: "warning",
+      });
+      if (!proceed) return;
+    }
     // Identity overrides are only forwarded when the catalog entry
     // flags either shape (HeaderPair or JSONMetadata) as customizable.
     // Sending them on a non-customizable provider would be a no-op
@@ -628,7 +677,11 @@ export default function AIProviderModal({
       // Drop the blank starter row: it exists to be filled, and there is now
       // something to fill the list with.
       const kept = prev.filter((m) => m.id !== "");
-      return [...kept, ...added];
+      // Unpriced rows first — they are the ones needing attention, and a long
+      // vendor list would otherwise bury them. Sorted here, once, rather than
+      // on every render: re-sorting live would make a row jump out from under
+      // the cursor the moment a rate was typed into it.
+      return sortUnpricedFirst([...kept, ...added]);
     });
   };
 
@@ -650,9 +703,7 @@ export default function AIProviderModal({
   const unpricedModelIds = useMemo(
     () =>
       new Set(
-        models
-          .filter((m) => m.id !== "" && !m.inputPer1k && !m.outputPer1k)
-          .map((m) => m.id),
+        models.filter((m) => m.id !== "" && hasNoPrice(m)).map((m) => m.id),
       ),
     [models],
   );
@@ -1450,19 +1501,26 @@ export default function AIProviderModal({
                   </HelpText>
                 )}
                 {discovered.error && (
-                  <HelpText className={"!mb-0 text-orange-400"}>
+                  <HelpText
+                    className={"!mb-0 text-orange-500 dark:text-orange-400"}
+                  >
                     {discovered.error}
                   </HelpText>
                 )}
               </div>
 
               {unpricedModelIds.size > 0 && (
-                <HelpText className={"!mb-0 text-yellow-400"}>
+                // The dark: variant is not optional — HelpText hardcodes
+                // dark:text-nb-gray-300, which beats an unprefixed colour and
+                // leaves the warning looking like ordinary help text.
+                <HelpText
+                  className={"!mb-0 text-yellow-600 dark:text-yellow-400"}
+                >
                   {unpricedModelIds.size === 1
-                    ? "1 model has no cost set"
-                    : `${unpricedModelIds.size} models have no cost set`}{" "}
-                  (outlined below). Requests to them record a cost of zero until
-                  you set input and output rates.
+                    ? "1 model has"
+                    : `${unpricedModelIds.size} models have`}{" "}
+                  no cost set (highlighted below). Requests are charged $0 until
+                  input and output rates are configured.
                 </HelpText>
               )}
 

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -1435,6 +1435,15 @@ export default function AIProviderModal({
                 )}
               </div>
 
+              {!discovered.isLoading &&
+                !discovered.error &&
+                discovered.models.length > 0 && (
+                  <HelpText className={"!mb-0"}>
+                    {discovered.models.length} models loaded. Use the{" "}
+                    <strong>Add More</strong> button to search and pick models.
+                  </HelpText>
+                )}
+
               {unpricedModelIds.size > 0 && (
                 // A callout rather than a line of help text: this is the one
                 // thing on the tab that costs money to miss, and it sat in the
@@ -1497,14 +1506,6 @@ export default function AIProviderModal({
                 />
               ))}
 
-              {!discovered.isLoading &&
-                !discovered.error &&
-                discovered.models.length > 0 && (
-                  <HelpText className={"!mb-0"}>
-                    {discovered.models.length} models loaded. Use the{" "}
-                    <strong>Add More</strong> button to search and pick models.
-                  </HelpText>
-                )}
               <Button
                 variant={"dotted"}
                 className={"w-full"}

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -30,6 +30,7 @@ import {
   MinusCircleIcon,
   PlusCircle,
   PlusIcon,
+  RefreshCwIcon,
   ShieldOffIcon,
   Sparkles,
   UploadIcon,
@@ -40,15 +41,14 @@ import {
   ReverseProxyDomain,
   ReverseProxyDomainType,
 } from "@/interfaces/ReverseProxy";
+import AIProviderLogo from "@/modules/agent-network/AIProviderLogo";
+import { useAIProviders } from "@/modules/agent-network/AIProvidersProvider";
 import {
   AIProvider,
   AIProviderId,
   ProviderModel,
 } from "@/modules/agent-network/data/mockData";
-import AIProviderLogo from "@/modules/agent-network/AIProviderLogo";
-import {
-  useAIProviders,
-} from "@/modules/agent-network/AIProvidersProvider";
+import { useDiscoveredModels } from "@/modules/agent-network/useDiscoveredModels";
 import { useProviderCatalog } from "@/modules/agent-network/useProviderCatalog";
 
 // EXTRA_HEADER_UI owns the dashboard copy for catalog-declared extra
@@ -160,6 +160,11 @@ type Props = {
 type EditableModel = ProviderModel & { _key: string };
 
 let modelKeySeq = 0;
+// MASKED_API_KEY is what the edit form shows in place of a stored credential.
+// The real key never reaches the browser, so anything equal to this is a
+// placeholder rather than something that can be sent to a vendor.
+const MASKED_API_KEY = "••••••••";
+
 const withModelKey = (m: ProviderModel): EditableModel => ({
   ...m,
   _key: `model-${modelKeySeq++}`,
@@ -201,6 +206,7 @@ export default function AIProviderModal({
   const [models, setModels] = useState<EditableModel[]>(() =>
     (provider?.models ?? []).map(withModelKey),
   );
+  const discovered = useDiscoveredModels();
 
   // Vertex AI authenticates with a service-account JSON key, not an API key.
   // We upload the file and store it base64-encoded in apiKey (the server
@@ -373,7 +379,9 @@ export default function AIProviderModal({
       const fallback = getById("openai_api");
       setProviderId("openai_api");
       setName(fallback ? fallback.name : "OpenAI API");
-      setUpstreamUrl(fallback?.default_host ? `https://${fallback.default_host}` : "");
+      setUpstreamUrl(
+        fallback?.default_host ? `https://${fallback.default_host}` : "",
+      );
       setApiKey("");
       setBootstrapCluster(
         settingsBootstrapped ? "" : validatedClusters[0]?.domain ?? "",
@@ -525,11 +533,67 @@ export default function AIProviderModal({
   // Catalog options the user hasn't already added; falls back to a
   // generic empty row when the catalog is exhausted or there is no
   // catalog (custom providers).
-  const catalogModelOptions = useMemo(
-    () => catalog?.models ?? [],
-    [catalog],
+  // Merged: the catalog first, then anything the vendor reported that the
+  // catalog does not already carry. Both the per-row picker and "Add More"
+  // read this one list, so merging here is all the wiring either needs.
+  //
+  // A catalog entry wins on collision — it carries prices, and the discovery
+  // response deliberately carries none.
+  const catalogModelOptions = useMemo<CatalogModelOption[]>(() => {
+    const base = catalog?.models ?? [];
+    if (discovered.models.length === 0) return base;
+
+    const known = new Set(base.map((m) => m.id));
+    const extra = discovered.models
+      .filter((m) => !known.has(m.id))
+      .map<CatalogModelOption>((m) => ({
+        id: m.id,
+        label: m.label || m.id,
+        input_per_1k: 0,
+        output_per_1k: 0,
+        pricing_known: m.pricing_known,
+      }));
+    return [...base, ...extra];
+  }, [catalog, discovered.models]);
+
+  // Editing a saved provider shows a masked api key, never the real one, so
+  // discovery reuses the stored credential by record id instead. A new
+  // provider has to supply the key the operator is typing.
+  const canDiscoverModels = useMemo(() => {
+    if (isEdit && provider?.id) return true;
+    return (
+      upstreamUrl.trim() !== "" &&
+      apiKey.trim() !== "" &&
+      apiKey !== MASKED_API_KEY
+    );
+  }, [isEdit, provider?.id, upstreamUrl, apiKey]);
+
+  const loadModelsFromProvider = () => {
+    if (isEdit && provider?.id) {
+      void discovered.discover({
+        catalog_provider_id: providerId,
+        provider_id: provider.id,
+      });
+      return;
+    }
+    void discovered.discover({
+      catalog_provider_id: providerId,
+      upstream_url: upstreamUrl.trim(),
+      api_key: apiKey.trim(),
+    });
+  };
+
+  // Discovered models NetBird cannot price. Registering one at the 0 it
+  // arrives with would record every request against it as free, so the
+  // operator is told which rows need a rate before saving.
+  const unpricedDiscovered = useMemo(
+    () => discovered.models.filter((m) => !m.pricing_known).map((m) => m.id),
+    [discovered.models],
   );
-  const usedModelIds = useMemo(() => new Set(models.map((m) => m.id)), [models]);
+  const usedModelIds = useMemo(
+    () => new Set(models.map((m) => m.id)),
+    [models],
+  );
   const addModel = () => {
     const next = catalogModelOptions.find((m) => !usedModelIds.has(m.id));
     if (next) {
@@ -587,10 +651,7 @@ export default function AIProviderModal({
               <Sparkles size={14} />
               Provider
             </TabsTrigger>
-            <TabsTrigger
-              value={"models"}
-              disabled={!canContinueFromProvider}
-            >
+            <TabsTrigger value={"models"} disabled={!canContinueFromProvider}>
               <Boxes size={14} />
               Models
             </TabsTrigger>
@@ -620,9 +681,10 @@ export default function AIProviderModal({
                   No active proxy clusters are available. Connect at least one
                   proxy under
                   <InlineLink href={"/reverse-proxy/services"}>
-                    {" "}Reverse Proxy
-                  </InlineLink>
-                  {" "}before adding a provider.
+                    {" "}
+                    Reverse Proxy
+                  </InlineLink>{" "}
+                  before adding a provider.
                 </Callout>
               )}
 
@@ -755,7 +817,9 @@ export default function AIProviderModal({
                           <>
                             Upload the Vertex AI service account JSON key.
                             NetBird base64-encodes it and prefixes it with{" "}
-                            <code className={"text-nb-gray-200"}>keyfile::</code>{" "}
+                            <code className={"text-nb-gray-200"}>
+                              keyfile::
+                            </code>{" "}
                             before injecting it on every upstream request, so
                             agents never see the key.
                           </>
@@ -829,7 +893,8 @@ export default function AIProviderModal({
                 </FormRow>
               )}
               {(catalog?.extra_headers ?? []).map((h) => {
-                const ui = EXTRA_HEADER_UI[h.name] ?? fallbackExtraHeaderUI(h.name);
+                const ui =
+                  EXTRA_HEADER_UI[h.name] ?? fallbackExtraHeaderUI(h.name);
                 return (
                   <FormRow
                     key={h.name}
@@ -858,16 +923,16 @@ export default function AIProviderModal({
                   </FormRow>
                 );
               })}
-                <FormRow
-                    label={"Display name"}
-                    helpText={"Shown in the Agent Network table."}
-                >
-                    <Input
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        placeholder={"e.g. OpenAI"}
-                    />
-                </FormRow>
+              <FormRow
+                label={"Display name"}
+                helpText={"Shown in the Agent Network table."}
+              >
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={"e.g. OpenAI"}
+                />
+              </FormRow>
             </div>
           </TabsContent>
 
@@ -902,8 +967,8 @@ export default function AIProviderModal({
                     >
                       metadata.tags
                     </code>{" "}
-                    in the JSON body so LiteLLM can enforce tag budgets and rate limits.
-                    The user identity is sent in the{" "}
+                    in the JSON body so LiteLLM can enforce tag budgets and rate
+                    limits. The user identity is sent in the{" "}
                     <code
                       className={
                         "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
@@ -911,10 +976,9 @@ export default function AIProviderModal({
                     >
                       x-litellm-end-user-id
                     </code>{" "}
-                    header. The proxy strips any client-supplied value
-                    first, so an app can&apos;t spoof identity. The
-                    configured API key must be a LiteLLM virtual key
-                    with{" "}
+                    header. The proxy strips any client-supplied value first, so
+                    an app can&apos;t spoof identity. The configured API key
+                    must be a LiteLLM virtual key with{" "}
                     <code
                       className={
                         "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
@@ -950,11 +1014,11 @@ export default function AIProviderModal({
                 <div>
                   <Label>Identity Headers</Label>
                   <HelpText className={"mb-0"}>
-                    Pick which wire headers carry the caller&apos;s identity
-                    on every upstream request. The proxy strips any
-                    client-supplied value first, so an app can&apos;t spoof
-                    identity. Leave a field empty to disable stamping for that
-                    dimension. The defaults shown as placeholders use the{" "}
+                    Pick which wire headers carry the caller&apos;s identity on
+                    every upstream request. The proxy strips any client-supplied
+                    value first, so an app can&apos;t spoof identity. Leave a
+                    field empty to disable stamping for that dimension. The
+                    defaults shown as placeholders use the{" "}
                     <code
                       className={
                         "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
@@ -962,8 +1026,8 @@ export default function AIProviderModal({
                     >
                       x-bf-dim-*
                     </code>{" "}
-                    family (Prometheus / OTEL — requires a matching
-                    declaration in your gateway&apos;s{" "}
+                    family (Prometheus / OTEL — requires a matching declaration
+                    in your gateway&apos;s{" "}
                     <code
                       className={
                         "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
@@ -979,30 +1043,38 @@ export default function AIProviderModal({
                     >
                       x-bf-lh-*
                     </code>{" "}
-                    to use Bifrost&apos;s always-on log-metadata path
-                    instead — no gateway-side config needed there.
+                    to use Bifrost&apos;s always-on log-metadata path instead —
+                    no gateway-side config needed there.
                   </HelpText>
                 </div>
 
                 <FormRow
                   label={"User identity header"}
-                  helpText={"Wire header name receiving the caller's user email (or peer name when unlinked). Leave empty to skip."}
+                  helpText={
+                    "Wire header name receiving the caller's user email (or peer name when unlinked). Leave empty to skip."
+                  }
                 >
                   <Input
                     value={identityHeaderUserId}
                     onChange={(e) => setIdentityHeaderUserId(e.target.value)}
-                    placeholder={identityDefaultUser || "x-bf-dim-netbird_user_id"}
+                    placeholder={
+                      identityDefaultUser || "x-bf-dim-netbird_user_id"
+                    }
                   />
                 </FormRow>
 
                 <FormRow
                   label={"Groups header"}
-                  helpText={"Wire header name receiving the caller's NetBird groups as a comma-separated list. Leave empty to skip."}
+                  helpText={
+                    "Wire header name receiving the caller's NetBird groups as a comma-separated list. Leave empty to skip."
+                  }
                 >
                   <Input
                     value={identityHeaderGroups}
                     onChange={(e) => setIdentityHeaderGroups(e.target.value)}
-                    placeholder={identityDefaultGroups || "x-bf-dim-netbird_groups"}
+                    placeholder={
+                      identityDefaultGroups || "x-bf-dim-netbird_groups"
+                    }
                   />
                 </FormRow>
               </div>
@@ -1024,18 +1096,20 @@ export default function AIProviderModal({
                       {jsonMetadataHeader || "metadata"}
                     </code>{" "}
                     header with the caller&apos;s identity so the gateway&apos;s
-                    logs and analytics key off the real user, not whichever
-                    app process happens to hold the API token. Pick the JSON
-                    key names that match your existing log filters; leave a
-                    field empty to omit that key from the JSON. The proxy
-                    strips any client-supplied value first, so an app
-                    can&apos;t spoof identity.
+                    logs and analytics key off the real user, not whichever app
+                    process happens to hold the API token. Pick the JSON key
+                    names that match your existing log filters; leave a field
+                    empty to omit that key from the JSON. The proxy strips any
+                    client-supplied value first, so an app can&apos;t spoof
+                    identity.
                   </HelpText>
                 </div>
 
                 <FormRow
                   label={"User identity key"}
-                  helpText={"JSON key receiving the caller's user email (or peer name when unlinked). Leave empty to skip."}
+                  helpText={
+                    "JSON key receiving the caller's user email (or peer name when unlinked). Leave empty to skip."
+                  }
                 >
                   <Input
                     value={identityHeaderUserId}
@@ -1046,7 +1120,9 @@ export default function AIProviderModal({
 
                 <FormRow
                   label={"Groups key"}
-                  helpText={"JSON key receiving the caller's NetBird groups as a comma-separated string. Leave empty to skip."}
+                  helpText={
+                    "JSON key receiving the caller's NetBird groups as a comma-separated string. Leave empty to skip."
+                  }
                 >
                   <Input
                     value={identityHeaderGroups}
@@ -1072,12 +1148,11 @@ export default function AIProviderModal({
                     >
                       x-portkey-metadata
                     </code>{" "}
-                    header with a JSON object so Portkey&apos;s analytics
-                    and budgets key off the real caller. The proxy strips
-                    any client-supplied value first, so an app can&apos;t
-                    spoof identity. Per Portkey&apos;s 128-character cap
-                    each value is truncated when needed. The mapping is
-                    fixed in this release.
+                    header with a JSON object so Portkey&apos;s analytics and
+                    budgets key off the real caller. The proxy strips any
+                    client-supplied value first, so an app can&apos;t spoof
+                    identity. Per Portkey&apos;s 128-character cap each value is
+                    truncated when needed. The mapping is fixed in this release.
                   </HelpText>
                 </div>
 
@@ -1187,9 +1262,9 @@ export default function AIProviderModal({
                     >
                       group_by=tag
                     </code>
-                    ). Header names are fixed by Vercel&apos;s API contract
-                    — renaming would silently disable attribution. The
-                    proxy strips any client-supplied value first.
+                    ). Header names are fixed by Vercel&apos;s API contract —
+                    renaming would silently disable attribution. The proxy
+                    strips any client-supplied value first.
                   </HelpText>
                 </div>
 
@@ -1210,11 +1285,11 @@ export default function AIProviderModal({
 
                 <HelpText className={"mb-0"}>
                   <strong>Caveats:</strong> Vercel caps tags at 10 per request
-                  (each 1–64 chars) and the user value at 256 chars. Members
-                  of more than 10 groups will see Vercel reject the request
-                  with HTTP 400 — re-scope group memberships if you hit it.
-                  Vercel charges $0.075 per 1,000 unique user/tag values
-                  written; budget accordingly for high-cardinality use cases.
+                  (each 1–64 chars) and the user value at 256 chars. Members of
+                  more than 10 groups will see Vercel reject the request with
+                  HTTP 400 — re-scope group memberships if you hit it. Vercel
+                  charges $0.075 per 1,000 unique user/tag values written;
+                  budget accordingly for high-cardinality use cases.
                 </HelpText>
               </div>
             </TabsContent>
@@ -1235,10 +1310,10 @@ export default function AIProviderModal({
                     >
                       user
                     </code>{" "}
-                    field — that&apos;s the OpenAI-standard field
-                    OpenRouter consults for per-user analytics. The proxy
-                    overwrites any client-supplied value first, so an app
-                    can&apos;t spoof identity.
+                    field — that&apos;s the OpenAI-standard field OpenRouter
+                    consults for per-user analytics. The proxy overwrites any
+                    client-supplied value first, so an app can&apos;t spoof
+                    identity.
                   </HelpText>
                 </div>
 
@@ -1256,16 +1331,17 @@ export default function AIProviderModal({
                 <HelpText className={"mb-0"}>
                   <strong>No groups dimension.</strong> OpenRouter does not
                   document a per-request tag, label, or team field — only
-                  per-user identity. NetBird&apos;s group memberships are
-                  not propagated to OpenRouter; if you need per-group
-                  attribution, query NetBird&apos;s own access log instead
-                  of OpenRouter&apos;s analytics.
+                  per-user identity. NetBird&apos;s group memberships are not
+                  propagated to OpenRouter; if you need per-group attribution,
+                  query NetBird&apos;s own access log instead of
+                  OpenRouter&apos;s analytics.
                 </HelpText>
                 <HelpText className={"mb-0"}>
-                  <strong>App branding</strong> (HTTP-Referer + X-OpenRouter-Title)
-                  is set per-provider on the Provider tab, not per-request.
-                  Operators who fill those in get their app surfaced on
-                  OpenRouter&apos;s public rankings and per-app analytics.
+                  <strong>App branding</strong> (HTTP-Referer +
+                  X-OpenRouter-Title) is set per-provider on the Provider tab,
+                  not per-request. Operators who fill those in get their app
+                  surfaced on OpenRouter&apos;s public rankings and per-app
+                  analytics.
                 </HelpText>
               </div>
             </TabsContent>
@@ -1278,11 +1354,50 @@ export default function AIProviderModal({
                 <HelpText>
                   Models exposed through this endpoint, with the per-1k
                   input/output prices used for cost tracking. Empty = all
-                  catalog models allowed at catalog prices. Cache rates
-                  left empty fall back to NetBird&apos;s defaults for the
-                  model; 0 bills cached tokens at the input rate.
+                  catalog models allowed at catalog prices. Cache rates left
+                  empty fall back to NetBird&apos;s defaults for the model; 0
+                  bills cached tokens at the input rate.
                 </HelpText>
               </div>
+
+              <div className={"flex items-center gap-3"}>
+                <Button
+                  variant={"secondary"}
+                  size={"xs"}
+                  disabled={discovered.isLoading || !canDiscoverModels}
+                  onClick={loadModelsFromProvider}
+                >
+                  <RefreshCwIcon size={13} />
+                  {discovered.isLoading
+                    ? "Loading models…"
+                    : "Load models from provider"}
+                </Button>
+                {!canDiscoverModels && (
+                  <HelpText className={"!mb-0"}>
+                    Enter the endpoint URL and API key first.
+                  </HelpText>
+                )}
+                {discovered.notSupported && (
+                  <HelpText className={"!mb-0"}>
+                    This provider has no model listing endpoint — the catalog
+                    list is used instead.
+                  </HelpText>
+                )}
+                {discovered.error && (
+                  <HelpText className={"!mb-0 text-orange-400"}>
+                    {discovered.error}
+                  </HelpText>
+                )}
+              </div>
+
+              {unpricedDiscovered.length > 0 && (
+                <HelpText className={"!mb-0 text-orange-400"}>
+                  NetBird has no default price for{" "}
+                  {unpricedDiscovered.join(", ")}. Set input and output rates
+                  before saving, or requests to those models record a cost of
+                  zero.
+                </HelpText>
+              )}
 
               {models.map((row, idx) => (
                 <ModelRowEditor
@@ -1403,10 +1518,7 @@ export default function AIProviderModal({
             )}
             {tab === "mappings" && (
               <>
-                <Button
-                  variant={"secondary"}
-                  onClick={() => setTab("models")}
-                >
+                <Button variant={"secondary"} onClick={() => setTab("models")}>
                   Back
                 </Button>
                 <Button
@@ -1466,6 +1578,11 @@ type CatalogModelOption = {
   cached_input_per_1k?: number;
   cache_read_per_1k?: number;
   cache_creation_per_1k?: number;
+  // false for a model the vendor reported but NetBird's pricing table does
+  // not know. It still lands with 0 rates, which is indistinguishable from a
+  // genuinely free model — so the Models tab names these explicitly rather
+  // than letting the operator register one that meters at zero.
+  pricing_known?: boolean;
 };
 
 // priceToInput renders a stored price as an editable string, always using "."
@@ -1600,7 +1717,9 @@ function ModelRowEditor({
   // single-option dropdown.
   const [customMode, setCustomMode] = useState(
     () =>
-      hasCatalog && row.id !== "" && !catalogModels.some((m) => m.id === row.id),
+      hasCatalog &&
+      row.id !== "" &&
+      !catalogModels.some((m) => m.id === row.id),
   );
   // The catalog is fetched async, so an edit-modal row can mount before it
   // arrives — the initializer then sees no catalog and leaves customMode off,

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -1510,18 +1510,24 @@ export default function AIProviderModal({
               </div>
 
               {unpricedModelIds.size > 0 && (
-                // The dark: variant is not optional — HelpText hardcodes
-                // dark:text-nb-gray-300, which beats an unprefixed colour and
-                // leaves the warning looking like ordinary help text.
-                <HelpText
-                  className={"!mb-0 text-yellow-600 dark:text-yellow-400"}
+                // A callout rather than a line of help text: this is the one
+                // thing on the tab that costs money to miss, and it sat in the
+                // same grey run of prose as everything else.
+                <Callout
+                  variant={"warning"}
+                  icon={
+                    <AlertCircleIcon
+                      size={14}
+                      className={"shrink-0 relative top-[3px]"}
+                    />
+                  }
                 >
                   {unpricedModelIds.size === 1
-                    ? "1 model has"
-                    : `${unpricedModelIds.size} models have`}{" "}
-                  no cost set (highlighted below). Requests are charged $0 until
-                  input and output rates are configured.
-                </HelpText>
+                    ? "The model below has"
+                    : `The ${unpricedModelIds.size} models below have`}{" "}
+                  no cost set. Usage is tracked at $0 and won&apos;t count
+                  toward budget limits.
+                </Callout>
               )}
 
               {models.map((row, idx) => (

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -177,17 +177,6 @@ const withModelKey = (m: ProviderModel): EditableModel => ({
 // configuration, while zero on both is the shape an unpriced model arrives in.
 const hasNoPrice = (m: ProviderModel) => !m.inputPer1k && !m.outputPer1k;
 
-// sortUnpricedFirst floats the rows needing a rate to the top, keeping the
-// relative order within each half so the vendor's own ordering survives.
-const sortUnpricedFirst = <T extends ProviderModel>(rows: T[]): T[] =>
-  rows
-    .map((row, index) => ({ row, index }))
-    .sort(
-      (a, b) =>
-        Number(hasNoPrice(b.row)) - Number(hasNoPrice(a.row)) ||
-        a.index - b.index,
-    )
-    .map(({ row }) => row);
 
 export default function AIProviderModal({
   open,
@@ -639,41 +628,6 @@ export default function AIProviderModal({
             api_key: apiKey.trim(),
           },
     );
-    if (found.length === 0) return;
-
-    // Expand the whole list into editable rows, priced. Leaving them behind a
-    // dropdown made the operator add and price each one by hand, which is the
-    // work this endpoint exists to remove — and the rates it returns are the
-    // ones the proxy bills with, so a prefilled row is accurate, not a guess.
-    setModels((prev) => {
-      // An id already on the form keeps its row untouched. The operator may
-      // have set a rate deliberately, and a refresh must not overwrite that
-      // with the default it was edited away from.
-      const existing = new Set(prev.map((m) => m.id));
-      const added = found
-        .filter((m) => !existing.has(m.id))
-        .map((m) =>
-          withModelKey({
-            id: m.id,
-            // A model NetBird cannot price arrives at zero and is flagged in
-            // the row rather than dropped: the vendor says this credential
-            // can reach it, so hiding it would hide a model they really have.
-            inputPer1k: m.input_per_1k,
-            outputPer1k: m.output_per_1k,
-            cachedInputPer1k: m.cached_input_per_1k,
-            cacheReadPer1k: m.cache_read_per_1k,
-            cacheCreationPer1k: m.cache_creation_per_1k,
-          }),
-        );
-      // Drop the blank starter row: it exists to be filled, and there is now
-      // something to fill the list with.
-      const kept = prev.filter((m) => m.id !== "");
-      // Unpriced rows first — they are the ones needing attention, and a long
-      // vendor list would otherwise bury them. Sorted here, once, rather than
-      // on every render: re-sorting live would make a row jump out from under
-      // the cursor the moment a rate was typed into it.
-      return sortUnpricedFirst([...kept, ...added]);
-    });
   };
 
   // A discovery result describes one provider, endpoint and credential. Once
@@ -1543,6 +1497,14 @@ export default function AIProviderModal({
                 />
               ))}
 
+              {!discovered.isLoading &&
+                !discovered.error &&
+                discovered.models.length > 0 && (
+                  <HelpText className={"!mb-0"}>
+                    {discovered.models.length} models loaded. Use the{" "}
+                    <strong>Add More</strong> button to search and pick models.
+                  </HelpText>
+                )}
               <Button
                 variant={"dotted"}
                 className={"w-full"}
@@ -1888,6 +1850,8 @@ function ModelRowEditor({
               }}
               options={dropdownOptions}
               placeholder={"Select a model..."}
+              showSearch
+              searchPlaceholder={"Search models..."}
             />
           ) : hasCatalog ? (
             <div className={"flex gap-2"}>

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -19,6 +19,7 @@ import Paragraph from "@components/Paragraph";
 import { SelectDropdown } from "@components/select/SelectDropdown";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@components/Tabs";
 import useFetchApi from "@utils/api";
+import { cn } from "@utils/helpers";
 import {
   AlertCircleIcon,
   ArrowRightLeft,
@@ -588,18 +589,46 @@ export default function AIProviderModal({
     );
   }, [useSavedCredential, upstreamUrl, apiKey]);
 
-  const loadModelsFromProvider = () => {
-    if (useSavedCredential && provider?.id) {
-      void discovered.discover({
-        catalog_provider_id: providerId,
-        provider_id: provider.id,
-      });
-      return;
-    }
-    void discovered.discover({
-      catalog_provider_id: providerId,
-      upstream_url: upstreamUrl.trim(),
-      api_key: apiKey.trim(),
+  const loadModelsFromProvider = async () => {
+    const found = await discovered.discover(
+      useSavedCredential && provider?.id
+        ? { catalog_provider_id: providerId, provider_id: provider.id }
+        : {
+            catalog_provider_id: providerId,
+            upstream_url: upstreamUrl.trim(),
+            api_key: apiKey.trim(),
+          },
+    );
+    if (found.length === 0) return;
+
+    // Expand the whole list into editable rows, priced. Leaving them behind a
+    // dropdown made the operator add and price each one by hand, which is the
+    // work this endpoint exists to remove — and the rates it returns are the
+    // ones the proxy bills with, so a prefilled row is accurate, not a guess.
+    setModels((prev) => {
+      // An id already on the form keeps its row untouched. The operator may
+      // have set a rate deliberately, and a refresh must not overwrite that
+      // with the default it was edited away from.
+      const existing = new Set(prev.map((m) => m.id));
+      const added = found
+        .filter((m) => !existing.has(m.id))
+        .map((m) =>
+          withModelKey({
+            id: m.id,
+            // A model NetBird cannot price arrives at zero and is flagged in
+            // the row rather than dropped: the vendor says this credential
+            // can reach it, so hiding it would hide a model they really have.
+            inputPer1k: m.input_per_1k,
+            outputPer1k: m.output_per_1k,
+            cachedInputPer1k: m.cached_input_per_1k,
+            cacheReadPer1k: m.cache_read_per_1k,
+            cacheCreationPer1k: m.cache_creation_per_1k,
+          }),
+        );
+      // Drop the blank starter row: it exists to be filled, and there is now
+      // something to fill the list with.
+      const kept = prev.filter((m) => m.id !== "");
+      return [...kept, ...added];
     });
   };
 
@@ -613,12 +642,19 @@ export default function AIProviderModal({
     resetDiscovered();
   }, [resetDiscovered, providerId, upstreamUrl, apiKey, open]);
 
-  // Discovered models NetBird cannot price. Registering one at the 0 it
-  // arrives with would record every request against it as free, so the
-  // operator is told which rows need a rate before saving.
-  const unpricedDiscovered = useMemo(
-    () => discovered.models.filter((m) => !m.pricing_known).map((m) => m.id),
-    [discovered.models],
+  // Rows carrying no price at all. Saving one records every request against
+  // that model as free, so the row is outlined and a single line says so —
+  // derived from the rates actually on the form rather than from the discovery
+  // response, so the warning clears the moment the operator types a rate, and
+  // covers a hand-added row just as well as a discovered one.
+  const unpricedModelIds = useMemo(
+    () =>
+      new Set(
+        models
+          .filter((m) => m.id !== "" && !m.inputPer1k && !m.outputPer1k)
+          .map((m) => m.id),
+      ),
+    [models],
   );
   const usedModelIds = useMemo(
     () => new Set(models.map((m) => m.id)),
@@ -1420,12 +1456,13 @@ export default function AIProviderModal({
                 )}
               </div>
 
-              {unpricedDiscovered.length > 0 && (
-                <HelpText className={"!mb-0 text-orange-400"}>
-                  NetBird has no default price for{" "}
-                  {unpricedDiscovered.join(", ")}. Set input and output rates
-                  before saving, or requests to those models record a cost of
-                  zero.
+              {unpricedModelIds.size > 0 && (
+                <HelpText className={"!mb-0 text-yellow-400"}>
+                  {unpricedModelIds.size === 1
+                    ? "1 model has no cost set"
+                    : `${unpricedModelIds.size} models have no cost set`}{" "}
+                  (outlined below). Requests to them record a cost of zero until
+                  you set input and output rates.
                 </HelpText>
               )}
 
@@ -1435,6 +1472,7 @@ export default function AIProviderModal({
                   row={row}
                   catalogModels={catalogModelOptions}
                   usedIds={usedModelIds}
+                  needsPrice={unpricedModelIds.has(row.id)}
                   onChangeId={(id) => {
                     const fromCatalog = catalogModelOptions.find(
                       (m) => m.id === id,
@@ -1686,6 +1724,7 @@ function ModelRowEditor({
   row,
   catalogModels,
   usedIds,
+  needsPrice,
   onChangeId,
   onChangeInput,
   onChangeOutput,
@@ -1699,6 +1738,10 @@ function ModelRowEditor({
   row: ProviderModel;
   catalogModels: CatalogModelOption[];
   usedIds: Set<string>;
+  // The row carries no price, so every request against it would record as
+  // free. Outlined rather than blocked: zero is a legitimate rate for a
+  // self-hosted model, and only the operator knows which case this is.
+  needsPrice: boolean;
   onChangeId: (id: string) => void;
   onChangeInput: (n: number) => void;
   onChangeOutput: (n: number) => void;
@@ -1786,9 +1829,12 @@ function ModelRowEditor({
 
   return (
     <div
-      className={
-        "flex flex-col gap-2 p-3 rounded border border-nb-gray-800 bg-nb-gray-900/20"
-      }
+      className={cn(
+        "flex flex-col gap-2 p-3 rounded border bg-nb-gray-900/20",
+        needsPrice
+          ? "border-yellow-500/60 bg-yellow-500/5"
+          : "border-nb-gray-800",
+      )}
     >
       <div className={"flex items-end gap-2"}>
         <div className={"flex-1 min-w-0"}>

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -201,7 +201,7 @@ export default function AIProviderModal({
   const [upstreamUrl, setUpstreamUrl] = useState<string>(
     provider?.upstreamUrl ?? "",
   );
-  const [apiKey, setApiKey] = useState(isEdit ? "••••••••" : "");
+  const [apiKey, setApiKey] = useState(isEdit ? MASKED_API_KEY : "");
   const [bootstrapCluster, setBootstrapCluster] = useState<string>("");
   const [models, setModels] = useState<EditableModel[]>(() =>
     (provider?.models ?? []).map(withModelKey),
@@ -367,7 +367,7 @@ export default function AIProviderModal({
       setProviderId(provider.providerId);
       setName(provider.name);
       setUpstreamUrl(provider.upstreamUrl);
-      setApiKey("••••••••");
+      setApiKey(MASKED_API_KEY);
       setBootstrapCluster("");
       setModels(provider.models.map(withModelKey));
       setExtraValues(provider.extraValues ?? {});
@@ -460,7 +460,7 @@ export default function AIProviderModal({
         skipTlsVerification: isCustomKind ? skipTlsVerification : false,
         metadataDisabled,
         // Only forward the API key when the user actually rotated it
-        ...(apiKey && apiKey !== "••••••••" ? { apiKey } : {}),
+        ...(apiKey && apiKey !== MASKED_API_KEY ? { apiKey } : {}),
       });
       handleClose();
       return;
@@ -559,17 +559,37 @@ export default function AIProviderModal({
   // Editing a saved provider shows a masked api key, never the real one, so
   // discovery reuses the stored credential by record id instead. A new
   // provider has to supply the key the operator is typing.
+  //
+  // That reuse is only right while the form still describes the record the
+  // credential belongs to. The API resolves a provider_id request entirely
+  // from the stored row — vendor, upstream and key — so switching the vendor
+  // dropdown and then asking by record id answers with the OLD vendor's models
+  // and offers them for the new one. A replacement key typed over the mask is
+  // the same mistake in the other direction: the operator wants that key
+  // tested, not the one already saved.
+  //
+  // Changing only the upstream URL deliberately keeps the saved path. The
+  // browser never holds the key, so asking against the edited URL is not
+  // something it can do until the record is saved.
+  const useSavedCredential =
+    isEdit &&
+    !!provider?.id &&
+    providerId === provider.providerId &&
+    apiKey.trim() === MASKED_API_KEY;
+
   const canDiscoverModels = useMemo(() => {
-    if (isEdit && provider?.id) return true;
+    if (useSavedCredential) return true;
     return (
       upstreamUrl.trim() !== "" &&
       apiKey.trim() !== "" &&
-      apiKey !== MASKED_API_KEY
+      // Compared trimmed on both sides: an untrimmed compare lets a padded
+      // mask through, and the request then sends the mask as the credential.
+      apiKey.trim() !== MASKED_API_KEY
     );
-  }, [isEdit, provider?.id, upstreamUrl, apiKey]);
+  }, [useSavedCredential, upstreamUrl, apiKey]);
 
   const loadModelsFromProvider = () => {
-    if (isEdit && provider?.id) {
+    if (useSavedCredential && provider?.id) {
       void discovered.discover({
         catalog_provider_id: providerId,
         provider_id: provider.id,
@@ -582,6 +602,16 @@ export default function AIProviderModal({
       api_key: apiKey.trim(),
     });
   };
+
+  // A discovery result describes one provider, endpoint and credential. Once
+  // any of those changes on screen, the previous answer is about a
+  // configuration that is no longer being edited, so it is dropped rather than
+  // left populating the model picker — whose ids are what save() registers.
+  // reset also invalidates any request still in flight.
+  const resetDiscovered = discovered.reset;
+  useEffect(() => {
+    resetDiscovered();
+  }, [resetDiscovered, providerId, upstreamUrl, apiKey, open]);
 
   // Discovered models NetBird cannot price. Registering one at the 0 it
   // arrives with would record every request against it as free, so the
@@ -835,14 +865,14 @@ export default function AIProviderModal({
                       onClick={() => keyFileInputRef.current?.click()}
                     >
                       <UploadIcon size={14} />
-                      {keyFileName || (isEdit && apiKey === "••••••••")
+                      {keyFileName || (isEdit && apiKey === MASKED_API_KEY)
                         ? "Replace JSON key"
                         : "Upload JSON key"}
                     </Button>
                     <span className={"text-xs text-nb-gray-300 truncate"}>
                       {keyFileName
                         ? keyFileName
-                        : isEdit && apiKey === "••••••••"
+                        : isEdit && apiKey === MASKED_API_KEY
                         ? "A key is already stored"
                         : "No file selected"}
                     </span>

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -490,7 +490,7 @@ export default function AIProviderModal({
         skipTlsVerification: isCustomKind ? skipTlsVerification : false,
         metadataDisabled,
         // Only forward the API key when the user actually rotated it
-        ...(apiKey && apiKey !== MASKED_API_KEY ? { apiKey } : {}),
+        ...(apiKey && apiKey.trim() !== MASKED_API_KEY ? { apiKey } : {}),
       });
       handleClose();
       return;
@@ -598,13 +598,16 @@ export default function AIProviderModal({
   // the same mistake in the other direction: the operator wants that key
   // tested, not the one already saved.
   //
-  // Changing only the upstream URL deliberately keeps the saved path. The
-  // browser never holds the key, so asking against the edited URL is not
-  // something it can do until the record is saved.
+  // Changing the upstream URL invalidates the saved path: discovery sends
+  // provider_id and the API resolves the URL from the stored row, so a changed
+  // URL would silently test the old endpoint. Require a freshly entered key
+  // when the URL differs; canDiscoverModels will block discovery until the
+  // operator provides one.
   const useSavedCredential =
     isEdit &&
     !!provider?.id &&
     providerId === provider.providerId &&
+    upstreamUrl === provider.upstreamUrl &&
     apiKey.trim() === MASKED_API_KEY;
 
   const canDiscoverModels = useMemo(() => {

--- a/src/modules/agent-network/useDiscoveredModels.ts
+++ b/src/modules/agent-network/useDiscoveredModels.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useApiCall } from "@utils/api";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 // DiscoveredModel is one model the vendor says this credential can reach.
 export type DiscoveredModel = {
@@ -62,11 +62,21 @@ export function useDiscoveredModels() {
     notSupported: false,
   });
 
+  // Each call takes the next generation, and only the newest one is allowed to
+  // write state. A discovery answers one specific provider, endpoint and
+  // credential; the operator can change any of those while it is in flight, and
+  // a slow first response landing after a fast second would otherwise fill the
+  // model picker with models belonging to a configuration no longer on screen —
+  // and those ids are what gets registered on save.
+  const generation = useRef(0);
+
   const discover = useCallback(
     async (req: DiscoveryRequest) => {
+      const gen = ++generation.current;
       setState({ models: [], isLoading: true, notSupported: false });
       try {
         const res = await request.post(req);
+        if (gen !== generation.current) return [];
         setState({
           models: res?.models ?? [],
           isLoading: false,
@@ -74,6 +84,7 @@ export function useDiscoveredModels() {
         });
         return res?.models ?? [];
       } catch (e) {
+        if (gen !== generation.current) return [];
         // 422 is the API saying this provider has no listing endpoint, which
         // is a fact about the catalog entry rather than a failure — the caller
         // keeps the catalog list and says so quietly.
@@ -94,10 +105,12 @@ export function useDiscoveredModels() {
     [request],
   );
 
-  const reset = useCallback(
-    () => setState({ models: [], isLoading: false, notSupported: false }),
-    [],
-  );
+  // reset bumps the generation too, so a request already in flight cannot
+  // repopulate the list it was just cleared from.
+  const reset = useCallback(() => {
+    generation.current += 1;
+    setState({ models: [], isLoading: false, notSupported: false });
+  }, []);
 
   return { ...state, discover, reset } as const;
 }

--- a/src/modules/agent-network/useDiscoveredModels.ts
+++ b/src/modules/agent-network/useDiscoveredModels.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useApiCall } from "@utils/api";
+import { useCallback, useState } from "react";
+
+// DiscoveredModel is one model the vendor says this credential can reach.
+export type DiscoveredModel = {
+  // The id to register, in the form the vendor issues it. For Bedrock that is
+  // the region-prefixed inference-profile id, which is the only form AWS
+  // accepts at invoke time — so it must be stored verbatim, not tidied up.
+  id: string;
+  label?: string;
+  // false when NetBird's shipped pricing table has no rate for this model. The
+  // operator has to supply one, or requests to it record a cost of zero.
+  pricing_known: boolean;
+};
+
+type DiscoveryResponse = { models: DiscoveredModel[] };
+
+type DiscoveryRequest = {
+  catalog_provider_id: string;
+  upstream_url?: string;
+  // Exactly one of these. api_key is for a provider being typed in and not yet
+  // saved; provider_id reuses a saved record's stored credential, which is how
+  // an existing provider refreshes its list without the browser ever holding
+  // the key. Sending both is refused by the API.
+  api_key?: string;
+  provider_id?: string;
+};
+
+// notSupported marks the outcome where the provider simply has no listing
+// endpoint — most gateways. It is not an error the operator should see as one:
+// the form falls back to the catalog's own models.
+export type DiscoveryState = {
+  models: DiscoveredModel[];
+  isLoading: boolean;
+  notSupported: boolean;
+  error?: string;
+};
+
+/**
+ * useDiscoveredModels asks the vendor which models a credential can actually
+ * reach, so the model picker can offer the operator's real entitlements
+ * instead of only NetBird's compiled-in catalog.
+ *
+ * The catalog cannot know which OpenAI models an org is entitled to, which
+ * Bedrock profiles an account and region hold, or which Vertex models a
+ * project has enabled — and it drifts as vendors retire models.
+ */
+export function useDiscoveredModels() {
+  // ignoreError: the failures here are expected and handled inline (a wrong
+  // key, a provider with no listing endpoint), so they must not raise the
+  // global error toast on top of the message shown in the form.
+  const request = useApiCall<DiscoveryResponse>(
+    "/agent-network/catalog/providers/models",
+    true,
+  );
+
+  const [state, setState] = useState<DiscoveryState>({
+    models: [],
+    isLoading: false,
+    notSupported: false,
+  });
+
+  const discover = useCallback(
+    async (req: DiscoveryRequest) => {
+      setState({ models: [], isLoading: true, notSupported: false });
+      try {
+        const res = await request.post(req);
+        setState({
+          models: res?.models ?? [],
+          isLoading: false,
+          notSupported: false,
+        });
+        return res?.models ?? [];
+      } catch (e) {
+        // 422 is the API saying this provider has no listing endpoint, which
+        // is a fact about the catalog entry rather than a failure — the caller
+        // keeps the catalog list and says so quietly.
+        const status = (e as { status?: number })?.status;
+        setState({
+          models: [],
+          isLoading: false,
+          notSupported: status === 422,
+          error:
+            status === 422
+              ? undefined
+              : (e as { message?: string })?.message ??
+                "Could not reach the provider",
+        });
+        return [];
+      }
+    },
+    [request],
+  );
+
+  const reset = useCallback(
+    () => setState({ models: [], isLoading: false, notSupported: false }),
+    [],
+  );
+
+  return { ...state, discover, reset } as const;
+}

--- a/src/modules/agent-network/useDiscoveredModels.ts
+++ b/src/modules/agent-network/useDiscoveredModels.ts
@@ -11,8 +11,16 @@ export type DiscoveredModel = {
   id: string;
   label?: string;
   // false when NetBird's shipped pricing table has no rate for this model. The
-  // operator has to supply one, or requests to it record a cost of zero.
+  // rates below are then all zero and the operator has to supply them, or
+  // requests to it record a cost of zero.
   pricing_known: boolean;
+  // The default rates this model would be billed at, from the same table the
+  // proxy uses — so a prefilled row shows what a request actually costs.
+  input_per_1k: number;
+  output_per_1k: number;
+  cached_input_per_1k?: number;
+  cache_read_per_1k?: number;
+  cache_creation_per_1k?: number;
 };
 
 type DiscoveryResponse = { models: DiscoveredModel[] };


### PR DESCRIPTION
## Describe your changes

The model picker only offered NetBird's compiled-in catalog, which goes stale as
vendors retire models and cannot reflect what an account is actually entitled to.

Adds a "Load models from provider" action backed by
`POST /agent-network/catalog/providers/models` (netbirdio/netbird#7246). Editing a
saved provider reuses the stored credential, so the masked key never reaches the
browser; creating a new one sends the key being typed. Discovered models merge into
the catalog options, with catalog entries winning a collision because they carry
pricing. A model the backend reports as unpriced is flagged and needs confirmation
before saving, so nothing is registered at a silent zero.

Two implementation notes: the unpriced warning renders once at list level rather
than per row, and the hook uses `ignoreError: true` so a provider-specific failure
is reported inline in the modal instead of as a global toast.

**Testing:** TypeScript and ESLint pass. The endpoint this consumes lands with
netbirdio/netbird#7246, so the Playwright run below exercises it for real once the
post-merge `main` images are built.

## Issue ticket number and link

https://linear.app/netbird/issue/NET-1519/bedrock-providers-cannot-serve-model-discovery

## Documentation
Select exactly one:

- [x] I added/updated documentation for this change
- [ ] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/945

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main
