### PR TITLE
Report the registered peer name as the WASM client's device name

### DIFF
--- a/src/modules/remote-access/useNetBirdClient.ts
+++ b/src/modules/remote-access/useNetBirdClient.ts
@@ -160,7 +160,7 @@ export const useNetBirdClient = () => {
   }, []);
 
   const connect = useCallback(
-    async (privateKey: string): Promise<boolean> => {
+    async (privateKey: string, deviceName?: string): Promise<boolean> => {
       await initialize();
 
       if (typeof (window as any).NetBirdClient !== "function") {
@@ -178,6 +178,10 @@ export const useNetBirdClient = () => {
           privateKey,
           logLevel: "info",
           managementURL: config.apiOrigin,
+          // Report the name the peer was registered with, so its meta does not
+          // change on the first sync (a meta change pushes a network map to
+          // every peer in the account).
+          ...(deviceName ? { deviceName } : {}),
         });
 
         await netBirdClient.current.start();
@@ -293,7 +297,7 @@ export const useNetBirdClient = () => {
           },
           `/${peerId}/temporary-access`,
         );
-        return await connect(keyPairs.privateKey);
+        return await connect(keyPairs.privateKey, name);
       } catch (error) {
         netBirdStore.setState({ status: NetBirdStatus.DISCONNECTED });
         throw error;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -82,7 +82,7 @@ const loadConfig = (): Config => {
     googleTagManagerID: configJson?.googleTagManagerID || undefined,
     authServiceUrl: configJson?.authServiceUrl ?? undefined,
     wasmPath:
-      configJson?.wasmPath || "https://pkgs.netbird.io/wasm/client/v0.76.3",
+      configJson?.wasmPath || "https://pkgs.netbird.io/wasm/client/v0.78.0",
     licensed: configJson?.licensed === "true",
     cloud: configJson?.cloud === "true",
     agentNetworkOnly: configJson?.agentNetworkOnly === "true",


### PR DESCRIPTION
The temporary-access flow registers the peer under a per-session name (for example `firefox-153-browser-client`), but the WASM client then reports a different hostname in its meta, so the peer renames itself on its first sync and management pushes a needless network map to every peer in the account. The client now receives the registered name as its device name, so the reported meta matches from the start.

- Pass the registered peer name to the WASM client as its device name
- Bump the default WASM client to v0.78.0, which honors the device name and adds the lazy-connection override

Merge after v0.78.0 is published; until then the new option is ignored by the older client and the bumped default path does not resolve.

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (internal client option plumbing, no user-facing behavior)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main
