### PR TITLE
Add a workflow bumping the WASM client on netbird releases

### DIFF
--- a/.github/workflows/bump-netbird.yml
+++ b/.github/workflows/bump-netbird.yml
@@ -47,19 +47,28 @@ jobs:
           branch="bump-netbird-wasm-${TAG#v}"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
+          # The branch name is derived from the tag, so a re-dispatch of the
+          # same release would collide with the branch and pull request an
+          # earlier run left behind.
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Branch ${branch} already exists, ${TAG} was handled by an earlier run"
+            exit 0
+          fi
+
           git checkout -b "${branch}"
           git add src/utils/config.ts
           if git diff --cached --quiet; then
-            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Default wasm path already at ${TAG}, nothing to do"
             exit 0
           fi
-          echo "no_changes=false" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           git commit -m "Bump the WASM client to ${TAG}"
           git push --set-upstream origin "${branch}"
 
       - name: Create pull request
-        if: steps.bump.outputs.no_changes != 'true'
+        if: steps.bump.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.NETBIRD_DEV_BOT_GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}

--- a/.github/workflows/bump-netbird.yml
+++ b/.github/workflows/bump-netbird.yml
@@ -1,0 +1,62 @@
+name: Bump netbird wasm client
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'NetBird release tag (e.g. v0.78.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NETBIRD_DEV_BOT_GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "dev@netbird.io"
+          git config --global user.name "netbirddev"
+
+      - name: Update the default wasm path
+        id: bump
+        run: |
+          tag="${{ inputs.tag }}"
+          sed -i "s|https://pkgs.netbird.io/wasm/client/v[0-9.]*|https://pkgs.netbird.io/wasm/client/${tag}|" src/utils/config.ts
+
+          version="${tag#v}"
+          branch="bump-netbird-wasm-${version}"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+
+          git checkout -b "${branch}"
+          git add src/utils/config.ts
+          if git diff --cached --quiet; then
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Default wasm path already at ${tag}, nothing to do"
+            exit 0
+          fi
+          echo "no_changes=false" >> "$GITHUB_OUTPUT"
+          git commit -m "Bump the WASM client to ${tag}"
+          git push --set-upstream origin "${branch}"
+
+      - name: Create pull request
+        if: steps.bump.outputs.no_changes != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NETBIRD_DEV_BOT_GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "Bump the WASM client to ${{ inputs.tag }}" \
+            --body "Automated wasm path bump triggered by netbird release ${{ inputs.tag }}."

--- a/.github/workflows/bump-netbird.yml
+++ b/.github/workflows/bump-netbird.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: main
           token: ${{ secrets.NETBIRD_DEV_BOT_GITHUB_TOKEN }}
 
       - name: Configure git
@@ -29,34 +30,43 @@ jobs:
           git config --global user.email "dev@netbird.io"
           git config --global user.name "netbirddev"
 
+      # The tag rides in env and is validated before use, so a crafted dispatch
+      # input cannot expand into shell source or reach the sed expression.
       - name: Update the default wasm path
         id: bump
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          tag="${{ inputs.tag }}"
-          sed -i "s|https://pkgs.netbird.io/wasm/client/v[0-9.]*|https://pkgs.netbird.io/wasm/client/${tag}|" src/utils/config.ts
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing tag '$TAG': expected vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
 
-          version="${tag#v}"
-          branch="bump-netbird-wasm-${version}"
+          sed -i "s|https://pkgs.netbird.io/wasm/client/v[0-9.]*|https://pkgs.netbird.io/wasm/client/${TAG}|" src/utils/config.ts
+
+          branch="bump-netbird-wasm-${TAG#v}"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
           git checkout -b "${branch}"
           git add src/utils/config.ts
           if git diff --cached --quiet; then
             echo "no_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Default wasm path already at ${tag}, nothing to do"
+            echo "Default wasm path already at ${TAG}, nothing to do"
             exit 0
           fi
           echo "no_changes=false" >> "$GITHUB_OUTPUT"
-          git commit -m "Bump the WASM client to ${tag}"
+          git commit -m "Bump the WASM client to ${TAG}"
           git push --set-upstream origin "${branch}"
 
       - name: Create pull request
         if: steps.bump.outputs.no_changes != 'true'
         env:
           GH_TOKEN: ${{ secrets.NETBIRD_DEV_BOT_GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
         run: |
           gh pr create \
             --base main \
-            --head "${{ steps.bump.outputs.branch }}" \
-            --title "Bump the WASM client to ${{ inputs.tag }}" \
-            --body "Automated wasm path bump triggered by netbird release ${{ inputs.tag }}."
+            --head "$BRANCH" \
+            --title "Bump the WASM client to ${TAG}" \
+            --body "Automated wasm path bump triggered by netbird release ${TAG}."

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -82,30 +82,11 @@ export async function apiGet<T>(page: Page, path: string): Promise<T> {
   return resp.json();
 }
 
-export async function apiPost<T>(
-  page: Page,
-  path: string,
-  body: unknown,
-): Promise<T> {
-  const { token, origin } = await getApiContext(page);
-  const resp = await page.request.post(`${origin}/api${path}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: body,
-  });
-  return resp.json();
-}
-
 export async function apiDelete(page: Page, path: string): Promise<void> {
   const { token, origin } = await getApiContext(page);
   await page.request.delete(`${origin}/api${path}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-}
-
-/** The management API origin, for callers that dial it directly. */
-export async function managementOrigin(page: Page): Promise<string> {
-  const { origin } = await getApiContext(page);
-  return origin;
 }
 
 /** List all groups. */

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -74,7 +74,7 @@ async function getApiContext(
   return ctx;
 }
 
-export async function apiGet<T>(page: Page, path: string): Promise<T> {
+async function apiGet<T>(page: Page, path: string): Promise<T> {
   const { token, origin } = await getApiContext(page);
   const resp = await page.request.get(`${origin}/api${path}`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -82,20 +82,7 @@ export async function apiGet<T>(page: Page, path: string): Promise<T> {
   return resp.json();
 }
 
-export async function apiPost<T>(
-  page: Page,
-  path: string,
-  body: unknown,
-): Promise<T> {
-  const { token, origin } = await getApiContext(page);
-  const resp = await page.request.post(`${origin}/api${path}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: body,
-  });
-  return resp.json();
-}
-
-export async function apiDelete(page: Page, path: string): Promise<void> {
+async function apiDelete(page: Page, path: string): Promise<void> {
   const { token, origin } = await getApiContext(page);
   await page.request.delete(`${origin}/api${path}`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -74,7 +74,7 @@ async function getApiContext(
   return ctx;
 }
 
-async function apiGet<T>(page: Page, path: string): Promise<T> {
+export async function apiGet<T>(page: Page, path: string): Promise<T> {
   const { token, origin } = await getApiContext(page);
   const resp = await page.request.get(`${origin}/api${path}`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -82,11 +82,30 @@ async function apiGet<T>(page: Page, path: string): Promise<T> {
   return resp.json();
 }
 
-async function apiDelete(page: Page, path: string): Promise<void> {
+export async function apiPost<T>(
+  page: Page,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const { token, origin } = await getApiContext(page);
+  const resp = await page.request.post(`${origin}/api${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: body,
+  });
+  return resp.json();
+}
+
+export async function apiDelete(page: Page, path: string): Promise<void> {
   const { token, origin } = await getApiContext(page);
   await page.request.delete(`${origin}/api${path}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
+}
+
+/** The management API origin, for callers that dial it directly. */
+export async function managementOrigin(page: Page): Promise<string> {
+  const { origin } = await getApiContext(page);
+  return origin;
 }
 
 /** List all groups. */

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -82,6 +82,19 @@ export async function apiGet<T>(page: Page, path: string): Promise<T> {
   return resp.json();
 }
 
+export async function apiPost<T>(
+  page: Page,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const { token, origin } = await getApiContext(page);
+  const resp = await page.request.post(`${origin}/api${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: body,
+  });
+  return resp.json();
+}
+
 export async function apiDelete(page: Page, path: string): Promise<void> {
   const { token, origin } = await getApiContext(page);
   await page.request.delete(`${origin}/api${path}`, {

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -1,17 +1,16 @@
 import { readFileSync } from "fs";
 import { join } from "path";
-import type { Peer } from "../../src/interfaces/Peer";
-import type { ReverseProxy } from "../../src/interfaces/ReverseProxy";
-import { apiDelete, apiGet, apiPost, deleteServicesByPrefix } from "../helpers/api";
 import { expect, test } from "../helpers/fixtures";
-import { CUSTOM_PORTS_DOMAIN } from "../helpers/reverse-proxy-l4";
-import { generateRandomName } from "../helpers/utils";
 
 /**
- * Guards the pinned default WASM client, which is what a version bump changes:
- * the artifact must instantiate, and the dashboard's own remote-access flow
- * must still bring it online against management. The tunnel itself is not
- * exercised; deeper flows live in the client end-to-end suites.
+ * Guards the pinned default WASM client, which is what a version bump changes.
+ * The artifact must download and instantiate against the wasm_exec.js this
+ * dashboard serves, and must publish the client entry point the remote-access
+ * modules construct. That pairing is the part a bump breaks: a missing build,
+ * a truncated upload, or a Go runtime newer than the checked-in loader.
+ *
+ * Bringing the client online needs signal, relay and a target peer, none of
+ * which exist in this environment; the client end-to-end suites cover that.
  */
 
 /** The wasm path pinned in config.ts, the single source the bump rewrites. */
@@ -27,7 +26,7 @@ const pinnedWasmPath = (): string => {
   return pinned![0];
 };
 
-test.describe.serial("WASM client @wasm", () => {
+test.describe("WASM client @wasm", () => {
   test("the pinned WASM client instantiates", async ({
     dashboardAsOwner: page,
   }) => {
@@ -48,6 +47,8 @@ test.describe.serial("WASM client @wasm", () => {
       );
       void go.run(wasmModule.instance);
 
+      // The Go runtime publishes its exports partway through startup, so the
+      // constructor appears some time after go.run() returns.
       const deadline = Date.now() + 30_000;
       while (Date.now() < deadline) {
         if (typeof (window as any).NetBirdClient === "function") {
@@ -59,81 +60,5 @@ test.describe.serial("WASM client @wasm", () => {
     }, pinnedWasmPath());
 
     expect(result).toBe("ok");
-  });
-
-  test("the remote-access flow brings the pinned WASM client online", async ({
-    dashboardAsOwner: page,
-  }) => {
-    test.setTimeout(300_000);
-
-    // The SSH page needs a peer to target. A fresh account has none, so one is
-    // minted the way the environment supports: exposing a service makes a proxy
-    // register an embedded peer for the account. The SSH session itself will
-    // fail against it, which is fine: the flow under test ends when the
-    // browser client is online.
-    await deleteServicesByPrefix(page, "wasm-e2e-");
-    const serviceName = generateRandomName("wasm-e2e-");
-    await apiPost<ReverseProxy>(page, "/reverse-proxies/services", {
-      name: serviceName,
-      domain: `${serviceName}.${CUSTOM_PORTS_DOMAIN}`,
-      enabled: true,
-      targets: [
-        {
-          target_type: "host",
-          protocol: "http",
-          host: "10.99.99.40",
-          port: 80,
-          enabled: true,
-        },
-      ],
-    });
-
-    let target: Peer | undefined;
-    for (let attempt = 0; attempt < 45 && !target; attempt++) {
-      await page.waitForTimeout(2_000);
-      const all = await apiGet<Peer[]>(page, "/peers");
-      target = all.find((p) => p.name.startsWith("proxy-"));
-    }
-    expect(target, "exposing a service should register a proxy peer").toBeTruthy();
-
-    const before = new Set(
-      (await apiGet<Peer[]>(page, "/peers")).map((p) => p.id),
-    );
-
-    // Mounting the page runs the dashboard's own chain: load the pinned wasm,
-    // generate a key, register temporary access, start the client.
-    await page.goto(`/peer/ssh?id=${target!.id}&user=root&port=22022`);
-
-    // Management's view proves the round trip: the flow's ephemeral peer shows
-    // up connected. Polled via the API because the connected flag is
-    // management state, not a page response.
-    let created: Peer | undefined;
-    try {
-      for (let attempt = 0; attempt < 45 && !created?.connected; attempt++) {
-        await page.waitForTimeout(2_000);
-        const all = await apiGet<Peer[]>(page, "/peers");
-        created = all.find(
-          (p) => !before.has(p.id) && p.name.endsWith("browser-client"),
-        );
-      }
-      expect(
-        created,
-        "the flow should register a browser client peer",
-      ).toBeTruthy();
-      expect(
-        created!.connected,
-        "the browser client peer should be connected",
-      ).toBe(true);
-    } finally {
-      // Best-effort: a throw here would mask the failure under test, and the
-      // test's artifacts must not outlive it in the shared environment.
-      try {
-        await page.goto("/peers");
-        if (created) await apiDelete(page, `/peers/${created.id}`);
-        await deleteServicesByPrefix(page, "wasm-e2e-");
-      } catch {
-        // The assertion that failed is the story; a cleanup miss is not.
-      }
-    }
   });
 });

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -52,9 +52,10 @@ test.describe("WASM client @wasm", () => {
       void go.run(wasmModule.instance);
 
       // The Go runtime publishes its exports partway through startup, so the
-      // constructor appears some time after go.run() returns. The dashboard
-      // gives it 10s before reporting a load failure.
-      const deadline = Date.now() + 15_000;
+      // constructor appears some time after go.run() returns. This matches the
+      // deadline the dashboard applies to the same wait, so an artifact this
+      // test accepts is one the dashboard can also load.
+      const deadline = Date.now() + 10_000;
       while (Date.now() < deadline) {
         if (typeof (window as any).NetBirdClient === "function") {
           return "ok";

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -1,52 +1,125 @@
 import { readFileSync } from "fs";
 import { join } from "path";
+import type { Page } from "@playwright/test";
 import { test, expect } from "../helpers/fixtures";
+import { apiDelete, apiGet, apiPost, managementOrigin } from "../helpers/api";
+import { generateKeypair } from "../../src/utils/wireguard";
+import type { Peer } from "../../src/interfaces/Peer";
 
 /**
- * Instantiates the pinned default WASM client. This is what guards a version
- * bump: the pinned URL must resolve and the module must compile, instantiate
- * and boot far enough to export its constructor. No management connection is
- * made, so this covers the artifact, not the tunnel.
+ * Guards the pinned default WASM client, which is what a version bump changes:
+ * the artifact must instantiate, and the client it exports must still speak to
+ * management with the options this dashboard passes. The tunnel itself is not
+ * exercised; deeper flows live in the client end-to-end suites.
  */
+
+/** The wasm path pinned in config.ts, the single source the bump rewrites. */
+const pinnedWasmPath = (): string => {
+  const configSource = readFileSync(
+    join(__dirname, "../../src/utils/config.ts"),
+    "utf8",
+  );
+  const pinned = configSource.match(
+    /https:\/\/pkgs\.netbird\.io\/wasm\/client\/v[0-9.]+/,
+  );
+  expect(pinned, "config.ts should pin a default wasm path").not.toBeNull();
+  return pinned![0];
+};
+
+/** Loads and boots the pinned module until it exports its constructor. */
+const bootWasmClient = async (page: Page, wasmUrl: string): Promise<string> =>
+  page.evaluate(async (url) => {
+    await new Promise<void>((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = "/wasm_exec.js";
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error("wasm_exec.js failed to load"));
+      document.head.appendChild(script);
+    });
+
+    const go = new (window as any).Go();
+    const module = await WebAssembly.instantiateStreaming(
+      fetch(url),
+      go.importObject,
+    );
+    void go.run(module.instance);
+
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      if (typeof (window as any).NetBirdClient === "function") {
+        return "ok";
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return "NetBirdClient never appeared";
+  }, wasmUrl);
+
 test.describe("WASM client @wasm", () => {
   test("the pinned WASM client instantiates", async ({
     dashboardAsOwner: page,
   }) => {
-    const configSource = readFileSync(
-      join(__dirname, "../../src/utils/config.ts"),
-      "utf8",
-    );
-    const pinned = configSource.match(
-      /https:\/\/pkgs\.netbird\.io\/wasm\/client\/v[0-9.]+/,
-    );
-    expect(pinned, "config.ts should pin a default wasm path").not.toBeNull();
+    expect(await bootWasmClient(page, pinnedWasmPath())).toBe("ok");
+  });
 
-    const result = await page.evaluate(async (wasmUrl) => {
-      await new Promise<void>((resolve, reject) => {
-        const script = document.createElement("script");
-        script.src = "/wasm_exec.js";
-        script.onload = () => resolve();
-        script.onerror = () => reject(new Error("wasm_exec.js failed to load"));
-        document.head.appendChild(script);
-      });
+  test("the pinned WASM client connects to management", async ({
+    dashboardAsOwner: page,
+  }) => {
+    test.setTimeout(180_000);
 
-      const go = new (window as any).Go();
-      const module = await WebAssembly.instantiateStreaming(
-        fetch(wasmUrl),
-        go.importObject,
-      );
-      void go.run(module.instance);
+    // Temporary access needs something to be granted against; the environment
+    // always has peers once its clusters are online.
+    const peers = await apiGet<Peer[]>(page, "/peers");
+    expect(
+      peers.length,
+      "the environment should have a peer to grant against",
+    ).toBeGreaterThan(0);
 
-      const deadline = Date.now() + 30_000;
-      while (Date.now() < deadline) {
-        if (typeof (window as any).NetBirdClient === "function") {
+    const keypair = generateKeypair();
+    const name = `e2e-wasm-${keypair.publicKey.slice(0, 6).toLowerCase().replace(/[^a-z0-9]/g, "")}`;
+    await apiPost(page, `/peers/${peers[0].id}/temporary-access`, {
+      name,
+      wg_pub_key: keypair.publicKey,
+      rules: ["tcp/22022"],
+    });
+
+    expect(await bootWasmClient(page, pinnedWasmPath())).toBe("ok");
+
+    const mgmt = await managementOrigin(page);
+    const started = await page.evaluate(
+      async ({ privateKey, managementURL, deviceName }) => {
+        const client = await (window as any).NetBirdClient({
+          privateKey,
+          managementURL,
+          deviceName,
+        });
+        (window as any).__e2eWasmClient = client;
+        try {
+          await client.start();
           return "ok";
+        } catch (error) {
+          return String(error);
         }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      return "NetBirdClient never appeared";
-    }, pinned![0]);
+      },
+      { privateKey: keypair.privateKey, managementURL: mgmt, deviceName: name },
+    );
+    expect(started, "the client should log in and sync").toBe("ok");
 
-    expect(result).toBe("ok");
+    // Management's view proves the login round trip: the registered peer shows
+    // up connected under the name it was registered with.
+    let created: Peer | undefined;
+    for (let attempt = 0; attempt < 30 && !created?.connected; attempt++) {
+      await page.waitForTimeout(2_000);
+      const all = await apiGet<Peer[]>(page, "/peers");
+      created = all.find((p) => p.name === name);
+    }
+    expect(created, "the registered peer should appear").toBeTruthy();
+    expect(created!.connected, "the registered peer should be connected").toBe(
+      true,
+    );
+
+    await page.evaluate(async () => {
+      await (window as any).__e2eWasmClient?.stop?.();
+    });
+    if (created) await apiDelete(page, `/peers/${created.id}`);
   });
 });

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -1,16 +1,13 @@
-import type { Page } from "@playwright/test";
 import { readFileSync } from "fs";
 import { join } from "path";
 import type { Peer } from "../../src/interfaces/Peer";
-import { generateKeypair } from "../../src/utils/wireguard";
-import { apiDelete, apiGet, apiPost, managementOrigin } from "../helpers/api";
+import { apiDelete, apiGet } from "../helpers/api";
 import { expect, test } from "../helpers/fixtures";
-import { generateRandomName } from "../helpers/utils";
 
 /**
  * Guards the pinned default WASM client, which is what a version bump changes:
- * the artifact must instantiate, and the client it exports must still speak to
- * management with the options this dashboard passes. The tunnel itself is not
+ * the artifact must instantiate, and the dashboard's own remote-access flow
+ * must still bring it online against management. The tunnel itself is not
  * exercised; deeper flows live in the client end-to-end suites.
  */
 
@@ -27,115 +24,85 @@ const pinnedWasmPath = (): string => {
   return pinned![0];
 };
 
-/** Loads and boots the pinned module until it exports its constructor. */
-const bootWasmClient = async (page: Page, wasmUrl: string): Promise<string> =>
-  page.evaluate(async (url) => {
-    await new Promise<void>((resolve, reject) => {
-      const script = document.createElement("script");
-      script.src = "/wasm_exec.js";
-      script.onload = () => resolve();
-      script.onerror = () => reject(new Error("wasm_exec.js failed to load"));
-      document.head.appendChild(script);
-    });
-
-    const go = new (window as any).Go();
-    const wasmModule = await WebAssembly.instantiateStreaming(
-      fetch(url),
-      go.importObject,
-    );
-    void go.run(wasmModule.instance);
-
-    const deadline = Date.now() + 30_000;
-    while (Date.now() < deadline) {
-      if (typeof (window as any).NetBirdClient === "function") {
-        return "ok";
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    return "NetBirdClient never appeared";
-  }, wasmUrl);
-
 test.describe.serial("WASM client @wasm", () => {
   test("the pinned WASM client instantiates", async ({
     dashboardAsOwner: page,
   }) => {
-    expect(await bootWasmClient(page, pinnedWasmPath())).toBe("ok");
+    const result = await page.evaluate(async (url) => {
+      await new Promise<void>((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "/wasm_exec.js";
+        script.onload = () => resolve();
+        script.onerror = () =>
+          reject(new Error("wasm_exec.js failed to load"));
+        document.head.appendChild(script);
+      });
+
+      const go = new (window as any).Go();
+      const wasmModule = await WebAssembly.instantiateStreaming(
+        fetch(url),
+        go.importObject,
+      );
+      void go.run(wasmModule.instance);
+
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        if (typeof (window as any).NetBirdClient === "function") {
+          return "ok";
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      return "NetBirdClient never appeared";
+    }, pinnedWasmPath());
+
+    expect(result).toBe("ok");
   });
 
-  test("the pinned WASM client connects to management", async ({
+  test("the remote-access flow brings the pinned WASM client online", async ({
     dashboardAsOwner: page,
   }) => {
     test.setTimeout(180_000);
 
-    // Temporary access needs something to be granted against; the environment
-    // always has peers once its clusters are online.
+    // The SSH page needs a peer to target; the environment always has peers
+    // once its clusters are online. The SSH session itself will fail against
+    // it, which is fine: the flow under test ends when the client is online.
     const peers = await apiGet<Peer[]>(page, "/peers");
     expect(
       peers.length,
-      "the environment should have a peer to grant against",
+      "the environment should have a peer to target",
     ).toBeGreaterThan(0);
+    const before = new Set(peers.map((p) => p.id));
 
-    const keypair = generateKeypair();
-    const name = generateRandomName("e2e-wasm-");
-    await apiPost(page, `/peers/${peers[0].id}/temporary-access`, {
-      name,
-      wg_pub_key: keypair.publicKey,
-      rules: ["tcp/22022"],
-    });
+    // Mounting the page runs the dashboard's own chain: load the pinned wasm,
+    // generate a key, register temporary access, start the client.
+    await page.goto(`/peer/ssh?id=${peers[0].id}&user=root&port=22022`);
 
+    // Management's view proves the round trip: the flow's ephemeral peer shows
+    // up connected. Polled via the API because the connected flag is
+    // management state, not a page response.
     let created: Peer | undefined;
     try {
-      expect(await bootWasmClient(page, pinnedWasmPath())).toBe("ok");
-
-      const mgmt = await managementOrigin(page);
-      const started = await page.evaluate(
-        async ({ privateKey, managementURL, deviceName }) => {
-          const client = await (window as any).NetBirdClient({
-            privateKey,
-            managementURL,
-            deviceName,
-          });
-          (window as any).__e2eWasmClient = client;
-          try {
-            await client.start();
-            return "ok";
-          } catch (error) {
-            return String(error);
-          }
-        },
-        {
-          privateKey: keypair.privateKey,
-          managementURL: mgmt,
-          deviceName: name,
-        },
-      );
-      expect(started, "the client should log in and sync").toBe("ok");
-
-      // Management's view proves the login round trip: the registered peer
-      // shows up connected under the name it was registered with. Polled via
-      // the API because the connected flag is management state, not a page
-      // response.
-      for (let attempt = 0; attempt < 30 && !created?.connected; attempt++) {
+      for (let attempt = 0; attempt < 45 && !created?.connected; attempt++) {
         await page.waitForTimeout(2_000);
         const all = await apiGet<Peer[]>(page, "/peers");
-        created = all.find((p) => p.name === name);
+        created = all.find(
+          (p) => !before.has(p.id) && p.name.endsWith("browser-client"),
+        );
       }
-      expect(created, "the registered peer should appear").toBeTruthy();
+      expect(
+        created,
+        "the flow should register a browser client peer",
+      ).toBeTruthy();
       expect(
         created!.connected,
-        "the registered peer should be connected",
+        "the browser client peer should be connected",
       ).toBe(true);
     } finally {
       // Best-effort: a throw here would mask the failure under test, and the
-      // registered peer must not outlive the test in the shared environment.
+      // ephemeral peer must not outlive the test in the shared environment.
       try {
-        await page.evaluate(async () => {
-          await (window as any).__e2eWasmClient?.stop?.();
-        });
-        const leftover =
-          created ??
-          (await apiGet<Peer[]>(page, "/peers")).find((p) => p.name === name);
-        if (leftover) await apiDelete(page, `/peers/${leftover.id}`);
+        await page.goto("/peers");
+        if (created) await apiDelete(page, `/peers/${created.id}`);
       } catch {
         // The assertion that failed is the story; a cleanup miss is not.
       }

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -4,7 +4,8 @@ import { join } from "path";
 import type { Peer } from "../../src/interfaces/Peer";
 import { generateKeypair } from "../../src/utils/wireguard";
 import { apiDelete, apiGet, apiPost, managementOrigin } from "../helpers/api";
-import { expect,test } from "../helpers/fixtures";
+import { expect, test } from "../helpers/fixtures";
+import { generateRandomName } from "../helpers/utils";
 
 /**
  * Guards the pinned default WASM client, which is what a version bump changes:
@@ -75,51 +76,69 @@ test.describe.serial("WASM client @wasm", () => {
     ).toBeGreaterThan(0);
 
     const keypair = generateKeypair();
-    const name = `e2e-wasm-${keypair.publicKey.slice(0, 6).toLowerCase().replace(/[^a-z0-9]/g, "")}`;
+    const name = generateRandomName("e2e-wasm-");
     await apiPost(page, `/peers/${peers[0].id}/temporary-access`, {
       name,
       wg_pub_key: keypair.publicKey,
       rules: ["tcp/22022"],
     });
 
-    expect(await bootWasmClient(page, pinnedWasmPath())).toBe("ok");
-
-    const mgmt = await managementOrigin(page);
-    const started = await page.evaluate(
-      async ({ privateKey, managementURL, deviceName }) => {
-        const client = await (window as any).NetBirdClient({
-          privateKey,
-          managementURL,
-          deviceName,
-        });
-        (window as any).__e2eWasmClient = client;
-        try {
-          await client.start();
-          return "ok";
-        } catch (error) {
-          return String(error);
-        }
-      },
-      { privateKey: keypair.privateKey, managementURL: mgmt, deviceName: name },
-    );
-    expect(started, "the client should log in and sync").toBe("ok");
-
-    // Management's view proves the login round trip: the registered peer shows
-    // up connected under the name it was registered with.
     let created: Peer | undefined;
-    for (let attempt = 0; attempt < 30 && !created?.connected; attempt++) {
-      await page.waitForTimeout(2_000);
-      const all = await apiGet<Peer[]>(page, "/peers");
-      created = all.find((p) => p.name === name);
-    }
-    expect(created, "the registered peer should appear").toBeTruthy();
-    expect(created!.connected, "the registered peer should be connected").toBe(
-      true,
-    );
+    try {
+      expect(await bootWasmClient(page, pinnedWasmPath())).toBe("ok");
 
-    await page.evaluate(async () => {
-      await (window as any).__e2eWasmClient?.stop?.();
-    });
-    if (created) await apiDelete(page, `/peers/${created.id}`);
+      const mgmt = await managementOrigin(page);
+      const started = await page.evaluate(
+        async ({ privateKey, managementURL, deviceName }) => {
+          const client = await (window as any).NetBirdClient({
+            privateKey,
+            managementURL,
+            deviceName,
+          });
+          (window as any).__e2eWasmClient = client;
+          try {
+            await client.start();
+            return "ok";
+          } catch (error) {
+            return String(error);
+          }
+        },
+        {
+          privateKey: keypair.privateKey,
+          managementURL: mgmt,
+          deviceName: name,
+        },
+      );
+      expect(started, "the client should log in and sync").toBe("ok");
+
+      // Management's view proves the login round trip: the registered peer
+      // shows up connected under the name it was registered with. Polled via
+      // the API because the connected flag is management state, not a page
+      // response.
+      for (let attempt = 0; attempt < 30 && !created?.connected; attempt++) {
+        await page.waitForTimeout(2_000);
+        const all = await apiGet<Peer[]>(page, "/peers");
+        created = all.find((p) => p.name === name);
+      }
+      expect(created, "the registered peer should appear").toBeTruthy();
+      expect(
+        created!.connected,
+        "the registered peer should be connected",
+      ).toBe(true);
+    } finally {
+      // Best-effort: a throw here would mask the failure under test, and the
+      // registered peer must not outlive the test in the shared environment.
+      try {
+        await page.evaluate(async () => {
+          await (window as any).__e2eWasmClient?.stop?.();
+        });
+        const leftover =
+          created ??
+          (await apiGet<Peer[]>(page, "/peers")).find((p) => p.name === name);
+        if (leftover) await apiDelete(page, `/peers/${leftover.id}`);
+      } catch {
+        // The assertion that failed is the story; a cleanup miss is not.
+      }
+    }
   });
 });

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { test, expect } from "../helpers/fixtures";
+
+/**
+ * Instantiates the pinned default WASM client. This is what guards a version
+ * bump: the pinned URL must resolve and the module must compile, instantiate
+ * and boot far enough to export its constructor. No management connection is
+ * made, so this covers the artifact, not the tunnel.
+ */
+test.describe("WASM client @wasm", () => {
+  test("the pinned WASM client instantiates", async ({
+    dashboardAsOwner: page,
+  }) => {
+    const configSource = readFileSync(
+      join(__dirname, "../../src/utils/config.ts"),
+      "utf8",
+    );
+    const pinned = configSource.match(
+      /https:\/\/pkgs\.netbird\.io\/wasm\/client\/v[0-9.]+/,
+    );
+    expect(pinned, "config.ts should pin a default wasm path").not.toBeNull();
+
+    const result = await page.evaluate(async (wasmUrl) => {
+      await new Promise<void>((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "/wasm_exec.js";
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error("wasm_exec.js failed to load"));
+        document.head.appendChild(script);
+      });
+
+      const go = new (window as any).Go();
+      const module = await WebAssembly.instantiateStreaming(
+        fetch(wasmUrl),
+        go.importObject,
+      );
+      void go.run(module.instance);
+
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        if (typeof (window as any).NetBirdClient === "function") {
+          return "ok";
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      return "NetBirdClient never appeared";
+    }, pinned![0]);
+
+    expect(result).toBe("ok");
+  });
+});

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -30,6 +30,10 @@ test.describe("WASM client @wasm", () => {
   test("the pinned WASM client instantiates", async ({
     dashboardAsOwner: page,
   }) => {
+    // The client is a ~60MB module fetched from the package host, so downloading
+    // and compiling it does not fit the default per-test budget.
+    test.setTimeout(180_000);
+
     const result = await page.evaluate(async (url) => {
       await new Promise<void>((resolve, reject) => {
         const script = document.createElement("script");
@@ -48,8 +52,9 @@ test.describe("WASM client @wasm", () => {
       void go.run(wasmModule.instance);
 
       // The Go runtime publishes its exports partway through startup, so the
-      // constructor appears some time after go.run() returns.
-      const deadline = Date.now() + 30_000;
+      // constructor appears some time after go.run() returns. The dashboard
+      // gives it 10s before reporting a load failure.
+      const deadline = Date.now() + 15_000;
       while (Date.now() < deadline) {
         if (typeof (window as any).NetBirdClient === "function") {
           return "ok";

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -38,11 +38,11 @@ const bootWasmClient = async (page: Page, wasmUrl: string): Promise<string> =>
     });
 
     const go = new (window as any).Go();
-    const module = await WebAssembly.instantiateStreaming(
+    const wasmModule = await WebAssembly.instantiateStreaming(
       fetch(url),
       go.importObject,
     );
-    void go.run(module.instance);
+    void go.run(wasmModule.instance);
 
     const deadline = Date.now() + 30_000;
     while (Date.now() < deadline) {
@@ -54,7 +54,7 @@ const bootWasmClient = async (page: Page, wasmUrl: string): Promise<string> =>
     return "NetBirdClient never appeared";
   }, wasmUrl);
 
-test.describe("WASM client @wasm", () => {
+test.describe.serial("WASM client @wasm", () => {
   test("the pinned WASM client instantiates", async ({
     dashboardAsOwner: page,
   }) => {

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -1,10 +1,10 @@
+import type { Page } from "@playwright/test";
 import { readFileSync } from "fs";
 import { join } from "path";
-import type { Page } from "@playwright/test";
-import { test, expect } from "../helpers/fixtures";
-import { apiDelete, apiGet, apiPost, managementOrigin } from "../helpers/api";
-import { generateKeypair } from "../../src/utils/wireguard";
 import type { Peer } from "../../src/interfaces/Peer";
+import { generateKeypair } from "../../src/utils/wireguard";
+import { apiDelete, apiGet, apiPost, managementOrigin } from "../helpers/api";
+import { expect,test } from "../helpers/fixtures";
 
 /**
  * Guards the pinned default WASM client, which is what a version bump changes:

--- a/e2e/tests/wasm-client.spec.ts
+++ b/e2e/tests/wasm-client.spec.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import type { Peer } from "../../src/interfaces/Peer";
-import { apiDelete, apiGet } from "../helpers/api";
+import type { ReverseProxy } from "../../src/interfaces/ReverseProxy";
+import { apiDelete, apiGet, apiPost, deleteServicesByPrefix } from "../helpers/api";
 import { expect, test } from "../helpers/fixtures";
+import { CUSTOM_PORTS_DOMAIN } from "../helpers/reverse-proxy-l4";
+import { generateRandomName } from "../helpers/utils";
 
 /**
  * Guards the pinned default WASM client, which is what a version bump changes:
@@ -61,21 +64,45 @@ test.describe.serial("WASM client @wasm", () => {
   test("the remote-access flow brings the pinned WASM client online", async ({
     dashboardAsOwner: page,
   }) => {
-    test.setTimeout(180_000);
+    test.setTimeout(300_000);
 
-    // The SSH page needs a peer to target; the environment always has peers
-    // once its clusters are online. The SSH session itself will fail against
-    // it, which is fine: the flow under test ends when the client is online.
-    const peers = await apiGet<Peer[]>(page, "/peers");
-    expect(
-      peers.length,
-      "the environment should have a peer to target",
-    ).toBeGreaterThan(0);
-    const before = new Set(peers.map((p) => p.id));
+    // The SSH page needs a peer to target. A fresh account has none, so one is
+    // minted the way the environment supports: exposing a service makes a proxy
+    // register an embedded peer for the account. The SSH session itself will
+    // fail against it, which is fine: the flow under test ends when the
+    // browser client is online.
+    await deleteServicesByPrefix(page, "wasm-e2e-");
+    const serviceName = generateRandomName("wasm-e2e-");
+    await apiPost<ReverseProxy>(page, "/reverse-proxies/services", {
+      name: serviceName,
+      domain: `${serviceName}.${CUSTOM_PORTS_DOMAIN}`,
+      enabled: true,
+      targets: [
+        {
+          target_type: "host",
+          protocol: "http",
+          host: "10.99.99.40",
+          port: 80,
+          enabled: true,
+        },
+      ],
+    });
+
+    let target: Peer | undefined;
+    for (let attempt = 0; attempt < 45 && !target; attempt++) {
+      await page.waitForTimeout(2_000);
+      const all = await apiGet<Peer[]>(page, "/peers");
+      target = all.find((p) => p.name.startsWith("proxy-"));
+    }
+    expect(target, "exposing a service should register a proxy peer").toBeTruthy();
+
+    const before = new Set(
+      (await apiGet<Peer[]>(page, "/peers")).map((p) => p.id),
+    );
 
     // Mounting the page runs the dashboard's own chain: load the pinned wasm,
     // generate a key, register temporary access, start the client.
-    await page.goto(`/peer/ssh?id=${peers[0].id}&user=root&port=22022`);
+    await page.goto(`/peer/ssh?id=${target!.id}&user=root&port=22022`);
 
     // Management's view proves the round trip: the flow's ephemeral peer shows
     // up connected. Polled via the API because the connected flag is
@@ -99,10 +126,11 @@ test.describe.serial("WASM client @wasm", () => {
       ).toBe(true);
     } finally {
       // Best-effort: a throw here would mask the failure under test, and the
-      // ephemeral peer must not outlive the test in the shared environment.
+      // test's artifacts must not outlive it in the shared environment.
       try {
         await page.goto("/peers");
         if (created) await apiDelete(page, `/peers/${created.id}`);
+        await deleteServicesByPrefix(page, "wasm-e2e-");
       } catch {
         // The assertion that failed is the story; a cleanup miss is not.
       }


### PR DESCRIPTION
Adds an automated bump PR for the pinned default WASM client path whenever a stable release is tagged, plus the e2e check that makes those bumps safe.

- A workflow_dispatch taking the release tag rewrites the default wasm path in src/utils/config.ts and opens a bump PR as the netbirddev bot; the tag is validated before it reaches the shell, and a re-dispatch of a tag that already has a branch exits without failing
- An e2e test downloads the pinned client and instantiates it against the wasm_exec.js this dashboard serves, so a bump to a path that does not resolve, a truncated artifact, or a Go runtime newer than the checked-in loader fails CI instead of reaching users

Bringing the client online needs signal, relay and a target peer, none of which exist in the dashboard test environment, so that level stays with the client end-to-end suites.

Requires the NETBIRD_DEV_BOT_GITHUB_TOKEN secret in this repo.

## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (CI automation, no user-facing behavior)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered workflow to update the default NetBird WASM client for a specified release and open a pull request automatically.
  - Prevents duplicate branches and pull requests when an update is already in progress or no change is required.
  - Validates release versions before processing and skips unnecessary updates.

- **Tests**
  - Streamlined WASM client end-to-end coverage to focus on successful client initialization and startup validation.
  - Improved test reliability by allowing additional time for client startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->