### PR TITLE
Keep the prices discovery returns for a loaded model

### DIFF
--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -567,8 +567,8 @@ export default function AIProviderModal({
   // catalog does not already carry. Both the per-row picker and "Add More"
   // read this one list, so merging here is all the wiring either needs.
   //
-  // A catalog entry wins on collision — it carries prices, and the discovery
-  // response deliberately carries none.
+  // A catalog entry wins on collision. Both sides price from the same table,
+  // so their rates agree; the catalog's label is the curated one.
   const catalogModelOptions = useMemo<CatalogModelOption[]>(() => {
     const base = catalog?.models ?? [];
     if (discovered.models.length === 0) return base;
@@ -579,8 +579,17 @@ export default function AIProviderModal({
       .map<CatalogModelOption>((m) => ({
         id: m.id,
         label: m.label || m.id,
-        input_per_1k: 0,
-        output_per_1k: 0,
+        // The rates the response carries. Bedrock is why this matters: its
+        // listing returns geography-prefixed ids, which never match a catalog
+        // entry by string, so every one of them arrives through this branch.
+        // The backend prices them off the normalized id and reports the rate
+        // for each — dropping it here registered a whole account's models at
+        // zero while the API was saying what they cost.
+        input_per_1k: m.input_per_1k,
+        output_per_1k: m.output_per_1k,
+        cached_input_per_1k: m.cached_input_per_1k,
+        cache_read_per_1k: m.cache_read_per_1k,
+        cache_creation_per_1k: m.cache_creation_per_1k,
         pricing_known: m.pricing_known,
       }));
     return [...base, ...extra];


### PR DESCRIPTION
## Describe your changes

Loading a provider's models merges anything the catalog does not already carry by exact id — and hardcoded both rates to zero on the way in. The comment gave the reason: *"the discovery response deliberately carries none."* That stopped being true when netbirdio/netbird#7246 began returning the same rates the proxy bills with.

**Bedrock feels all of it.** Its listing returns geography-prefixed ids (`eu.anthropic.claude-opus-4-7`) while the catalog holds the bare `anthropic.claude-opus-4-7`, so no Bedrock model ever matches by string and every one of them takes this branch. Selecting one filled its row with $0 and the form then warned the model had no cost set — while `GET /agent-network/catalog/providers/models` had reported a real rate for it. Usage against a model saved that way records nothing, and past usage cannot be re-priced.

The backend was right the whole way through: `decorate` prices each listed id off its normalized form (`eu.anthropic.claude-opus-4-7` → `anthropic.claude-opus-4-7`), so the response carries `input_per_1k`, `output_per_1k` and the cache rates. The modal just dropped them.

Exact-id matching stays. Collapsing a geography-prefixed id onto its catalog entry would hand back the bare form, and only the prefixed one is invocable at AWS — so both spellings continue to appear, which is correct: they are different routing targets that happen to cost the same.

Split out of netbirdio/dashboard#772 so it can land on its own. That PR keeps the refused-save handling, which depends on backend work that has not merged yet; this is a user-visible pricing bug on `main` today and shouldn't wait behind it.

## Issue ticket number and link

<!-- Linear ticket being filed; link to follow. -->

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

The docs already describe the intended behaviour — *"a model the catalog already prices arrives priced"* in *Load Models from the Provider*. This restores it; nothing to re-document.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGaLnp5xzAeSnAASvbcFA8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved reported input, output, and cache pricing for discovered AI models.
  * Ensured catalog pricing remains authoritative when model IDs overlap.
  * Added pricing support for geography-prefixed Bedrock models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->