### PR TITLE
feat(agent-network): add agentgateway provider support

### DIFF
--- a/e2e/tests/agent-network-agentgateway-provider.spec.ts
+++ b/e2e/tests/agent-network-agentgateway-provider.spec.ts
@@ -4,108 +4,94 @@
  * Exercises the catalog-driven provider flow against a management build that
  * includes the agentgateway catalog entry. Older builds skip the test.
  */
-import { type Browser, expect, type Page, test } from "@playwright/test";
 import {
   deleteAgentNetworkProvidersByPrefix,
   listAgentNetworkCatalog,
   supportsAgentNetworkSettingsBootstrap,
 } from "../helpers/api";
-import { loginToApp } from "../helpers/auth";
+import { navigateTo } from "../helpers/auth";
+import { expect, test } from "../helpers/fixtures";
 import { generateRandomName } from "../helpers/utils";
 
 const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
 const AGENTGATEWAY_CATALOG_ID = "agentgateway";
 const PROVIDER_PREFIX = "e2e-agentgateway-";
 
-async function newAgentNetworkPage(browser: Browser): Promise<{
-  page: Page;
-  close: () => Promise<void>;
-}> {
-  const context = await browser.newContext({
-    storageState: "e2e/fixtures/auth/owner.json",
-  });
-  await context.addInitScript(
-    ([key, value]) => {
-      try {
-        window.localStorage.setItem(key as string, value as string);
-      } catch (e) {}
-    },
-    [AGENT_NETWORK_CONFIG_KEY, "enabled"],
-  );
-  const page = await context.newPage();
-  await loginToApp(page, "owner");
-  return { page, close: () => context.close() };
-}
-
 test.describe
   .serial("Agent Network agentgateway provider @agent-network", () => {
   test("connect agentgateway with its trusted identity mapping", async ({
-    browser,
+    dashboardAsOwner: page,
   }) => {
-    const { page, close } = await newAgentNetworkPage(browser);
+    await page.addInitScript(
+      ([key, value]) => {
+        try {
+          window.localStorage.setItem(key as string, value as string);
+        } catch {}
+      },
+      [AGENT_NETWORK_CONFIG_KEY, "enabled"],
+    );
+
+    const catalog = await listAgentNetworkCatalog(page);
+    test.skip(
+      !catalog.some((entry) => entry.id === AGENTGATEWAY_CATALOG_ID),
+      `management catalog has no ${AGENTGATEWAY_CATALOG_ID} entry`,
+    );
+    test.skip(
+      !(await supportsAgentNetworkSettingsBootstrap(page)),
+      "management build does not support Agent Network settings bootstrap",
+    );
+
+    await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
     try {
-      const catalog = await listAgentNetworkCatalog(page);
-      test.skip(
-        !catalog.some((entry) => entry.id === AGENTGATEWAY_CATALOG_ID),
-        `management catalog has no ${AGENTGATEWAY_CATALOG_ID} entry`,
-      );
-      test.skip(
-        !(await supportsAgentNetworkSettingsBootstrap(page)),
-        "management build does not support Agent Network settings bootstrap",
-      );
-
-      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
-      await page.goto("/agent-network/providers");
-      await page.keyboard.press("Escape");
+      await navigateTo(page, "/agent-network/providers");
 
       await page
-        .getByRole("button", { name: "Connect Provider" })
+        .getByTestId("connect-agent-network-provider")
         .first()
         .click({ force: true });
       await page
-        .getByRole("button", { name: /OpenAI API/ })
-        .first()
+        .getByTestId("agent-network-provider-type")
         .click({ force: true });
       await page
-        .getByPlaceholder("Search providers...")
+        .getByTestId("select-dropdown-search")
         .fill(AGENTGATEWAY_CATALOG_ID);
       await page
-        .getByText(AGENTGATEWAY_CATALOG_ID, { exact: true })
-        .first()
+        .getByTestId("agent-network-provider-option-agentgateway")
         .click({ force: true });
 
       const upstreamURL = "https://agentgateway.e2e.example";
       await page
-        .getByPlaceholder("https://your-agentgateway-proxy")
+        .getByTestId("agent-network-provider-upstream-url")
         .fill(upstreamURL);
       await page
-        .getByPlaceholder("Paste the virtual API key")
+        .getByTestId("agent-network-provider-api-key")
         .fill("e2e-agentgateway-virtual-key");
 
       const providerName = generateRandomName(PROVIDER_PREFIX);
-      await page.locator('input[value="agentgateway"]').fill(providerName);
+      await page.getByTestId("agent-network-provider-name").fill(providerName);
 
-      await page.getByRole("tab", { name: "Models" }).click({ force: true });
-      await expect(page.getByText(/Empty = all catalog models/)).toBeVisible();
-      await page.getByRole("button", { name: "Continue" }).click();
+      await page
+        .getByTestId("agent-network-provider-models-tab")
+        .click({ force: true });
+      await expect(
+        page.getByTestId("agent-network-provider-models-help"),
+      ).toContainText("Empty = all catalog models");
+      await page
+        .getByTestId("agent-network-provider-continue")
+        .click({ force: true });
 
-      await expect(page.getByRole("tab", { name: "Mappings" })).toHaveAttribute(
-        "data-state",
-        "active",
-      );
-      await expect(page.getByText("x-netbird-user-id")).toBeVisible();
-      await expect(page.getByText("x-netbird-groups")).toBeVisible();
       await expect(
-        page.getByText("User identity", { exact: true }),
-      ).toBeVisible();
+        page.getByTestId("agent-network-provider-mappings-tab"),
+      ).toHaveAttribute("data-state", "active");
       await expect(
-        page.getByText("Authorizing groups (CSV)", { exact: true }),
-      ).toBeVisible();
+        page.getByTestId("agent-network-provider-user-mapping"),
+      ).toContainText("x-netbird-user-id");
       await expect(
-        page.getByText(
-          /must not be used as an agentgateway authorization claim/,
-        ),
-      ).toBeVisible();
+        page.getByTestId("agent-network-provider-groups-mapping"),
+      ).toContainText("x-netbird-groups");
+      await expect(
+        page.getByTestId("agent-network-provider-groups-guidance"),
+      ).toContainText("must not be used as an agentgateway authorization claim");
 
       const createResponse = page.waitForResponse(
         (response) =>
@@ -113,10 +99,9 @@ test.describe
           response.request().method() === "POST",
         { timeout: 30_000 },
       );
-      await page
-        .getByRole("button", { name: "Connect Provider" })
-        .last()
-        .click({ force: true });
+      await page.getByTestId("agent-network-provider-submit").click({
+        force: true,
+      });
       const created = await createResponse;
       expect([200, 201]).toContain(created.status());
 
@@ -131,22 +116,33 @@ test.describe
       expect(body).not.toHaveProperty("identity_header_user_id");
       expect(body).not.toHaveProperty("identity_header_groups");
 
-      await expect(page.getByText(providerName).first()).toBeVisible();
-      await expect(page.getByText("All models").first()).toBeVisible();
-
-      await page.getByText(providerName).first().click({ force: true });
+      await expect(page.getByTestId(providerName)).toBeVisible();
       await expect(
-        page.getByText("Edit Provider", { exact: true }),
-      ).toBeVisible();
-      await expect(page.locator(`input[value="${upstreamURL}"]`)).toBeVisible();
-      await page.getByRole("tab", { name: "Mappings" }).click({ force: true });
-      await expect(page.getByText("x-netbird-user-id")).toBeVisible();
-      await expect(page.getByText("x-netbird-groups")).toBeVisible();
-      await page.keyboard.press("Escape");
+        page.getByTestId(`provider-models-${providerName}`),
+      ).toHaveText("All models");
 
-      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
+      await page.getByTestId(providerName).click({ force: true });
+      await expect(
+        page.getByTestId("agent-network-provider-modal"),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("agent-network-provider-upstream-url"),
+      ).toHaveValue(upstreamURL);
+      await page
+        .getByTestId("agent-network-provider-mappings-tab")
+        .click({ force: true });
+      await expect(
+        page.getByTestId("agent-network-provider-user-mapping"),
+      ).toContainText("x-netbird-user-id");
+      await expect(
+        page.getByTestId("agent-network-provider-groups-mapping"),
+      ).toContainText("x-netbird-groups");
+      await page
+        .getByTestId("agent-network-provider-modal")
+        .getByTestId("modal-close")
+        .click({ force: true });
     } finally {
-      await close();
+      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
     }
   });
 });

--- a/e2e/tests/agent-network-agentgateway-provider.spec.ts
+++ b/e2e/tests/agent-network-agentgateway-provider.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Agent Network agentgateway provider spec.
+ *
+ * Exercises the catalog-driven provider flow against a management build that
+ * includes the agentgateway catalog entry. Older builds skip the test.
+ */
+import { type Browser, expect, type Page, test } from "@playwright/test";
+import {
+  deleteAgentNetworkProvidersByPrefix,
+  listAgentNetworkCatalog,
+  supportsAgentNetworkSettingsBootstrap,
+} from "../helpers/api";
+import { loginToApp } from "../helpers/auth";
+import { generateRandomName } from "../helpers/utils";
+
+const AGENT_NETWORK_CONFIG_KEY = "netbird-test-agent-network";
+const AGENTGATEWAY_CATALOG_ID = "agentgateway";
+const PROVIDER_PREFIX = "e2e-agentgateway-";
+
+async function newAgentNetworkPage(browser: Browser): Promise<{
+  page: Page;
+  close: () => Promise<void>;
+}> {
+  const context = await browser.newContext({
+    storageState: "e2e/fixtures/auth/owner.json",
+  });
+  await context.addInitScript(
+    ([key, value]) => {
+      try {
+        window.localStorage.setItem(key as string, value as string);
+      } catch (e) {}
+    },
+    [AGENT_NETWORK_CONFIG_KEY, "enabled"],
+  );
+  const page = await context.newPage();
+  await loginToApp(page, "owner");
+  return { page, close: () => context.close() };
+}
+
+test.describe
+  .serial("Agent Network agentgateway provider @agent-network", () => {
+  test("connect agentgateway with its trusted identity mapping", async ({
+    browser,
+  }) => {
+    const { page, close } = await newAgentNetworkPage(browser);
+    try {
+      const catalog = await listAgentNetworkCatalog(page);
+      test.skip(
+        !catalog.some((entry) => entry.id === AGENTGATEWAY_CATALOG_ID),
+        `management catalog has no ${AGENTGATEWAY_CATALOG_ID} entry`,
+      );
+      test.skip(
+        !(await supportsAgentNetworkSettingsBootstrap(page)),
+        "management build does not support Agent Network settings bootstrap",
+      );
+
+      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
+      await page.goto("/agent-network/providers");
+      await page.keyboard.press("Escape");
+
+      await page
+        .getByRole("button", { name: "Connect Provider" })
+        .first()
+        .click({ force: true });
+      await page
+        .getByRole("button", { name: /OpenAI API/ })
+        .first()
+        .click({ force: true });
+      await page
+        .getByPlaceholder("Search providers...")
+        .fill(AGENTGATEWAY_CATALOG_ID);
+      await page
+        .getByText(AGENTGATEWAY_CATALOG_ID, { exact: true })
+        .first()
+        .click({ force: true });
+
+      const upstreamURL = "https://agentgateway.e2e.example";
+      await page
+        .getByPlaceholder("https://your-agentgateway-proxy")
+        .fill(upstreamURL);
+      await page
+        .getByPlaceholder("Paste the virtual API key")
+        .fill("e2e-agentgateway-virtual-key");
+
+      const providerName = generateRandomName(PROVIDER_PREFIX);
+      await page.locator('input[value="agentgateway"]').fill(providerName);
+
+      await page.getByRole("tab", { name: "Models" }).click({ force: true });
+      await expect(page.getByText(/Empty = all catalog models/)).toBeVisible();
+      await page.getByRole("button", { name: "Continue" }).click();
+
+      await expect(page.getByRole("tab", { name: "Mappings" })).toHaveAttribute(
+        "data-state",
+        "active",
+      );
+      await expect(page.getByText("x-netbird-user-id")).toBeVisible();
+      await expect(page.getByText("x-netbird-groups")).toBeVisible();
+      await expect(
+        page.getByText("User identity", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Authorizing groups (CSV)", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(
+          /must not be used as an agentgateway authorization claim/,
+        ),
+      ).toBeVisible();
+
+      const createResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes("/agent-network/providers") &&
+          response.request().method() === "POST",
+        { timeout: 30_000 },
+      );
+      await page
+        .getByRole("button", { name: "Connect Provider" })
+        .last()
+        .click({ force: true });
+      const created = await createResponse;
+      expect([200, 201]).toContain(created.status());
+
+      const body = created.request().postDataJSON();
+      expect(body).toMatchObject({
+        provider_id: AGENTGATEWAY_CATALOG_ID,
+        name: providerName,
+        upstream_url: upstreamURL,
+        models: [],
+        metadata_disabled: false,
+      });
+      expect(body).not.toHaveProperty("identity_header_user_id");
+      expect(body).not.toHaveProperty("identity_header_groups");
+
+      await expect(page.getByText(providerName).first()).toBeVisible();
+      await expect(page.getByText("All models").first()).toBeVisible();
+
+      await page.getByText(providerName).first().click({ force: true });
+      await expect(
+        page.getByText("Edit Provider", { exact: true }),
+      ).toBeVisible();
+      await expect(page.locator(`input[value="${upstreamURL}"]`)).toBeVisible();
+      await page.getByRole("tab", { name: "Mappings" }).click({ force: true });
+      await expect(page.getByText("x-netbird-user-id")).toBeVisible();
+      await expect(page.getByText("x-netbird-groups")).toBeVisible();
+      await page.keyboard.press("Escape");
+
+      await deleteAgentNetworkProvidersByPrefix(page, PROVIDER_PREFIX);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -323,6 +323,8 @@ export default function AIProviderModal({
     "litellm_proxy",
     "vercel_ai_gateway",
     "openrouter",
+    "portkey",
+    "bedrock_api",
   ].includes(providerId);
   const showGenericFixedHeaderPair =
     !!fixedHeaderPair && !hasSpecializedFixedHeaderPairView;
@@ -571,6 +573,11 @@ export default function AIProviderModal({
       label: p.name,
       searchValue: `${p.name} ${p.id}`,
       group: groupLabel[p.kind] ?? "Other",
+      renderItem: () => (
+        <span data-testid={`agent-network-provider-option-${p.id}`}>
+          {p.name}
+        </span>
+      ),
       icon: ({ size }: { size?: number }) => (
         <AIProviderLogo providerId={p.id as AIProviderId} size={size ?? 16} />
       ),
@@ -732,7 +739,10 @@ export default function AIProviderModal({
 
   return (
     <Modal open={open} onOpenChange={(o) => (o ? null : handleClose())}>
-      <ModalContent maxWidthClass={"max-w-2xl"}>
+      <ModalContent
+        maxWidthClass={"max-w-2xl"}
+        data-testid={"agent-network-provider-modal"}
+      >
         <ModalHeader
           icon={<AgentNetworkIcon className={"fill-netbird"} size={18} />}
           title={isEdit ? "Edit Provider" : "Connect Provider"}
@@ -750,7 +760,11 @@ export default function AIProviderModal({
               <Sparkles size={14} />
               Provider
             </TabsTrigger>
-            <TabsTrigger value={"models"} disabled={!canContinueFromProvider}>
+            <TabsTrigger
+              value={"models"}
+              disabled={!canContinueFromProvider}
+              data-testid={"agent-network-provider-models-tab"}
+            >
               <Boxes size={14} />
               Models
             </TabsTrigger>
@@ -758,6 +772,7 @@ export default function AIProviderModal({
               <TabsTrigger
                 value={"mappings"}
                 disabled={!canContinueFromProvider}
+                data-testid={"agent-network-provider-mappings-tab"}
               >
                 <ArrowRightLeft size={14} />
                 Mappings
@@ -804,6 +819,7 @@ export default function AIProviderModal({
                 helpText={"AI provider and upstream URL to expose through NetBird."}
               >
                 <SelectDropdown
+                  data-testid={"agent-network-provider-type"}
                   value={providerId}
                   onChange={(v) => {
                     const next = v as AIProviderId;
@@ -857,6 +873,7 @@ export default function AIProviderModal({
                 />
               </FormRow>
               <Input
+                data-testid={"agent-network-provider-upstream-url"}
                 value={upstreamUrl}
                 onChange={(e) => setUpstreamUrl(e.target.value)}
                 placeholder={upstreamUrlPlaceholder(providerId)}
@@ -975,6 +992,7 @@ export default function AIProviderModal({
                   }
                 >
                   <Input
+                    data-testid={"agent-network-provider-api-key"}
                     type={"password"}
                     showPasswordToggle
                     value={apiKey}
@@ -1028,6 +1046,7 @@ export default function AIProviderModal({
                 helpText={"Shown in the Agent Network table."}
               >
                 <Input
+                  data-testid={"agent-network-provider-name"}
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   placeholder={"e.g. OpenAI"}
@@ -1235,7 +1254,11 @@ export default function AIProviderModal({
           )}
 
           {showMappings && showGenericFixedHeaderPair && (
-            <TabsContent value={"mappings"} className={"pb-8"}>
+            <TabsContent
+              value={"mappings"}
+              className={"pb-8"}
+              data-testid={"agent-network-provider-identity-mappings"}
+            >
               <div className={"px-8 pt-3 flex-col flex gap-4"}>
                 <FancyToggleSwitch
                   value={!metadataDisabled}
@@ -1276,29 +1299,33 @@ export default function AIProviderModal({
                     <MappingRow
                       header={fixedHeaderPair.end_user_id_header}
                       sourceLabel={"User identity"}
+                      data-testid={"agent-network-provider-user-mapping"}
                     />
                   )}
                   {fixedHeaderPair?.tags_header && (
                     <MappingRow
                       header={fixedHeaderPair.tags_header}
                       sourceLabel={"Authorizing groups (CSV)"}
+                      data-testid={"agent-network-provider-groups-mapping"}
                     />
                   )}
                 </div>
 
                 {providerId === "agentgateway" && (
-                  <HelpText className={"mb-0"}>
-                    <code
-                      className={
-                        "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
-                      }
-                    >
-                      x-netbird-groups
-                    </code>{" "}
-                    contains sorted group display names for attribution. It is
-                    not a delimiter-safe set of stable group IDs and must not
-                    be used as an agentgateway authorization claim.
-                  </HelpText>
+                  <div data-testid={"agent-network-provider-groups-guidance"}>
+                    <HelpText className={"mb-0"}>
+                      <code
+                        className={
+                          "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
+                        }
+                      >
+                        x-netbird-groups
+                      </code>{" "}
+                      contains sorted group display names for attribution. It
+                      is not a delimiter-safe set of stable group IDs and must
+                      not be used as an agentgateway authorization claim.
+                    </HelpText>
+                  </div>
                 )}
               </div>
             </TabsContent>
@@ -1521,13 +1548,15 @@ export default function AIProviderModal({
             <div className={"px-8 pt-3 flex-col flex gap-3"}>
               <div>
                 <Label>Models</Label>
-                <HelpText>
-                  Models exposed through this endpoint, with the per-1k
-                  input/output prices used for cost tracking. Empty = all
-                  catalog models allowed at catalog prices. Cache rates left
-                  empty fall back to NetBird&apos;s defaults for the model; 0
-                  bills cached tokens at the input rate.
-                </HelpText>
+                <div data-testid={"agent-network-provider-models-help"}>
+                  <HelpText>
+                    Models exposed through this endpoint, with the per-1k
+                    input/output prices used for cost tracking. Empty = all
+                    catalog models allowed at catalog prices. Cache rates left
+                    empty fall back to NetBird&apos;s defaults for the model; 0
+                    bills cached tokens at the input rate.
+                  </HelpText>
+                </div>
               </div>
 
               <div className={"flex items-center gap-3"}>
@@ -1671,6 +1700,7 @@ export default function AIProviderModal({
                   variant={"primary"}
                   onClick={() => setTab("models")}
                   disabled={!canContinueFromProvider}
+                  data-testid={"agent-network-provider-continue"}
                 >
                   Continue
                 </Button>
@@ -1689,6 +1719,7 @@ export default function AIProviderModal({
                     variant={"primary"}
                     onClick={() => setTab("mappings")}
                     disabled={!canContinueFromProvider}
+                    data-testid={"agent-network-provider-continue"}
                   >
                     Continue
                   </Button>
@@ -1697,6 +1728,7 @@ export default function AIProviderModal({
                     variant={"primary"}
                     onClick={handleSubmit}
                     disabled={!canContinueFromProvider}
+                    data-testid={"agent-network-provider-submit"}
                   >
                     {isEdit ? (
                       "Save Changes"
@@ -1719,6 +1751,7 @@ export default function AIProviderModal({
                   variant={"primary"}
                   onClick={handleSubmit}
                   disabled={!canContinueFromProvider}
+                  data-testid={"agent-network-provider-submit"}
                 >
                   {isEdit ? (
                     "Save Changes"
@@ -2101,12 +2134,15 @@ function ModelRowEditor({
 function MappingRow({
   header,
   sourceLabel,
+  "data-testid": dataTestId,
 }: {
   header: string;
   sourceLabel: string;
+  "data-testid"?: string;
 }) {
   return (
     <div
+      data-testid={dataTestId}
       className={
         "flex items-center gap-3 px-4 py-3 border-b border-nb-gray-900 last:border-b-0"
       }

--- a/src/modules/agent-network/AIProviderModal.tsx
+++ b/src/modules/agent-network/AIProviderModal.tsx
@@ -114,6 +114,8 @@ function upstreamUrlPlaceholder(providerId: AIProviderId): string {
       return "https://openrouter.ai/api/v1";
     case "litellm_proxy":
       return "https://your-litellm-host";
+    case "agentgateway":
+      return "https://your-agentgateway-proxy";
     case "portkey":
       return "https://api.portkey.ai";
     case "vllm":
@@ -141,6 +143,8 @@ function upstreamUrlHelpText(providerId: AIProviderId): string {
       return "Vercel AI Gateway uses a fixed endpoint; only the API key varies by operator. Apps choose the upstream provider with the model prefix, e.g. openai/gpt-5.4 or anthropic/claude-opus-4.6.";
     case "openrouter":
       return "OpenRouter uses a fixed endpoint, openrouter.ai/api/v1; apps choose the upstream provider via the model prefix, e.g. anthropic/claude-* or openai/gpt-*.";
+    case "agentgateway":
+      return "The agentgateway proxy listener URL reachable from the NetBird proxy. Keep this listener private so requests cannot bypass NetBird's identity enforcement.";
     case "vllm":
       return "Your local vLLM server's OpenAI-compatible base URL.";
     default:
@@ -288,6 +292,10 @@ export default function AIProviderModal({
   // entry, so this never double-counts.
   const customizableIdentity =
     customizableHeaderPair || customizableJsonMetadata;
+  const fixedHeaderPair =
+    catalog?.identity_injection?.header_pair?.customizable === false
+      ? catalog.identity_injection.header_pair
+      : undefined;
   // Defaults shown as input placeholders. The first non-empty source
   // wins; HeaderPair vs JSONMetadata are exclusive so either branch
   // is empty when the other is set.
@@ -306,20 +314,18 @@ export default function AIProviderModal({
   const jsonMetadataHeader =
     catalog?.identity_injection?.json_metadata?.header ?? "";
 
-  // showMappings reveals the Mappings tab for provider types whose
-  // downstream gateway keys identity off NetBird-stamped headers.
-  // For non-customizable shapes (LiteLLM, Portkey) the mapping is
-  // fixed in v1 — the tab is read-only. For customizable shapes
-  // (Bifrost) the operator picks the wire header names, so the tab
-  // renders editable inputs.
+  // The management catalog owns the general identity-injection contract.
+  // Bedrock retains its separate request-metadata mapping, and fixed HeaderPair
+  // providers without tailored guidance get the generic read-only view.
   const showMappings =
-    providerId === "litellm_proxy" ||
-    providerId === "portkey" ||
-    providerId === "bifrost" ||
-    providerId === "cloudflare_ai_gateway" ||
-    providerId === "vercel_ai_gateway" ||
-    providerId === "openrouter" ||
-    providerId === "bedrock_api";
+    !!catalog?.identity_injection || providerId === "bedrock_api";
+  const hasSpecializedFixedHeaderPairView = [
+    "litellm_proxy",
+    "vercel_ai_gateway",
+    "openrouter",
+  ].includes(providerId);
+  const showGenericFixedHeaderPair =
+    !!fixedHeaderPair && !hasSpecializedFixedHeaderPairView;
 
   // If the user flips provider type while viewing the Mappings tab and
   // the new type doesn't show mappings, snap back to the Provider tab
@@ -945,7 +951,9 @@ export default function AIProviderModal({
                 <FormRow
                   label={
                     <>
-                      Provider API key
+                      {providerId === "agentgateway"
+                        ? "Virtual API key"
+                        : "Provider API key"}
                       <HelpTooltip
                         content={
                           <>
@@ -960,7 +968,11 @@ export default function AIProviderModal({
                       />
                     </>
                   }
-                  helpText={"The API key issued by the provider."}
+                  helpText={
+                    providerId === "agentgateway"
+                      ? "The raw virtual key configured for strict API-key authentication on agentgateway."
+                      : "The API key issued by the provider."
+                  }
                 >
                   <Input
                     type={"password"}
@@ -973,6 +985,8 @@ export default function AIProviderModal({
                         ? "sk-..."
                         : providerId === "anthropic_api"
                         ? "sk-ant-..."
+                        : providerId === "agentgateway"
+                        ? "Paste the virtual API key"
                         : "Paste your API key"
                     }
                   />
@@ -1216,6 +1230,76 @@ export default function AIProviderModal({
                     placeholder={identityDefaultGroups || "netbird_groups"}
                   />
                 </FormRow>
+              </div>
+            </TabsContent>
+          )}
+
+          {showMappings && showGenericFixedHeaderPair && (
+            <TabsContent value={"mappings"} className={"pb-8"}>
+              <div className={"px-8 pt-3 flex-col flex gap-4"}>
+                <FancyToggleSwitch
+                  value={!metadataDisabled}
+                  onChange={(v) => setMetadataDisabled(!v)}
+                  label={
+                    <>
+                      <ArrowRightLeft size={15} />
+                      Forward Identity Metadata
+                    </>
+                  }
+                  helpText={
+                    "Stamp the trusted NetBird identity headers below onto upstream requests."
+                  }
+                />
+
+                <div>
+                  <Label>Trusted Identity Headers</Label>
+                  <HelpText className={"mb-0"}>
+                    NetBird removes caller-supplied values before adding the
+                    authenticated identity shown below. The upstream listener
+                    must remain reachable only through the NetBird proxy.
+                    {providerId === "agentgateway" && (
+                      <>
+                        {" "}
+                        The virtual key authenticates NetBird but does not make
+                        headers from another network path trustworthy.
+                      </>
+                    )}
+                  </HelpText>
+                </div>
+
+                <div
+                  className={
+                    "rounded-md overflow-hidden border border-nb-gray-900 bg-nb-gray-920/30"
+                  }
+                >
+                  {fixedHeaderPair?.end_user_id_header && (
+                    <MappingRow
+                      header={fixedHeaderPair.end_user_id_header}
+                      sourceLabel={"User identity"}
+                    />
+                  )}
+                  {fixedHeaderPair?.tags_header && (
+                    <MappingRow
+                      header={fixedHeaderPair.tags_header}
+                      sourceLabel={"Authorizing groups (CSV)"}
+                    />
+                  )}
+                </div>
+
+                {providerId === "agentgateway" && (
+                  <HelpText className={"mb-0"}>
+                    <code
+                      className={
+                        "text-xs font-mono text-nb-gray-100 bg-nb-gray-900/60 rounded px-1.5 py-0.5"
+                      }
+                    >
+                      x-netbird-groups
+                    </code>{" "}
+                    contains sorted group display names for attribution. It is
+                    not a delimiter-safe set of stable group IDs and must not
+                    be used as an agentgateway authorization claim.
+                  </HelpText>
+                )}
               </div>
             </TabsContent>
           )}

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Mock data for the Agent Network section. No backend wired up yet.
 // All numbers, IDs, and text are static placeholders for click-through.
 

--- a/src/modules/agent-network/data/mockData.ts
+++ b/src/modules/agent-network/data/mockData.ts
@@ -14,6 +14,7 @@ export type AIProviderId =
   | "mistral_api"
   | "kimi_api"
   | "litellm_proxy"
+  | "agentgateway"
   | "portkey"
   | "bifrost"
   | "cloudflare_ai_gateway"

--- a/src/modules/agent-network/table/AgentProvidersTable.tsx
+++ b/src/modules/agent-network/table/AgentProvidersTable.tsx
@@ -15,12 +15,12 @@ import React, { useState } from "react";
 import AIAccessIcon from "@/assets/icons/AgentNetworkIcon";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
-import { AIProvider } from "@/modules/agent-network/data/mockData";
-import { useAIProviders } from "@/modules/agent-network/AIProvidersProvider";
 import AIProviderLogo from "@/modules/agent-network/AIProviderLogo";
 import AIProviderModal from "@/modules/agent-network/AIProviderModal";
-import { useProviderCatalog } from "@/modules/agent-network/useProviderCatalog";
+import { useAIProviders } from "@/modules/agent-network/AIProvidersProvider";
+import { AIProvider } from "@/modules/agent-network/data/mockData";
 import AgentProviderActionCell from "@/modules/agent-network/table/AgentProviderActionCell";
+import { useProviderCatalog } from "@/modules/agent-network/useProviderCatalog";
 
 function NameCell({ provider }: { provider: AIProvider }) {
   const { getById } = useProviderCatalog();

--- a/src/modules/agent-network/table/AgentProvidersTable.tsx
+++ b/src/modules/agent-network/table/AgentProvidersTable.tsx
@@ -70,10 +70,20 @@ function NameCell({ provider }: { provider: AIProvider }) {
 
 function ModelsCell({ provider }: { provider: AIProvider }) {
   if (provider.models.length === 0) {
-    return <span className={"text-xs text-nb-gray-400"}>All Models</span>;
+    return (
+      <span
+        className={"text-xs text-nb-gray-400"}
+        data-testid={`provider-models-${provider.name}`}
+      >
+        All Models
+      </span>
+    );
   }
   return (
-    <span className={"text-xs text-nb-gray-300"}>
+    <span
+      className={"text-xs text-nb-gray-300"}
+      data-testid={`provider-models-${provider.name}`}
+    >
       {provider.models.length} Models
     </span>
   );
@@ -212,7 +222,11 @@ const AddProviderButton = () => {
   // button instead of a wizard that can only fail.
   if (!permission?.["agent_network.providers"]?.create) return null;
   return (
-    <Button variant={"primary"} onClick={openWizard}>
+    <Button
+      variant={"primary"}
+      onClick={openWizard}
+      data-testid={"connect-agent-network-provider"}
+    >
       <PlusCircle size={16} />
       Connect Provider
     </Button>


### PR DESCRIPTION
## Issue ticket number and link

Related to https://github.com/netbirdio/netbird/issues/6970

Adds catalog-driven agentgateway provider setup, virtual-key guidance, and a read-only view of the trusted NetBird identity headers. The e2e coverage verifies provider creation and the identity trust-boundary copy when the management catalog exposes agentgateway.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (the integration documentation is maintained separately in netbirdio/docs)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added support for configuring Agent Network `agentgateway` providers.
* Added provider-specific proxy URL guidance, API key labels, and help text.
* Added the ability to discover and load models directly from supported providers.
* Added pricing indicators and confirmation prompts for models without pricing.
* Added trusted identity header mappings with optional identity metadata forwarding.
* Improved provider setup and management workflows with clearer navigation and guidance.

## Bug Fixes

* Restricted provider editing and connection actions according to user permissions.

## Tests

* Expanded automated coverage for `agentgateway` provider setup, editing, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->