### PR TITLE
Detect Entra connection from auth service SSO connections

### DIFF
--- a/src/modules/integrations/sso/useSSOConnections.tsx
+++ b/src/modules/integrations/sso/useSSOConnections.tsx
@@ -24,10 +24,14 @@ export const useSSOConnections = () => {
   }, [ssos]);
 
   const genericConnection = useMemo(() => {
-    return ssos?.[0];
+    // Exclude connections derived from user profile
+    return ssos?.find((sso) => sso.id !== "none");
   }, [ssos]);
 
   const entraConnection = useMemo(() => {
+    const entraConnection = ssos?.find((sso) => sso.name === "azure-oauth2");
+    if (entraConnection) return entraConnection;
+
     const sub = oidcUser?.sub;
     const isEntra = sub?.includes("oauth2|azure-oauth2");
     return isEntra
@@ -38,7 +42,7 @@ export const useSSOConnections = () => {
           provider: "azure-oauth2",
         } as SSOConnection)
       : undefined;
-  }, [oidcUser]);
+  }, [ssos, oidcUser]);
 
   return {
     jumpCloudConnection,


### PR DESCRIPTION
## Issue ticket number and link

N/A

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This is an internal bug fix for detecting the Entra SSO connection in the Entra SCIM setup. It does not change any user-facing behavior or configuration described in the docs.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

## Description

### Problem

Users who register with username/password first and later log in via Entra get their identities linked in Auth0, but the token `sub` keeps the primary `auth0|` identity. `entraConnection` in `useSSOConnections` only checks the `sub` for `oauth2|azure-oauth2`, so these users see the "sign in with SSO first" warning in the Entra SCIM setup even though their profile has an Entra identity.

### Changes

- `entraConnection` now prefers the `azure-oauth2` connection returned by the auth service (netbirdio/auth#13 derives it from the Auth0 user profile identities), with the `sub` check kept as fallback.
- `genericConnection` skips profile-derived entries (`id === "none"`) so generic SCIM setup behavior is unchanged.
- JumpCloud detection is unaffected.

Depends on netbirdio/auth#13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO connection selection by ignoring placeholder entries.
  * Azure OAuth2 connections are now preferred when available, with a fallback maintained for other configurations.
  * Connection details now update correctly when the available SSO connections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
