### PR TITLE
fix(e2e): stabilize agentgateway provider test

### DIFF
--- a/e2e/tests/agent-network-agentgateway-provider.spec.ts
+++ b/e2e/tests/agent-network-agentgateway-provider.spec.ts
@@ -115,11 +115,14 @@ test.describe
       });
       expect(body).not.toHaveProperty("identity_header_user_id");
       expect(body).not.toHaveProperty("identity_header_groups");
+      await expect(
+        page.getByTestId("agent-network-provider-modal"),
+      ).toBeHidden();
 
       await expect(page.getByTestId(providerName)).toBeVisible();
       await expect(
         page.getByTestId(`provider-models-${providerName}`),
-      ).toHaveText("All models");
+      ).toHaveText("All Models");
 
       await page.getByTestId(providerName).click({ force: true });
       await expect(


### PR DESCRIPTION
## Issue ticket number and link

N/A

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (E2E-only assertion stabilization; no user-facing behavior changed)

### Docs PR URL (required if "docs added" is checked)

N/A

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main

## Summary
- match the provider table's `All Models` label casing
- wait for the creation modal to close before reopening the provider for edit assertions

## Verification
- `npx playwright test --config=e2e/playwright.config.ts e2e/tests/agent-network-agentgateway-provider.spec.ts`
- 2 passed, 2 skipped