### PR TITLE
Show peer-sourced policies in the Control Center peer view

### DIFF
--- a/src/modules/control-center/hooks/views/usePeerView.ts
+++ b/src/modules/control-center/hooks/views/usePeerView.ts
@@ -2,19 +2,19 @@ import { Edge, Node } from "@xyflow/react";
 import { sortBy } from "lodash";
 import { Group } from "@/interfaces/Group";
 import { Policy } from "@/interfaces/Policy";
+import { useControlCenterData } from "@/modules/control-center/hooks/useControlCenterData";
 import {
-  addNode,
   addEdge,
+  addNode,
   DEFAULT_LAYOUT_CONFIG,
 } from "@/modules/control-center/utils/graph-builder";
+import { withFreshGroupCounts } from "@/modules/control-center/utils/helpers";
 import { applyD3HierarchicalLayout } from "@/modules/control-center/utils/layouts";
 import {
   addAgentNetworkProviderNodes,
   useAgentNetworkOverlay,
 } from "./agent-network-overlay";
 import { addDestinationResourceNodes, ViewResult } from "./types";
-import { useControlCenterData } from "@/modules/control-center/hooks/useControlCenterData";
-import { withFreshGroupCounts } from "@/modules/control-center/utils/helpers";
 
 export function usePeerView() {
   const { policies, peers, networks, networkResources, groups, isDataReady } =
@@ -39,6 +39,7 @@ export function usePeerView() {
       (policiesOverride ?? policies!).filter((p) => {
         const rule = p.rules?.[0];
         if (!rule) return false;
+        if (rule.sourceResource?.id === peerId) return true;
         const sources = rule.sources as Group[];
         return sources?.some((d) => peerGroups?.some((pg) => pg.id === d.id));
       }),
@@ -80,7 +81,6 @@ export function usePeerView() {
           type: "smart",
           data: { enabled, policy },
         });
-
       });
 
       addDestinationResourceNodes(


### PR DESCRIPTION
## What

The Control Center peer view matched policies only by source **group** membership, so a policy whose source is the peer itself never appeared in that peer's view.

There was no group fallback either: a rule carrying a `sourceResource` has its `sources` nulled on save (`PoliciesProvider.tsx`), so for exactly these policies the group check could only ever return false.

## How

Match `rule.sourceResource` against the peer id alongside the group check, in `usePeerView`.

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

This fixes a filter bug in an existing view — peer-sourced policies were already creatable and deployable, they just weren't drawn on the peer they belonged to. No user-facing concept, setting, or workflow changes.

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

n/a

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer views now include policies whose source resource matches the selected peer, in addition to policies based on group membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->