### PR TITLE
mark is cloud false unless explicitly overridden

### DIFF
--- a/src/utils/netbird.ts
+++ b/src/utils/netbird.ts
@@ -55,15 +55,7 @@ export const isNetBirdCloud = () => {
   if (override) return override === "cloud";
   if (process.env.APP_ENV === "test") return true;
   if (config.cloud) return true;
-  // `next build` renders the tree in Node to emit the static export, where the
-  // hostname is unknowable. The prerendered output is discarded on the client,
-  // so this only has to avoid throwing.
-  if (typeof window === "undefined") return false;
-  const hostname = window.location.hostname;
-  if (hostname.includes("selfhosted")) return false;
-  return (
-    hostname.endsWith(".netbird.io") || hostname.endsWith(".wiretrustee.com")
-  );
+  return false;
 };
 
 // hasLicensedFlag returns true when the deployment declares a self-hosted


### PR DESCRIPTION
## Issue ticket number and link

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

https://github.com/netbirdio/docs/pull/__

## E2E tests
Optional: override the image tags used by the Playwright e2e workflow.
Defaults to `main` when omitted.

management-cloud-tag: main
reverse-proxy-tag: main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud deployment detection no longer relies on the browser hostname.
  - Hostnames ending in `.netbird.io` or `.wiretrustee.com` are no longer automatically identified as cloud deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->