### PR TITLE
Add the debug-bundle upload destination to the Clients settings

### DIFF
--- a/src/interfaces/Account.ts
+++ b/src/interfaces/Account.ts
@@ -35,6 +35,7 @@ export interface Account {
     local_mfa_enabled?: boolean;
     ipv6_enabled_groups?: string[];
     network_range_v6?: string;
+    debug_bundle_upload_url?: string;
     agent_network_only?: boolean;
     dashboard_features?: AccountDashboardFeatures;
   };

--- a/src/modules/settings/ClientSettingsTab.tsx
+++ b/src/modules/settings/ClientSettingsTab.tsx
@@ -433,8 +433,7 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
               Where clients send debug bundles. A bundle carries peer logs,
               routes, DNS and firewall state, so this decides whose
               infrastructure that data lands on. Leave it empty to use the
-              service NetBird runs; a self-hosted deployment that leaves it
-              empty keeps the bundle on the peer instead.{" "}
+              service NetBird runs.{" "}
               <InlineLink
                 href={"https://docs.netbird.io/manage/peers/remote-jobs"}
                 target={"_blank"}

--- a/src/modules/settings/ClientSettingsTab.tsx
+++ b/src/modules/settings/ClientSettingsTab.tsx
@@ -18,6 +18,7 @@ import { useApiCall } from "@utils/api";
 import { cn, validator } from "@utils/helpers";
 import {
   AlertTriangle,
+  BugIcon,
   ClockFadingIcon,
   ExternalLinkIcon,
   MonitorSmartphoneIcon,
@@ -96,6 +97,10 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
     account.settings?.auto_update_always ?? false,
   );
 
+  const [debugBundleUploadUrl, setDebugBundleUploadUrl] = useState(
+    account.settings?.debug_bundle_upload_url ?? "",
+  );
+
   const [peerExposeEnabled, setPeerExposeEnabled] = useState<boolean>(
     account?.settings?.peer_expose_enabled ?? false,
   );
@@ -112,6 +117,7 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
     autoUpdateMethod,
     autoUpdateCustomVersion,
     autoUpdateAlways,
+    debugBundleUploadUrl,
     peerExposeEnabled,
     peerExposeGroupNames,
   ]);
@@ -132,6 +138,21 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
     return "";
   }, [autoUpdateCustomVersion]);
 
+  // Mirrors the rule the API enforces. https only: the client fetches an upload
+  // URL from this endpoint and then PUTs the bundle to whatever comes back, so a
+  // plaintext hop is a place to intercept both.
+  const debugBundleUploadUrlError = useMemo(() => {
+    if (debugBundleUploadUrl === "") return "";
+    try {
+      const parsed = new URL(debugBundleUploadUrl);
+      if (parsed.protocol !== "https:") return "The URL must use https";
+      if (!parsed.hostname) return "The URL must have a host";
+      return "";
+    } catch {
+      return "Please enter a valid URL, e.g., https://upload.example.com/upload-url";
+    }
+  }, [debugBundleUploadUrl]);
+
   const canSaveCustomVersion =
     autoUpdateCustomVersion !== "" &&
     autoUpdateMethod === "custom" &&
@@ -142,6 +163,7 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
       !hasChanges ||
       !permission.settings.update ||
       (autoUpdateMethod === "custom" && !canSaveCustomVersion) ||
+      debugBundleUploadUrlError !== "" ||
       (peerExposeEnabled && peerExposeGroups.length === 0)
     );
   }, [
@@ -149,6 +171,7 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
     permission.settings.update,
     autoUpdateMethod,
     canSaveCustomVersion,
+    debugBundleUploadUrlError,
     peerExposeEnabled,
     peerExposeGroups,
   ]);
@@ -169,6 +192,7 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
             ...account.settings,
             auto_update_version: autoUpdateCustomVersion || autoUpdateMethod,
             auto_update_always: autoUpdateAlways,
+            debug_bundle_upload_url: debugBundleUploadUrl,
             peer_expose_enabled: peerExposeEnabled,
             peer_expose_groups: peerExposeGroupIds,
           },
@@ -179,6 +203,7 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
             autoUpdateMethod,
             autoUpdateCustomVersion,
             autoUpdateAlways,
+            debugBundleUploadUrl,
             peerExposeEnabled,
             peerExposeGroupNames,
           ]);
@@ -395,6 +420,42 @@ function ClientSettingsTabContent({ account }: Readonly<Props>) {
                   data-testid="peer-expose-groups-selector"
                 />
               </div>
+            </div>
+          </div>
+
+          <div>
+            <Label>
+              <BugIcon size={15} />
+              Debug Bundle Upload
+            </Label>
+
+            <HelpText>
+              Where clients send debug bundles. A bundle carries peer logs,
+              routes, DNS and firewall state, so this decides whose
+              infrastructure that data lands on. Leave it empty to use the
+              service NetBird runs; a self-hosted deployment that leaves it
+              empty keeps the bundle on the peer instead.{" "}
+              <InlineLink
+                href={"https://docs.netbird.io/manage/peers/remote-jobs"}
+                target={"_blank"}
+              >
+                Learn more
+                <ExternalLinkIcon size={12} />
+              </InlineLink>
+            </HelpText>
+            <div className={"mt-2"}>
+              <Input
+                value={debugBundleUploadUrl}
+                customPrefix={"URL"}
+                placeholder={"e.g., https://upload.example.com/upload-url"}
+                error={debugBundleUploadUrlError}
+                errorTooltip={true}
+                disabled={!permission.settings.update}
+                data-cy={"debug-bundle-upload-url"}
+                onChange={(v) => {
+                  setDebugBundleUploadUrl(v.target.value);
+                }}
+              />
             </div>
           </div>
 


### PR DESCRIPTION
Exposes the `debug_bundle_upload_url` account setting added in netbirdio/netbird#7514 as a `Debug Bundle Upload` field under Settings > Clients.

A debug bundle carries peer logs, routes, DNS and firewall state, so the destination decides whose infrastructure that data lands on. Until now every client path that uploaded one without a human picking a destination sent it to the service NetBird runs, with no way for a self-hosted operator to point it elsewhere.

Empty keeps the current behaviour — peers upload to NetBird's service — so nothing changes for an account that leaves it alone. The URL is validated as https-with-host on the client too, matching what the API accepts: the peer fetches an upload URL from this endpoint and then PUTs the bundle to whatever comes back, so a plaintext hop would expose both.

Docs: netbirdio/docs#971.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a client setting for configuring a debug bundle upload URL.
  - Added validation requiring a non-empty HTTPS URL with a valid hostname.
  - Added guidance text and prevented saving when the URL is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->